### PR TITLE
read display-name from the database, not from the application-preference

### DIFF
--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -267,9 +267,8 @@ public class CreateProfileActivity extends BaseActionBarActivity {
   }
 
   private void initializeProfileName(boolean excludeSystem) {
-    if (!TextUtils.isEmpty(Prefs.getProfileName(this))) {
-      String profileName = Prefs.getProfileName(this);
-
+    String profileName  = DcHelper.get(this, DcHelper.CONFIG_DISPLAY_NAME);
+    if (!TextUtils.isEmpty(profileName)) {
       name.setText(profileName);
       name.setSelection(profileName.length(), profileName.length());
     } else if (!excludeSystem) {
@@ -430,7 +429,6 @@ public class CreateProfileActivity extends BaseActionBarActivity {
         Context context    = CreateProfileActivity.this;
         DcHelper.set(context, DcHelper.CONFIG_DISPLAY_NAME, name);
         setStatusText();
-        Prefs.setProfileName(context, name);
 
         try {
           AvatarHelper.setSelfAvatar(CreateProfileActivity.this, DcHelper.get(context, DcHelper.CONFIG_ADDRESS), avatarBytes);

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -57,7 +57,6 @@ public class Prefs {
 
   public  static final String SYSTEM_EMOJI_PREF                = "pref_system_emoji";
   public  static final String DIRECT_CAPTURE_CAMERA_ID         = "pref_direct_capture_camera_id";
-  private static final String PROFILE_NAME_PREF                = "pref_profile_name";
   private static final String PROFILE_AVATAR_ID_PREF           = "pref_profile_avatar_id";
   public  static final String INCOGNITO_KEYBORAD_PREF          = "pref_incognito_keyboard";
 
@@ -120,14 +119,6 @@ public class Prefs {
 
   public static boolean isIncognitoKeyboardEnabled(Context context) {
     return getBooleanPreference(context, INCOGNITO_KEYBORAD_PREF, false);
-  }
-
-  public static void setProfileName(Context context, String name) {
-    setStringPreference(context, PROFILE_NAME_PREF, name);
-  }
-
-  public static String getProfileName(Context context) {
-    return getStringPreference(context, PROFILE_NAME_PREF, null);
   }
 
   public static void setProfileAvatarId(Context context, int id) {


### PR DESCRIPTION
reading the displayname from the application-preferences works only for a single installation and works not when data are imported.

so, there is no reason to save these information twice; therefor this pr also stops saving the displayname to the application-preferences at all.

closes #423 

 @angelo-fuchs @Boehrsi @florianhaar i think, that pr not requested to review by a special person can be reviewed/merged by the first person that offers some time to comment and/or thinks the pr can be merged.

i think adding reviewers by name is only needed if the pr-review should _really_ be assigned to a special person or maybe when one knows the person is online or the pr is urgent or so.

therefore i added no one as reviewers to the pr :)