### PR TITLE
enable STATIC_LOGIN mech

### DIFF
--- a/MessengerProj/jni/cyrussasl/include/sasl/config.h
+++ b/MessengerProj/jni/cyrussasl/include/sasl/config.h
@@ -403,7 +403,7 @@
 /* #undef STATIC_LDAPDB */
 
 /* Link LOGIN Staticly */
-/* #undef STATIC_LOGIN */
+#define STATIC_LOGIN
 
 /* Link NTLM Staticly */
 /* #undef STATIC_NTLM */


### PR DESCRIPTION
Enable STATIC_LOGIN mech to make it possible to use the authentication-type PLAIN

With this change it was possible to log in to Office365 SMTP server, see #168 