### PR TITLE
fix group-indicator display on searching for contacts and messages

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -197,6 +197,7 @@ public class ConversationListItem extends RelativeLayout
     archivedView.setVisibility(GONE);
     unreadIndicator.setVisibility(GONE);
     deliveryStatusIndicator.setNone();
+    groupIndicator.setVisibility(GONE);
 
     setBatchState(false);
     setBgColor();
@@ -227,6 +228,7 @@ public class ConversationListItem extends RelativeLayout
     archivedView.setVisibility(GONE);
     unreadIndicator.setVisibility(GONE);
     deliveryStatusIndicator.setNone();
+    groupIndicator.setVisibility(GONE);
 
     setBatchState(false);
     setBgColor();


### PR DESCRIPTION
this pr hide the group-indicator for the contact- and messages-search-result; it was displayed accidentally if the view was used by a group-chat before (views are recycled).

closes #669