### PR TITLE
swap hidden-location and file button for a smoother layout

### DIFF
--- a/res/layout/attachment_type_selector.xml
+++ b/res/layout/attachment_type_selector.xml
@@ -78,26 +78,29 @@
 
             </LinearLayout>
 
-            <LinearLayout android:layout_width="match_parent"
+            <LinearLayout android:id="@+id/location_linear_layout"
+                          android:layout_width="match_parent"
                           android:layout_height="wrap_content"
-                          android:gravity="center"
                           android:layout_weight="1"
+                          android:gravity="center"
                           android:orientation="vertical">
 
                 <org.thoughtcrime.securesms.components.CircleColorImageView
-                        android:id="@+id/document_button"
-                        android:layout_width="53dp"
-                        android:layout_height="53dp"
-                        android:src="@drawable/ic_insert_drive_file_white_24dp"
-                        android:scaleType="center"
-                        android:contentDescription="@string/file"
-                        app:circleColor="@color/document_icon"/>
+                    android:id="@+id/location_button"
+                    android:layout_width="53dp"
+                    android:layout_height="53dp"
+                    android:src="@drawable/ic_location_on_white_24dp"
+                    android:scaleType="center"
+                    android:visibility="gone"
+                    android:contentDescription="@string/location"
+                    app:circleColor="@color/location_icon"/>
 
                 <TextView android:layout_marginTop="10dp"
-                          style="@style/AttachmentTypeLabel"
                           android:layout_width="wrap_content"
                           android:layout_height="wrap_content"
-                          android:text="@string/file"/>
+                          android:visibility="gone"
+                          style="@style/AttachmentTypeLabel"
+                          android:text="@string/location"/>
 
             </LinearLayout>
 
@@ -162,29 +165,26 @@
 
             </LinearLayout>
 
-            <LinearLayout android:id="@+id/location_linear_layout"
-                          android:layout_width="match_parent"
+            <LinearLayout android:layout_width="match_parent"
                           android:layout_height="wrap_content"
-                          android:layout_weight="1"
                           android:gravity="center"
+                          android:layout_weight="1"
                           android:orientation="vertical">
 
                 <org.thoughtcrime.securesms.components.CircleColorImageView
-                        android:id="@+id/location_button"
-                        android:layout_width="53dp"
-                        android:layout_height="53dp"
-                        android:src="@drawable/ic_location_on_white_24dp"
-                        android:scaleType="center"
-                        android:visibility="gone"
-                        android:contentDescription="@string/location"
-                        app:circleColor="@color/location_icon"/>
+                    android:id="@+id/document_button"
+                    android:layout_width="53dp"
+                    android:layout_height="53dp"
+                    android:src="@drawable/ic_insert_drive_file_white_24dp"
+                    android:scaleType="center"
+                    android:contentDescription="@string/file"
+                    app:circleColor="@color/document_icon"/>
 
                 <TextView android:layout_marginTop="10dp"
+                          style="@style/AttachmentTypeLabel"
                           android:layout_width="wrap_content"
                           android:layout_height="wrap_content"
-                          android:visibility="gone"
-                          style="@style/AttachmentTypeLabel"
-                          android:text="@string/location"/>
+                          android:text="@string/file"/>
 
             </LinearLayout>
 


### PR DESCRIPTION
the swap results in two buttons in the first fow - camera and gallery - and the other stuff in the second row; no gaps.

looks much better imho.

also, when we re-enable the location button, it get's a first-class function as placed in the first row then :)