### PR TITLE
displaying a list of pictures instead of just one when opening a pic in chat

### DIFF
--- a/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
@@ -2810,9 +2810,13 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                             PhotoViewer.getInstance().setParentActivity(getParentActivity());
                             //PhotoViewer.getInstance().openPhoto(message, message.type != MessageObject.MO_TYPE0_TEXT ? dialog_id : 0,
                             //        ChatActivity.this, getPhotosInChat());
-                            ArrayList<Object> photos = getPhotosInChat();
+                            //ArrayList<Object> photos = getPhotosInChat();
                             int index = getIndexOfCellPhoto(cell);
-                            PhotoViewer.getInstance().openPhoto(null, 0, ChatActivity.this, photos, index);
+                            //PhotoViewer.getInstance().openPhoto(null, 0, ChatActivity.this, photos, index);
+
+                            ArrayList<MessageObject> photoMessages = getPhotoMessages();
+                            PhotoViewer.getInstance().openPhotoList(message, message.type != MessageObject.MO_TYPE0_TEXT ? dialog_id : 0,
+                                    ChatActivity.this, photoMessages, index);
                         } else if (message.type == MessageObject.MO_TYPE9_FILE || message.type == MessageObject.MO_TYPE3_VIDEO ) {
                             AndroidUtilities.openForViewOrShare(getParentActivity(), message.getId(), Intent.ACTION_VIEW);
                         }
@@ -2832,24 +2836,23 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
             return new Holder(view);
         }
 
-        private ArrayList<Object> getPhotosInChat() {
-            ArrayList<Object> photos = new ArrayList<>();
+        private ArrayList<MessageObject> getPhotoMessages() {
+            ArrayList<MessageObject> photos = new ArrayList<>();
 
             for(int msg_index = 0; msg_index < m_msglist.length; msg_index ++) {
-                MrMsg msg = MrMailbox.getMsg(m_msglist[msg_index]);
-                switch (msg.getType()) {
+                MrMsg mrMsg = MrMailbox.getMsg(m_msglist[msg_index]);
+                switch (mrMsg.getType()) {
                     case MrMsg.MR_MSG_IMAGE:
                     case MrMsg.MR_MSG_GIF:
                     {
-                        TLRPC.Message tlrpcMsg = msg.get_TLRPC_Message();
-                        MediaController.PhotoEntry entry = new MediaController.PhotoEntry(0, tlrpcMsg.id,
-                                msg.getTimestamp(), tlrpcMsg.attachPath, 0, false);
-                        photos.add(entry);
+
+                        TLRPC.Message msg = mrMsg.get_TLRPC_Message();
+                        // generateLayout replaces emojis in text and other text rendering actions.
+                        MessageObject photoMsg = new MessageObject(msg, false);
+
+                        photos.add(photoMsg);
                     }
-                    case MrMsg.MR_MSG_TEXT:
-                        Log.d(TAG, "getPhotosInChat: a message: " + msg.getText());
                 }
-                msg.get_TLRPC_Message();
             }
             return photos;
         }
@@ -2867,7 +2870,6 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                         photoCount ++;
                     }
                 }
-                msg.get_TLRPC_Message();
             }
             return 0; // didn't find the matching photo.
         }

--- a/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/ChatActivity.java
@@ -48,6 +48,7 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
+import android.util.Log;
 import android.util.SparseIntArray;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -82,6 +83,7 @@ import com.b44t.messenger.Components.RecyclerListView;
 import com.b44t.messenger.Components.SizeNotifierFrameLayout;
 import com.b44t.messenger.ActionBar.Theme;
 
+import java.io.Console;
 import java.io.File;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -2806,7 +2808,11 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
 
                         if( /*(Build.VERSION.SDK_INT >= 16 && message.isVideo()) ||*/ message.type == MessageObject.MO_TYPE1_PHOTO || message.isGif()) {
                             PhotoViewer.getInstance().setParentActivity(getParentActivity());
-                            PhotoViewer.getInstance().openPhoto(message, message.type != MessageObject.MO_TYPE0_TEXT ? dialog_id : 0, ChatActivity.this);
+                            //PhotoViewer.getInstance().openPhoto(message, message.type != MessageObject.MO_TYPE0_TEXT ? dialog_id : 0,
+                            //        ChatActivity.this, getPhotosInChat());
+                            ArrayList<Object> photos = getPhotosInChat();
+                            int index = getIndexOfCellPhoto(cell);
+                            PhotoViewer.getInstance().openPhoto(null, 0, ChatActivity.this, photos, index);
                         } else if (message.type == MessageObject.MO_TYPE9_FILE || message.type == MessageObject.MO_TYPE3_VIDEO ) {
                             AndroidUtilities.openForViewOrShare(getParentActivity(), message.getId(), Intent.ACTION_VIEW);
                         }
@@ -2826,7 +2832,47 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
             return new Holder(view);
         }
 
-        @Override
+        private ArrayList<Object> getPhotosInChat() {
+            ArrayList<Object> photos = new ArrayList<>();
+
+            for(int msg_index = 0; msg_index < m_msglist.length; msg_index ++) {
+                MrMsg msg = MrMailbox.getMsg(m_msglist[msg_index]);
+                switch (msg.getType()) {
+                    case MrMsg.MR_MSG_IMAGE:
+                    case MrMsg.MR_MSG_GIF:
+                    {
+                        TLRPC.Message tlrpcMsg = msg.get_TLRPC_Message();
+                        MediaController.PhotoEntry entry = new MediaController.PhotoEntry(0, tlrpcMsg.id,
+                                msg.getTimestamp(), tlrpcMsg.attachPath, 0, false);
+                        photos.add(entry);
+                    }
+                    case MrMsg.MR_MSG_TEXT:
+                        Log.d(TAG, "getPhotosInChat: a message: " + msg.getText());
+                }
+                msg.get_TLRPC_Message();
+            }
+            return photos;
+        }
+
+        private int getIndexOfCellPhoto(ChatMessageCell callingCell) {
+            int photoCount = 0;
+            for(int msg_index = 0; msg_index < m_msglist.length; msg_index ++) {
+                MrMsg msg = MrMailbox.getMsg(m_msglist[msg_index]);
+                switch (msg.getType()) {
+                    case MrMsg.MR_MSG_IMAGE:
+                    case MrMsg.MR_MSG_GIF:
+                    {
+                        if(callingCell.getMessageObject().getId() == msg.getId())
+                            return photoCount; // count up until now.
+                        photoCount ++;
+                    }
+                }
+                msg.get_TLRPC_Message();
+            }
+            return 0; // didn't find the matching photo.
+        }
+
+                @Override
         public void onBindViewHolder(RecyclerView.ViewHolder holder, int i) {
             if (i >= 0 && i < m_msglist.length) {
                 View view = holder.itemView;

--- a/MessengerProj/src/main/java/com/b44t/messenger/MessageObject.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/MessageObject.java
@@ -89,6 +89,11 @@ public class MessageObject {
 
     public ArrayList<TextLayoutBlock> textLayoutBlocks;
 
+    /**
+     *
+     * @param message The outer message.
+     * @param generateLayout Set to true for raw text messages, so emojis and other graphical elements get rendered.
+     */
     public MessageObject(TLRPC.Message message, boolean generateLayout) {
         if (textPaint == null) {
             textPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
@@ -167,6 +172,7 @@ public class MessageObject {
                 }
             }
         }
+        // TODO: change 1000 here to MO_TYPE1000_INIT_VAL
         if (oldType != 1000 && oldType != type) {
             generateThumbs(false);
         }

--- a/MessengerProj/src/main/java/com/b44t/messenger/PhotoViewer.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/PhotoViewer.java
@@ -2137,7 +2137,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         pickerView.updateSelectedCount(placeProvider.getSelectedCount(), false);
     }
 
-    private void onPhotoShow(final MessageObject messageObject, final TLRPC.FileLocation fileLocation, final ArrayList<MessageObject> messages, final ArrayList<Object> photos, int index, final PlaceProviderObject object) {
+    private void setupPhotoShow() {
         classGuid = ApplicationLoader.generateClassGuid();
         currentMessageObject = null;
         currentFileLocation = null;
@@ -2170,7 +2170,6 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         imagesArrTemp.clear();
         //currentUserAvatarLocation = null;
         containerView.setPadding(0, 0, 0, 0);
-        currentThumb = object != null ? object.thumb : null;
         menuItem.setVisibility(View.VISIBLE);
         bottomLayout.setVisibility(View.VISIBLE);
         //menuItem.hideSubItem(gallery_menu_showall);
@@ -2201,8 +2200,15 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                 radialProgressViews[a].setBackgroundState(-1, false);
             }
         }
+    }
 
-        if (messageObject != null && messages == null) {
+    private void onPhotoShow(final MessageObject messageObject, final TLRPC.FileLocation fileLocation,
+                             final ArrayList<MessageObject> messages, final ArrayList<Object> photos,
+                             int index, final PlaceProviderObject object) {
+        currentThumb = object != null ? object.thumb : null;
+        setupPhotoShow();
+
+        if (messageObject != null && messages == null) { // display a single image from a message.
             imagesArr.add(messageObject);
             if (currentAnimation != null) {
                 needSearchImageInArr = false;
@@ -2212,18 +2218,18 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                 //menuItem.showSubItem(gallery_menu_showall);
             }
             setImageIndex(0, true);
-        } else if (fileLocation != null) {
+        } else if (fileLocation != null) { // display a single file from a known resource
             avatarsDialogId = object.dialogId;
             imagesArrLocations.add(fileLocation);
             imagesArrLocationsSizes.add(object.size);
             avatarsArr.add(new TLRPC.TL_photoEmpty());
             setImageIndex(0, true);
             //currentUserAvatarLocation = fileLocation;
-        } else if (messages != null) {
+        } else if (messages != null) { // display a list of files from messages
             //menuItem.showSubItem(gallery_menu_showall);
             opennedFromMedia = true;
             imagesArr.addAll(messages);
-            if (!opennedFromMedia) {
+            if (!opennedFromMedia) { // TODO: check this line, reads like: Must never happen
                 Collections.reverse(imagesArr);
                 index = imagesArr.size() - index - 1;
             }
@@ -2232,7 +2238,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                 imagesByIds[message.getDialogId() == currentDialogId ? 0 : 1].put(message.getId(), message);
             }
             setImageIndex(index, true);
-        } else if (photos != null) {
+        } else if (photos != null) { // display a list of files from gallery, to be able to select one of them
             if (sendPhotoType == 0) {
                 checkImageView.setVisibility(View.VISIBLE);
             }
@@ -2666,8 +2672,12 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                     if (size[0] == 0) {
                         size[0] = -1;
                     }
-                    TLRPC.PhotoSize thumbLocation = messageObject != null ? FileLoader.getClosestPhotoSizeWithSize(messageObject.photoThumbs, 100) : null;
-                    imageReceiver.setImage(fileLocation, null, null, placeHolder != null ? new BitmapDrawable(null, placeHolder) : null, thumbLocation != null ? thumbLocation.location : null, "b", size[0], null, avatarsDialogId != 0);
+                    TLRPC.PhotoSize thumbLocation = messageObject != null ?
+                            FileLoader.getClosestPhotoSizeWithSize(messageObject.photoThumbs, 100) : null;
+                    imageReceiver.setImage(fileLocation, null, null,
+                            placeHolder != null ? new BitmapDrawable(null, placeHolder) : null,
+                            thumbLocation != null ? thumbLocation.location : null, null,
+                            size[0], null, avatarsDialogId != 0);
                 }
             } else {
                 imageReceiver.setNeedsQualityThumb(false);
@@ -2701,9 +2711,11 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         openPhoto(null, fileLocation, null, null, 0, provider, null, 0);
     }
 
-    /*public void openPhoto(final ArrayList<MessageObject> messages, final int index, long dialogId, final PhotoViewerProvider provider) {
-        openPhoto(messages.get(index), null, messages, null, index, provider, null, dialogId);
-    }*/
+    public void openPhotoList(final MessageObject messageObject, final long dialogId,
+                              final PhotoViewerProvider provider, final ArrayList<MessageObject> photoMessages,
+                              final int index) {
+        openPhoto(messageObject, null, photoMessages, null, index, provider, null, dialogId);
+    }
 
     public void openPhotoForSelect(final ArrayList<Object> photos, final int index, int type, final PhotoViewerProvider provider, ChatActivity chatActivity) {
         sendPhotoType = type;
@@ -2726,8 +2738,13 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         return animationInProgress != 0;
     }
 
-    public void openPhoto(final MessageObject messageObject, final TLRPC.FileLocation fileLocation, final ArrayList<MessageObject> messages, final ArrayList<Object> photos, final int index, final PhotoViewerProvider provider, ChatActivity chatActivity, long dialogId) {
-        if (parentActivity == null || isVisible || provider == null && checkAnimation() || messageObject == null && fileLocation == null && messages == null && photos == null) {
+    private void openPhoto(final MessageObject messageObject, final TLRPC.FileLocation fileLocation,
+                          final ArrayList<MessageObject> messages, final ArrayList<Object> photos,
+                          final int index, final PhotoViewerProvider provider,
+                          final ChatActivity chatActivity, final long dialogId) {
+        // TODO: the next line wants some parenthesis to clear the intent.
+        if (parentActivity == null || isVisible || provider == null && checkAnimation() ||
+                messageObject == null && fileLocation == null && messages == null && photos == null) {
             return;
         }
 
@@ -2921,7 +2938,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                 }
             };
         } else {
-            if (photos != null) {
+            if (photos != null) { // is always true, if object==null && photos==null we return at the beginning of the method.
                 windowLayoutParams.flags = 0;
                 windowLayoutParams.softInputMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN;
                 wm.updateViewLayout(windowView, windowLayoutParams);

--- a/MessengerProj/src/main/java/com/b44t/messenger/PhotoViewer.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/PhotoViewer.java
@@ -2693,8 +2693,8 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         return isVisible && !disableShowCheck && object != null && currentPathObject != null && object.equals(currentPathObject);
     }
 
-    public void openPhoto(final MessageObject messageObject, long dialogId, final PhotoViewerProvider provider) {
-        openPhoto(messageObject, null, null, null, 0, provider, null, dialogId);
+    public void openPhoto(final MessageObject messageObject, long dialogId, final PhotoViewerProvider provider, ArrayList<Object> photos, int index) {
+        openPhoto(messageObject, null, null, photos, index, provider, null, dialogId);
     }
 
     public void openPhoto(final TLRPC.FileLocation fileLocation, final PhotoViewerProvider provider) {


### PR DESCRIPTION
This fixes #10.
Most action was in selecting a different segment of the openPhoto function in PhotoViewer (as indicated by method openPhotoList).
In ChatActivitiy I just gather together the pictures of this chat (currently all I can find, maybe there should be a limit...?)

change in line (original) 2670 (now 2679) should be reviewed: I suppress the blurring of thumbnails (thumbFilter "b" -> thumbFilter null). I did this because the list view kept showing the blurred thumbs for pictures that were to small to require a thumb in the first place.
I could not find the place in the code where the switch from "blurred thumb" to "clear image" would happen, but I assume there is a better solution then to just suppress the thumb blurring in the first place.