### PR TITLE
Do not try to update the permanent notification when the screen is on, fix #362

### DIFF
--- a/MessengerProj/src/main/java/com/b44t/messenger/KeepAliveService.java
+++ b/MessengerProj/src/main/java/com/b44t/messenger/KeepAliveService.java
@@ -111,8 +111,10 @@ public class KeepAliveService extends Service {
 
     public void updateForegroundNotification()
     {
-        // update the notification by simply creating a new notification with the same ID, see https://developer.android.com/training/notify-user/managing.html#Updating
-        NotificationManager nm = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
-        nm.notify(FG_NOTIFICATION_ID, createNotification());
+        if ( !ApplicationLoader.isScreenOn ) {
+            // update the notification by simply creating a new notification with the same ID, see https://developer.android.com/training/notify-user/managing.html#Updating
+            NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            nm.notify(FG_NOTIFICATION_ID, createNotification());
+        }
     }
 }


### PR DESCRIPTION
Fix #362. You can reproduce #362 by changing the "configuration", e.g. by rotating the screen (Delta Chat does not need to be in foreground for this).

However, my fix adds a dependence from KeepAliveService to ApplicationLoader. Also, now, KeepAliveService "knows" that the permanent notification is only shown when the screen is off. Therefore, in case you want to change this, you will have to remember to change KeepAliveService as well. 

A better solution may be a "isForegroundTaskRunning()" method somewhere else, but I do not know where.