### PR TITLE
Add Gmail specific info in setup.

### DIFF
--- a/MessengerProj/src/main/java/com/b44t/messenger/Cells/TextInfoCell.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/Cells/TextInfoCell.java
@@ -23,6 +23,7 @@
 package com.b44t.messenger.Cells;
 
 import android.content.Context;
+import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.widget.FrameLayout;
@@ -67,12 +68,25 @@ public class TextInfoCell extends FrameLayout {
 
     public void setText(CharSequence text)
     {
-        setText(text, null, true);
+        setText(text, null, true, false);
     }
 
     public void setText(CharSequence text, CharSequence icon, boolean borderBotton)
     {
+        setText(text, icon, borderBotton, false);
+    }
+
+    public void setText(CharSequence text, CharSequence icon, boolean borderBotton, boolean clickableHtml)
+    {
         textView.setText(text);
+
+        if( clickableHtml ) {
+            //allow for clickable Links in TextViews
+            //https://stackoverflow.com/questions/2734270/how-do-i-make-links-in-a-textview-clickable
+            //as this avoids the onClickListener to be called (used at least for the "expand" icon in the AccountSettings)
+            //we do this only explicitly
+            textView.setMovementMethod(LinkMovementMethod.getInstance());
+        }
 
         FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) textView.getLayoutParams();
         lp.width        = LayoutHelper.WRAP_CONTENT;

--- a/MessengerProj/src/main/res/values-da/strings.xml
+++ b/MessengerProj/src/main/res/values-da/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">IMAP port</string>
     <string name="InboxHeadline">Indbakke</string>
     <string name="OutboxHeadline">Udbakke</string>
-    <string name="MyAccountExplain">For kendte e-post udbyder bliver ekstra opsætninger bestemt automatisk.</string>
-    <string name="MyAccountExplain2" >Nogle gange, <![CDATA[<b>]]>skal IMAP aktiveres<![CDATA[</b>]]> i e-post web grænseflade.\n\nKontakt e-post udbyder eller venner ved problemer.</string>
+    <string name="MyAccountExplain">For kendte e-post udbyder bliver ekstra opsætninger bestemt automatisk.<![CDATA[<br/>]]><![CDATA[<br/>]]>Nogle gange, <![CDATA[<b>]]>skal IMAP aktiveres<![CDATA[</b>]]> i e-post web grænseflade.\n\nKontakt e-post udbyder eller venner ved problemer.</string>
     <string name="AccountNotConfigured">Konto ikke opsat</string>
     <string name="AboutThisProgram">Om Delta Chat</string>
     <string name="NotSet">Ikke angivet</string>

--- a/MessengerProj/src/main/res/values-de/strings.xml
+++ b/MessengerProj/src/main/res/values-de/strings.xml
@@ -317,8 +317,14 @@
     <string name="ImapPort">IMAP-Port</string>
     <string name="InboxHeadline">Posteingang</string>
     <string name="OutboxHeadline">Postausgang</string>
-    <string name="MyAccountExplain">Für bekannte E-Mail-Anbieter werden die weiteren Einstellungen automatisch ermittelt.</string>
-    <string name="MyAccountExplain2" >Manchmal muss die <![CDATA[<b>]]>IMAP-Funktion<![CDATA[</b>]]> noch in der E-Mail-Weboberfläche <![CDATA[<b>]]>eingeschaltet<![CDATA[</b>]]> werden.\n\nBei Problemen kann der E-Mail-Anbieter oder ein Bekannter weiterhelfen.</string>
+    <string name="AdvancedOptions">Erweiterte Einstellungen...</string>
+    <string name="MyAccountExplain">Für bekannte E-Mail-Anbieter werden die weiteren Einstellungen automatisch ermittelt.
+        <![CDATA[<br/>]]><![CDATA[<br/>]]>
+        Manchmal muss die <![CDATA[<b>]]>IMAP-Funktion<![CDATA[</b>]]> noch in der E-Mail-Weboberfläche <![CDATA[<b>]]>eingeschaltet<![CDATA[</b>]]> werden.\n\nBei Problemen kann der E-Mail-Anbieter oder ein Bekannter weiterhelfen.</string>
+    <string name="MyAccountExplainGmail">Für <![CDATA[<b>]]>GMail<![CDATA[</b>]]> Accounts muss ein
+        <![CDATA[<a href="https://security.google.com/settings/security/apppasswords">]]>App-Passwort<![CDATA[</a>]]> erstellt werden, wenn 2FA aktiv ist.
+        <![CDATA[<br/>]]>Falls diese Einstellung nicht vorhanden ist, müssen Sie Zugriff für <![CDATA[<a href="https://myaccount.google.com/lesssecureapps">]]>weniger sichere Apps<![CDATA[</a>]]> zulassen.
+    </string>
     <string name="AccountNotConfigured">Konto nicht konfiguriert</string>
     <string name="AboutThisProgram">Über Delta Chat</string>
     <string name="NotSet">Nicht gesetzt</string>

--- a/MessengerProj/src/main/res/values-es/strings.xml
+++ b/MessengerProj/src/main/res/values-es/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">Puerto IMAP</string>
     <string name="InboxHeadline">Bandeja de entrada</string>
     <string name="OutboxHeadline">Bandeja de salida</string>
-    <string name="MyAccountExplain">Para proveedores conocidos de correo, los ajustes adicionales se determinan automáticamente.</string>
-    <string name="MyAccountExplain2" >Algunas veces, <b>hay que habilitar IMAP</b> en la interfaz web del correo.\n\nEn caso de problemas, consulte a su proveedor de correo o el de sus amigos.</string>
+    <string name="MyAccountExplain">Para proveedores conocidos de correo, los ajustes adicionales se determinan automáticamente.<![CDATA[<br/>]]><![CDATA[<br/>]]>Algunas veces, <b>hay que habilitar IMAP</b> en la interfaz web del correo.\n\nEn caso de problemas, consulte a su proveedor de correo o el de sus amigos.</string>
     <string name="AccountNotConfigured">Cuenta no configurada</string>
     <string name="AboutThisProgram">Sobre Delta Chat</string>
     <string name="NotSet">No establecido</string>

--- a/MessengerProj/src/main/res/values-eu/strings.xml
+++ b/MessengerProj/src/main/res/values-eu/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">IMAP ataka</string>
     <string name="InboxHeadline">Sarrera ontzia</string>
     <string name="OutboxHeadline">Irteera ontzia</string>
-    <string name="MyAccountExplain">E-mail hornitzaile ezagunentzat, ezarpen gehigarriak automatikoki zehaztuko dira.</string>
-    <string name="MyAccountExplain2" >Batzuetan, <![CDATA[<b>]]>IMAP gaitu behar da<![CDATA[</b>]]> e-mail zerbitzuaren web interfazean.\n\nGaldetu zure e-mail hornitzaileari edo lagunei arazoak badituzu.</string>
+    <string name="MyAccountExplain">E-mail hornitzaile ezagunentzat, ezarpen gehigarriak automatikoki zehaztuko dira.<![CDATA[<br/>]]><![CDATA[<br/>]]>Batzuetan, <![CDATA[<b>]]>IMAP gaitu behar da<![CDATA[</b>]]> e-mail zerbitzuaren web interfazean.\n\nGaldetu zure e-mail hornitzaileari edo lagunei arazoak badituzu.</string>
     <string name="AccountNotConfigured">Kontua konfiguratu gabe</string>
     <string name="AboutThisProgram">Delta Chat-i buruz</string>
     <string name="NotSet">Ezarri gabe</string>

--- a/MessengerProj/src/main/res/values-fr/strings.xml
+++ b/MessengerProj/src/main/res/values-fr/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">Port IMAP</string>
     <string name="InboxHeadline">Boîte de réception</string>
     <string name="OutboxHeadline">Boîte d\'envoi</string>
-    <string name="MyAccountExplain">Pour les fournisseurs e-mails connus, les paramètres suivants seront déterminés automatiquement.</string>
-    <string name="MyAccountExplain2" >Parfois, <![CDATA[<b>]]>IMAP doit être activé<![CDATA[</b>]]> depuis l\'interface web.\n\nSi vous rencontrez des problème, demandez à votre fournisseur ou à vos amis.</string>
+    <string name="MyAccountExplain">Pour les fournisseurs e-mails connus, les paramètres suivants seront déterminés automatiquement.<![CDATA[<br/>]]><![CDATA[<br/>]]>Parfois, <![CDATA[<b>]]>IMAP doit être activé<![CDATA[</b>]]> depuis l\'interface web.\n\nSi vous rencontrez des problème, demandez à votre fournisseur ou à vos amis.</string>
     <string name="AccountNotConfigured">Compte non configuré</string>
     <string name="AboutThisProgram">À propos Delta Chat</string>
     <string name="NotSet">Non défini</string>

--- a/MessengerProj/src/main/res/values-hu/strings.xml
+++ b/MessengerProj/src/main/res/values-hu/strings.xml
@@ -316,8 +316,7 @@
     <string name="ImapPort">IMAP port</string>
     <string name="InboxHeadline">Bejövő</string>
     <string name="OutboxHeadline">Kimenő</string>
-    <string name="MyAccountExplain">Ismert e-mail szolgáltató esetén az alábbi beállításokat automatikusan meghatározzuk.</string>
-    <string name="MyAccountExplain2" >Előfordulhat, hogy az IMAP/SMTP szolgáltatást az email fiókod webes felületén engedélyezni kell.\n\nHa nem megy, kérj segítséget a szolgáltatótól vagy a barátaidtól.</string>
+    <string name="MyAccountExplain">Ismert e-mail szolgáltató esetén az alábbi beállításokat automatikusan meghatározzuk.<![CDATA[<br/>]]><![CDATA[<br/>]]>Előfordulhat, hogy az IMAP/SMTP szolgáltatást az email fiókod webes felületén engedélyezni kell.\n\nHa nem megy, kérj segítséget a szolgáltatótól vagy a barátaidtól.</string>
     <string name="AccountNotConfigured">A fiók nincs beállítva</string>
     <string name="AboutThisProgram">Delta Chat névjegye</string>
     <string name="NotSet">Nincs beállítva</string>

--- a/MessengerProj/src/main/res/values-it/strings.xml
+++ b/MessengerProj/src/main/res/values-it/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">Porta IMAP</string>
     <string name="InboxHeadline">In arrivo</string>
     <string name="OutboxHeadline">In uscita</string>
-    <string name="MyAccountExplain">Per i provider email conosciuti, le impostazioni aggiuntive vengono configurate automaticamente.</string>
-    <string name="MyAccountExplain2" >A volte, <![CDATA[<b>]]>IMAP deve essere abilitato<![CDATA[</b>]]> dall\'interfaccia web dell\'email.\n\nSe si riscontrano problemi contattare il proprio provider email o i propri amici.</string>
+    <string name="MyAccountExplain">Per i provider email conosciuti, le impostazioni aggiuntive vengono configurate automaticamente.<![CDATA[<br/>]]><![CDATA[<br/>]]>A volte, <![CDATA[<b>]]>IMAP deve essere abilitato<![CDATA[</b>]]> dall\'interfaccia web dell\'email.\n\nSe si riscontrano problemi contattare il proprio provider email o i propri amici.</string>
     <string name="AccountNotConfigured">Account non configurato</string>
     <string name="AboutThisProgram">Informazioni su Delta Chat</string>
     <string name="NotSet">Non impostato</string>

--- a/MessengerProj/src/main/res/values-nb/strings.xml
+++ b/MessengerProj/src/main/res/values-nb/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">IMAP-port</string>
     <string name="InboxHeadline">Innboks</string>
     <string name="OutboxHeadline">Utboks</string>
-    <string name="MyAccountExplain">For kjente e-posttilbydere blir ytterligere innstillinger bestemt automatisk.</string>
-    <string name="MyAccountExplain2" >Noen ganger må  <![CDATA[<b>]]>IMAP<![CDATA[</b>]]> skrus på i vev-e-postgrenseflaten.\n\nVed problemer, spør din e-posttilbyder eller vennene dine.</string>
+    <string name="MyAccountExplain">For kjente e-posttilbydere blir ytterligere innstillinger bestemt automatisk.<![CDATA[<br/>]]><![CDATA[<br/>]]>Noen ganger må  <![CDATA[<b>]]>IMAP<![CDATA[</b>]]> skrus på i vev-e-postgrenseflaten.\n\nVed problemer, spør din e-posttilbyder eller vennene dine.</string>
     <string name="AccountNotConfigured">Konto ikke satt opp</string>
     <string name="AboutThisProgram">Om</string>
     <string name="NotSet">Ikke satt</string>

--- a/MessengerProj/src/main/res/values-nl/strings.xml
+++ b/MessengerProj/src/main/res/values-nl/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">IMAP-poort</string>
     <string name="InboxHeadline">Postvak IN</string>
     <string name="OutboxHeadline">Postvak UIT</string>
-    <string name="MyAccountExplain">Bij bekende e-maildiensten worden de instellingen automatisch bepaald.</string>
-    <string name="MyAccountExplain2" >Soms moet <![CDATA[<b>]]>IMAP ingeschakeld worden<![CDATA[</b>]]> op de e-mailwebsite.\n\nAls je problemen hebt, vraag dan je e-maildienst of vrienden om hulp.</string>
+    <string name="MyAccountExplain">Bij bekende e-maildiensten worden de instellingen automatisch bepaald.<![CDATA[<br/>]]><![CDATA[<br/>]]>Soms moet <![CDATA[<b>]]>IMAP ingeschakeld worden<![CDATA[</b>]]> op de e-mailwebsite.\n\nAls je problemen hebt, vraag dan je e-maildienst of vrienden om hulp.</string>
     <string name="AccountNotConfigured">Account niet ingesteld</string>
     <string name="AboutThisProgram">Over Delta Chat</string>
     <string name="NotSet">Niet ingesteld</string>

--- a/MessengerProj/src/main/res/values-pl/strings.xml
+++ b/MessengerProj/src/main/res/values-pl/strings.xml
@@ -345,8 +345,7 @@
     <string name="ImapPort">IMAP port</string>
     <string name="InboxHeadline">Skrzynka odbiorcza</string>
     <string name="OutboxHeadline">Skrzynka nadawcza</string>
-    <string name="MyAccountExplain">Dla znanych dostawców usług poczty elektronicznej poniższe ustawienia są określane automatycznie.</string>
-    <string name="MyAccountExplain2" >Czasami <![CDATA[<b>]]>IMAP musi być włączony<![CDATA[</b>]]> w interfejsie www poczty internetowej.\n\nZ problemami należy zwrócić się do usługodawcy e-mail lub znajomych.</string>
+    <string name="MyAccountExplain">Dla znanych dostawców usług poczty elektronicznej poniższe ustawienia są określane automatycznie.<![CDATA[<br/>]]><![CDATA[<br/>]]>Czasami <![CDATA[<b>]]>IMAP musi być włączony<![CDATA[</b>]]> w interfejsie www poczty internetowej.\n\nZ problemami należy zwrócić się do usługodawcy e-mail lub znajomych.</string>
     <string name="AccountNotConfigured">Konto nie jest skonfigurowane</string>
     <string name="AboutThisProgram">O Delta Chat</string>
     <string name="NotSet">Nie ustawiona</string>

--- a/MessengerProj/src/main/res/values-pt/strings.xml
+++ b/MessengerProj/src/main/res/values-pt/strings.xml
@@ -317,8 +317,7 @@
     <string name="ImapPort">Porta IMAP</string>
     <string name="InboxHeadline">Caixa de entrada</string>
     <string name="OutboxHeadline">Caixa de saída</string>
-    <string name="MyAccountExplain">Para provedores de e-mail mais populares as configurações a seguir são detectadas automaticamente.</string>
-    <string name="MyAccountExplain2" >Por vezes <![CDATA[<b>]]> é necessário habilitar o IMAP/SMTP<![CDATA[</b>]]> nas configurações do servidor de e-mail.\n\nSe tiver dificuldades peça ajuda aos administradores do servidor ou a algum amigo.</string>
+    <string name="MyAccountExplain">Para provedores de e-mail mais populares as configurações a seguir são detectadas automaticamente.<![CDATA[<br/>]]><![CDATA[<br/>]]>Por vezes <![CDATA[<b>]]> é necessário habilitar o IMAP/SMTP<![CDATA[</b>]]> nas configurações do servidor de e-mail.\n\nSe tiver dificuldades peça ajuda aos administradores do servidor ou a algum amigo.</string>
     <string name="AccountNotConfigured">Conta não configurada</string>
     <string name="AboutThisProgram">Sobre Delta Chat</string>
     <string name="NotSet">Não configurado</string>

--- a/MessengerProj/src/main/res/values-ru/strings.xml
+++ b/MessengerProj/src/main/res/values-ru/strings.xml
@@ -345,8 +345,7 @@
     <string name="ImapPort">IMAP порт</string>
     <string name="InboxHeadline">Входящие</string>
     <string name="OutboxHeadline">Исходящие</string>
-    <string name="MyAccountExplain">Для известных поставщиков электронной почты дополнительные настройки определяются автоматически.</string>
-    <string name="MyAccountExplain2" >Иногда <![CDATA[<b>]]>IMAP должен быть включён<![CDATA[</b>]]> в веб-интерфейсе электронной почты.\n\nВ случае затруднений обратитесь к своему поставщику услуги электронной почты или компетентным друзьям.</string>
+    <string name="MyAccountExplain">Для известных поставщиков электронной почты дополнительные настройки определяются автоматически.<![CDATA[<br/>]]><![CDATA[<br/>]]>Иногда <![CDATA[<b>]]>IMAP должен быть включён<![CDATA[</b>]]> в веб-интерфейсе электронной почты.\n\nВ случае затруднений обратитесь к своему поставщику услуги электронной почты или компетентным друзьям.</string>
     <string name="AccountNotConfigured">Аккаунт не настроен</string>
     <string name="AboutThisProgram">Delta Chat (Дельта Чат)</string>
     <string name="NotSet">Не задано</string>

--- a/MessengerProj/src/main/res/values-sq/strings.xml
+++ b/MessengerProj/src/main/res/values-sq/strings.xml
@@ -316,8 +316,7 @@
     <string name="ImapPort">Portë IMAP</string>
     <string name="InboxHeadline">Të marrë</string>
     <string name="OutboxHeadline">Të dërguar</string>
-    <string name="MyAccountExplain">Për furnizues të njohur shërbimesh email, rregullimet shtesë përcaktohen vetvetiu.</string>
-    <string name="MyAccountExplain2" >Ndonjëherë, <![CDATA[<b>]]>IMAP lypset të aktivizohet<![CDATA[</b>]]> te pjesa e dukshme e sistemit email web.\n\nNëse hasni probleme, këshillohuni me furnizuesin e email-it ose me shokë tuajt.</string>
+    <string name="MyAccountExplain">Për furnizues të njohur shërbimesh email, rregullimet shtesë përcaktohen vetvetiu.<![CDATA[<br/>]]><![CDATA[<br/>]]>Ndonjëherë, <![CDATA[<b>]]>IMAP lypset të aktivizohet<![CDATA[</b>]]> te pjesa e dukshme e sistemit email web.\n\nNëse hasni probleme, këshillohuni me furnizuesin e email-it ose me shokë tuajt.</string>
     <string name="AccountNotConfigured">Llogari e paformësuar</string>
     <string name="AboutThisProgram">Mbi Delta Chat-in</string>
     <string name="NotSet">E papërcaktuar</string>

--- a/MessengerProj/src/main/res/values-uk/strings.xml
+++ b/MessengerProj/src/main/res/values-uk/strings.xml
@@ -345,8 +345,7 @@
     <string name="ImapPort">IMAP порт</string>
     <string name="InboxHeadline">Скринька для вхідних</string>
     <string name="OutboxHeadline">Скринька для вихідних</string>
-    <string name="MyAccountExplain">Для відомих email-поставників, додаткові налаштування обираються автоматично.</string>
-    <string name="MyAccountExplain2" >Інколи, <![CDATA[<b>]]>IMAP має бути ввімкненим<![CDATA[</b>]]> у верстці email.\n\nУ разі виникнення проблем, спитайте поради у вашого email-поставника або друзів.</string>
+    <string name="MyAccountExplain">Для відомих email-поставників, додаткові налаштування обираються автоматично.<![CDATA[<br/>]]><![CDATA[<br/>]]>Інколи, <![CDATA[<b>]]>IMAP має бути ввімкненим<![CDATA[</b>]]> у верстці email.\n\nУ разі виникнення проблем, спитайте поради у вашого email-поставника або друзів.</string>
     <string name="AccountNotConfigured">Обліківка не налаштована</string>
     <string name="AboutThisProgram">Про оповісник</string>
     <string name="NotSet">Не встановлено</string>

--- a/MessengerProj/src/main/res/values/strings.xml
+++ b/MessengerProj/src/main/res/values/strings.xml
@@ -317,8 +317,15 @@
     <string name="ImapPort">IMAP port</string>
     <string name="InboxHeadline">Inbox</string>
     <string name="OutboxHeadline">Outbox</string>
-    <string name="MyAccountExplain">For known email providers, additional settings are determinated automatically.</string>
-    <string name="MyAccountExplain2" >Sometimes, <![CDATA[<b>]]>IMAP needs to be enabled<![CDATA[</b>]]> in the email web frontend.\n\nConsult your email provider or friends if you run into problems.</string>
+    <string name="AdvancedOptions">Advanced Options...</string>
+    <string name="MyAccountExplain">For known email providers, additional settings are determinated automatically.
+        <![CDATA[<br/>]]>
+        <![CDATA[<br/>]]>
+        Sometimes, <![CDATA[<b>]]>IMAP needs to be enabled<![CDATA[</b>]]> in the email web frontend.\n\nConsult your email provider or friends if you run into problems.</string>
+    <string name="MyAccountExplainGmail">For <![CDATA[<b>]]>GMail<![CDATA[</b>]]> Accounts you either need to create an
+        <![CDATA[<a href="https://security.google.com/settings/security/apppasswords">]]>App-Password<![CDATA[</a>]]> if you have 2FA enabled.
+        <![CDATA[<br/>]]>If this settings is not available, you need to enable <![CDATA[<a href="https://myaccount.google.com/lesssecureapps">]]>Less Secure Apps<![CDATA[</a>]]>
+    </string>
     <string name="AccountNotConfigured">Account not configured</string>
     <string name="AboutThisProgram">About Delta Chat</string>
     <string name="NotSet">Not set</string>


### PR DESCRIPTION
This PR adds a GMail specific text with links to `enable less secure apps` or `create an app password` to the setup dialog, if the E-Mail adress is recognized as GMail (`@gmail.` or `@googlemail.`).
It addresses #20 (#178).

![screenshot_20180622-073030](https://user-images.githubusercontent.com/1052720/41759355-5a62f7f2-75ee-11e8-958a-067ea02dcd66.png)
