### PR TITLE
Group Create Issues #698

### DIFF
--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -277,6 +277,9 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
           groupCreateInDb();
         }
 
+        if (groupChatId==0) // Group still hasn't been created e.g. due to empty name
+          return true;
+
         if(isEdit()) {
           groupUpdateDone();
         }

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -472,6 +472,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
         Intent qrIntent = new Intent(GroupCreateActivity.this, QrShowActivity.class);
         qrIntent.putExtra(QrShowActivity.CHAT_ID, groupChatId);
         startActivity(qrIntent);
+        initializeExistingGroup(); // To reread the recipients from the newly created group.
     }
   }
 


### PR DESCRIPTION
Fixes #698 part 1 and 2.

The problem in part 2 was, that a new group is created before the QR code is shown. If one goes back, the group members list in GroupCreateActivity is not updated from the new group. It therefore stays empty and if the GroupCreateActivity is closed, the group is updated from the, still empty, members list, so all members are deleted from the group. I would think this is also the case when someone scans the QR code and joins the group, but I couldn't test it as I don't have a second phone with delta chat at hand.

On top of rereading the members list (this pr) one could also think about initialising the members list with the "Me" contact, since it will later be added automatically. This would make it more transparent to the user.