### PR TITLE
Lock pattern security issues #649

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -417,7 +417,7 @@
 
     <!-- screen lock -->
     <string name="screenlock_title">Screen lock</string>
-    <string name="screenlock_explain">Lock Delta Chat access with Android screen lock or fingerprint</string>
+    <string name="screenlock_explain">Lock access with Android screen lock or fingerprint; to avoid appearing the previous content, please also enable \"Screen security\"</string>
     <string name="screenlock_authentication_failed">Authentication failed.</string>
     <string name="screenlock_unlock_title">Unlock Delta Chat</string>
     <string name="screenlock_unlock_description">Please enter your system defined secret to unlock Delta Chat.</string>

--- a/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -39,13 +39,21 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
 
     @Override
     protected void onStart() {
-        super.onStart();
         if (ScreenLockUtil.isScreenLockEnabled(this) && ScreenLockUtil.getShouldLockApp() && !isWaitingForResult) {
-            ScreenLockUtil.applyScreenLock(this);
+          ScreenLockUtil.applyScreenLock(this);
+        } else {
+          findViewById(android.R.id.content).setVisibility(View.VISIBLE);
         }
+        super.onStart();
     }
 
-    @Override
+  @Override
+  protected void onStop() {
+    findViewById(android.R.id.content).setVisibility(View.GONE);
+    super.onStop();
+  }
+
+  @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
       super.onActivityResult(requestCode, resultCode, data);
       isWaitingForResult = false;
@@ -139,6 +147,8 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
   @Override
   public void startActivityForResult(Intent intent, int requestCode) {
     super.startActivityForResult(intent, requestCode);
-    isWaitingForResult = true;
+    if (requestCode != -1) {
+      isWaitingForResult = true;
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -49,7 +49,9 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
 
   @Override
   protected void onStop() {
-    findViewById(android.R.id.content).setVisibility(View.GONE);
+    if (ScreenLockUtil.isScreenLockEnabled(this)) {
+      findViewById(android.R.id.content).setVisibility(View.GONE);
+    }
     super.onStop();
   }
 

--- a/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -28,6 +28,7 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
   private Timer timer;
 
   private boolean isWaitingForResult;
+  private boolean isHiddenByScreenLock;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -41,8 +42,9 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
     protected void onStart() {
         if (ScreenLockUtil.isScreenLockEnabled(this) && ScreenLockUtil.getShouldLockApp() && !isWaitingForResult) {
           ScreenLockUtil.applyScreenLock(this);
-        } else {
+        } else if (isHiddenByScreenLock) {
           findViewById(android.R.id.content).setVisibility(View.VISIBLE);
+          isHiddenByScreenLock = false;
         }
         super.onStart();
     }
@@ -51,6 +53,7 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
   protected void onStop() {
     if (ScreenLockUtil.isScreenLockEnabled(this)) {
       findViewById(android.R.id.content).setVisibility(View.GONE);
+      isHiddenByScreenLock = true;
     }
     super.onStop();
   }

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -83,11 +83,6 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   }
 
   @Override
-  public void onDestroy() {
-    super.onDestroy();
-  }
-
-  @Override
   public boolean onPrepareOptionsMenu(Menu menu) {
     MenuInflater inflater = this.getMenuInflater();
     menu.clear();

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -262,6 +262,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+      super.onActivityResult(requestCode, resultCode, data);
       if (requestCode == REQUEST_CODE_PICK_RINGTONE && resultCode == RESULT_OK && data != null) {
         Uri uri = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
 

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -137,6 +137,7 @@ public class AdvancedPreferenceFragment extends CorrectedPreferenceFragment
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
       if (resultCode == RESULT_OK) {
         if (requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP) {
           performBackup();

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -20,6 +20,7 @@ import org.thoughtcrime.securesms.components.SwitchPreferenceCompat;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Prefs;
+import org.thoughtcrime.securesms.util.ScreenLockUtil;
 
 import java.util.concurrent.TimeUnit;
 
@@ -114,6 +115,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
             boolean enabled = (Boolean) newValue;
             manageScreenLockChildren(enabled);
             Prefs.setScreenLockEnabled(getContext(), enabled);
+            ScreenLockUtil.setShouldLockApp(false);
             return true;
         }
     }

--- a/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
@@ -156,6 +156,7 @@ public class ChatBackgroundActivity extends BaseActionBarActivity {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
         final Context context = getApplicationContext();
         if (data != null && context != null && resultCode == RESULT_OK && requestCode == ApplicationPreferencesActivity.REQUEST_CODE_SET_BACKGROUND) {
             imageUri = data.getData();

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -82,6 +82,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
     if (requestCode == REQUEST_CODE_NOTIFICATION_SELECTED && resultCode == RESULT_OK && data != null) {
       Uri uri = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
 


### PR DESCRIPTION
Should fix #649:

- Cleanups 
- Call super.onActivityResult(requestCode, resultCode, data) where needed to avoid problems
- Hide UI on stop and only show it if no screen lock is active or if the screen lock was successfully unlocked
- Fixed some cases where the screen lock wasn't applied
- Fixed one case where the screen lock was applied after initial activation, but it shouldn't

I tried to test on new and old devices and hope every edge case is now fixed. But it would be great if some tests on new and old device would be performed by the reviewer before merging.