### PR TITLE
Request permissions to use the Camera before starting Capture

### DIFF
--- a/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
@@ -1211,7 +1211,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
     private void processSelectedAttach(int which) {
         if (which == ChatAttachAlert.ATTACH_BUTTON_IDX_CAMERA ) {
             if (Build.VERSION.SDK_INT >= 23 && getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-                getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, LaunchActivity.REQ_CAMERA_PERMISSION_ID);
                 return;
             }
             try {
@@ -1282,7 +1282,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
         } else if (which == ChatAttachAlert.ATTACH_BUTTON_IDX_VIDEO) {
             try {
                 if (Build.VERSION.SDK_INT >= 23 && getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-                    getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                    getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, LaunchActivity.REQ_CAMERA_PERMISSION_ID);
                     return;
                 }
                 Intent takeVideoIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);

--- a/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
@@ -1210,6 +1210,10 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
 
     private void processSelectedAttach(int which) {
         if (which == ChatAttachAlert.ATTACH_BUTTON_IDX_CAMERA ) {
+            if (Build.VERSION.SDK_INT >= 23 && getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+                getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                return;
+            }
             try {
                 Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
                 File image = AndroidUtilities.generatePicturePath();
@@ -1277,6 +1281,10 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
             presentFragment(fragment);
         } else if (which == ChatAttachAlert.ATTACH_BUTTON_IDX_VIDEO) {
             try {
+                if (Build.VERSION.SDK_INT >= 23 && getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+                    getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                    return;
+                }
                 Intent takeVideoIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
                 File video = AndroidUtilities.generateVideoPath();
                 if (video != null) {

--- a/MessengerProj/src/main/java/com/b44t/messenger/Components/AvatarUpdater.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/Components/AvatarUpdater.java
@@ -77,7 +77,7 @@ public class AvatarUpdater implements PhotoCropActivity.PhotoEditActivityDelegat
     public void openCamera() {
         if (Build.VERSION.SDK_INT >= 23 && parentFragment != null && parentFragment.getParentActivity() != null) {
             if (parentFragment.getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-                parentFragment.getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                parentFragment.getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, LaunchActivity.REQ_CAMERA_PERMISSION_ID);
                 return;
             }
         }

--- a/MessengerProj/src/main/java/com/b44t/messenger/Components/AvatarUpdater.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/Components/AvatarUpdater.java
@@ -75,6 +75,12 @@ public class AvatarUpdater implements PhotoCropActivity.PhotoEditActivityDelegat
     }
 
     public void openCamera() {
+        if (Build.VERSION.SDK_INT >= 23 && parentFragment != null && parentFragment.getParentActivity() != null) {
+            if (parentFragment.getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+                parentFragment.getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                return;
+            }
+        }
         try {
             Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
             File image = AndroidUtilities.generatePicturePath();

--- a/MessengerProj/src/main/java/com/b44t/messenger/LaunchActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/LaunchActivity.java
@@ -741,11 +741,13 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
     }
 
     public static final int REQ_CONTACT_N_STORAGE_PERMISON_ID = 1;
+    public static final int REQ_CAMERA_PERMISSION_ID = 50;
 
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == REQ_CONTACT_N_STORAGE_PERMISON_ID || requestCode == 3 || requestCode == 4 || requestCode == 5) {
+        if (requestCode == REQ_CONTACT_N_STORAGE_PERMISON_ID || requestCode == 3 || requestCode == 4 || requestCode == 5
+         || requestCode == REQ_CAMERA_PERMISSION_ID) {
             int grantedCount = 0;
             String msg = "";
             for (int i = 0; i < permissions.length; i++) {

--- a/MessengerProj/src/main/java/com/b44t/messenger/LaunchActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/LaunchActivity.java
@@ -774,6 +774,9 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
                         case Manifest.permission.RECORD_AUDIO:
                             msg += "- " + ApplicationLoader.applicationContext.getString(R.string.PermissionNoAudio) + "\n\n";
                             break;
+                        case Manifest.permission.CAMERA:
+                            msg += "- " + ApplicationLoader.applicationContext.getString(R.string.PermissionCamera) + "\n\n";
+                            break;
                     }
                 }
             }

--- a/MessengerProj/src/main/java/com/b44t/messenger/WallpapersActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/WallpapersActivity.java
@@ -29,12 +29,14 @@
 
 package com.b44t.messenger;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Point;
 import android.graphics.drawable.Drawable;
@@ -217,6 +219,10 @@ public class WallpapersActivity extends BaseFragment implements NotificationCent
                         public void onClick(DialogInterface dialogInterface, int i) {
                             try {
                                 if (i == 0) {
+                                    if (Build.VERSION.SDK_INT >= 23 && getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+                                        getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                                        return;
+                                    }
                                     Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
                                     File image = AndroidUtilities.generatePicturePath();
                                     if (image != null) {

--- a/MessengerProj/src/main/java/com/b44t/messenger/WallpapersActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/WallpapersActivity.java
@@ -220,7 +220,7 @@ public class WallpapersActivity extends BaseFragment implements NotificationCent
                             try {
                                 if (i == 0) {
                                     if (Build.VERSION.SDK_INT >= 23 && getParentActivity().checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-                                        getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, 4);
+                                        getParentActivity().requestPermissions(new String[]{Manifest.permission.CAMERA}, LaunchActivity.REQ_CAMERA_PERMISSION_ID);
                                         return;
                                     }
                                     Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);

--- a/MessengerProj/src/main/res/values/strings.xml
+++ b/MessengerProj/src/main/res/values/strings.xml
@@ -470,4 +470,5 @@
     <string name="FetchModeSaveBattery">Save battery</string>
     <string name="FetchModePersistentConnection">Persistent connection</string>
     <string name="FetchModeExplain">When using the fetch mode <![CDATA[<i>]]>Save battery<![CDATA[</i>]]>, new messages appear at once if the app is in foreground and with an average delay of 30 seconds if the app is not used. When the device is in doze mode, the delay may be longer. This is the default mode.\n\n<![CDATA[<i>]]>Persistent connection<![CDATA[</i>]]> is typically faster but may require the app to be whitelisted in the system settings to consume more battery.\n\nWhich fetch mode do you want to use?</string>
+    <string name="PermissionCamera">Access to the camera is needed if you want to take photos or if you want to scan QR codes.</string>
 </resources>


### PR DESCRIPTION
At least on my phone (Android 7.0) the ACTION_IMAGE_CAPTURE and ACTION_VIDEO_CAPTURE Intents silently fail if the app does not have the camera permission. (#319).
I use the same code like it is used on other places to request for that permission if it is not granted.
I tested it and it works as expected.