### PR TITLE
#685 date alignment in media gallery

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="yesterday">Yesterday</string>
     <string name="this_week">This week</string>
     <string name="this_month">This month</string>
+    <string name="last_week">Last week</string>
+    <string name="last_month">Last month</string>
     <!-- Translators: show beside messages that are "N minutes old". prefer a short string, prefer abbreviations if they're well-known -->
     <plurals name="n_minutes">
         <item quantity="one">%d min</item>

--- a/src/org/thoughtcrime/securesms/database/loaders/BucketedThreadMediaLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/BucketedThreadMediaLoader.java
@@ -14,7 +14,6 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.database.Address;
 
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -72,17 +71,33 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
     private final TimeBucket   TODAY;
     private final TimeBucket   YESTERDAY;
     private final TimeBucket   THIS_WEEK;
+    private final TimeBucket   LAST_WEEK;
     private final TimeBucket   THIS_MONTH;
+    private final TimeBucket   LAST_MONTH;
     private final MonthBuckets OLDER;
 
     private final TimeBucket[] TIME_SECTIONS;
 
     public BucketedThreadMedia(@NonNull Context context) {
-      this.TODAY         = new TimeBucket(context.getString(R.string.today), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, 0), Long.MAX_VALUE);
-      this.YESTERDAY     = new TimeBucket(context.getString(R.string.yesterday), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -1), TODAY.startTime);
-      this.THIS_WEEK     = new TimeBucket(context.getString(R.string.this_week), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -6), YESTERDAY.startTime);
-      this.THIS_MONTH    = new TimeBucket(context.getString(R.string.this_month), TimeBucket.addToCalendar(Calendar.MONTH, -1), THIS_WEEK.startTime);
-      this.TIME_SECTIONS = new TimeBucket[]{TODAY, YESTERDAY, THIS_WEEK, THIS_MONTH};
+      // from today midnight until the end of human time
+      this.TODAY         = new TimeBucket(context.getString(R.string.today),
+          addToCalendarFromTodayMidnight(Calendar.DAY_OF_YEAR, 0), Long.MAX_VALUE);
+      // from yesterday midnight until today midnight
+      this.YESTERDAY     = new TimeBucket(context.getString(R.string.yesterday),
+          addToCalendarFromTodayMidnight(Calendar.DAY_OF_YEAR, -1), TODAY.startTime);
+      // from the closest start of week until yesterday midnight (that can be a negative timespace and thus be empty)
+      this.THIS_WEEK     = new TimeBucket(context.getString(R.string.this_week),
+          setInCalendarFromTodayMidnight(Calendar.DAY_OF_WEEK, getCalendar().getFirstDayOfWeek()), YESTERDAY.startTime);
+      // from the closest start of week one week back until the closest start of week.
+      this.LAST_WEEK     = new TimeBucket(context.getString(R.string.last_week),
+          addToCalendarFrom(THIS_WEEK.startTime, Calendar.WEEK_OF_YEAR, -1), THIS_WEEK.startTime);
+      // from the closest 1st of a month until one week prior to the closest start of week (can be negative and thus empty)
+      this.THIS_MONTH    = new TimeBucket(context.getString(R.string.this_month),
+          setInCalendarFromTodayMidnight(Calendar.DAY_OF_MONTH, 1), LAST_WEEK.startTime);
+      // from the closest 1st of a month, one month back to the closest 1st of a month
+      this.LAST_MONTH    = new TimeBucket(context.getString(R.string.last_month),
+          addToCalendarFrom(THIS_MONTH.startTime, Calendar.MONTH, -1), LAST_WEEK.startTime);
+      this.TIME_SECTIONS = new TimeBucket[]{TODAY, YESTERDAY, THIS_WEEK, LAST_WEEK, THIS_MONTH, LAST_MONTH};
       this.OLDER         = new MonthBuckets();
     }
 
@@ -124,6 +139,39 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
       else                                    return OLDER.getName(section - activeTimeBuckets.size(), locale);
     }
 
+    // tests should override this function to deliver a preset calendar.
+    Calendar getCalendar() {
+      return Calendar.getInstance();
+    }
+
+    long setInCalendarFromTodayMidnight(int field, int amount) {
+      Calendar calendar = getCalendar();
+      setCalendarToTodayMidnight(calendar);
+      calendar.set(field, amount);
+      return calendar.getTimeInMillis();
+    }
+
+    long addToCalendarFrom(long relativeTo, int field, int amount) {
+      Calendar calendar = getCalendar();
+      calendar.setTime(new Date(relativeTo));
+      calendar.add(field, amount);
+      return calendar.getTimeInMillis();
+    }
+
+    long addToCalendarFromTodayMidnight(int field, int amount) {
+      Calendar calendar = getCalendar();
+      setCalendarToTodayMidnight(calendar);
+      calendar.add(field, amount);
+      return calendar.getTimeInMillis();
+    }
+
+    void setCalendarToTodayMidnight(Calendar calendar) {
+      calendar.set(Calendar.HOUR_OF_DAY, 0);
+      calendar.set(Calendar.MINUTE, 0);
+      calendar.set(Calendar.SECOND, 0);
+      calendar.set(Calendar.MILLISECOND, 0);
+    }
+
     private static class TimeBucket {
 
       private final List<DcMsg> records = new LinkedList<>();
@@ -160,16 +208,6 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
 
       String getName() {
         return name;
-      }
-
-      static long addToCalendar(int field, int amount) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(Calendar.HOUR_OF_DAY, 0);
-        calendar.set(Calendar.MINUTE, 0);
-        calendar.set(Calendar.SECOND, 0);
-        calendar.set(Calendar.MILLISECOND, 0);
-        calendar.add(field, amount);
-        return calendar.getTimeInMillis();
       }
     }
 

--- a/src/org/thoughtcrime/securesms/database/loaders/BucketedThreadMediaLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/BucketedThreadMediaLoader.java
@@ -14,6 +14,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.database.Address;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -77,10 +78,10 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
     private final TimeBucket[] TIME_SECTIONS;
 
     public BucketedThreadMedia(@NonNull Context context) {
-      this.TODAY         = new TimeBucket(context.getString(R.string.today), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -1), TimeBucket.addToCalendar(Calendar.YEAR, 1000));
-      this.YESTERDAY     = new TimeBucket(context.getString(R.string.yesterday), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -2), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -1));
-      this.THIS_WEEK     = new TimeBucket(context.getString(R.string.this_week), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -7), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -2));
-      this.THIS_MONTH    = new TimeBucket(context.getString(R.string.this_month), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -30), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -7));
+      this.TODAY         = new TimeBucket(context.getString(R.string.today), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, 0), Long.MAX_VALUE);
+      this.YESTERDAY     = new TimeBucket(context.getString(R.string.yesterday), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -1), TODAY.startTime);
+      this.THIS_WEEK     = new TimeBucket(context.getString(R.string.this_week), TimeBucket.addToCalendar(Calendar.DAY_OF_YEAR, -6), YESTERDAY.startTime);
+      this.THIS_MONTH    = new TimeBucket(context.getString(R.string.this_month), TimeBucket.addToCalendar(Calendar.MONTH, -1), THIS_WEEK.startTime);
       this.TIME_SECTIONS = new TimeBucket[]{TODAY, YESTERDAY, THIS_WEEK, THIS_MONTH};
       this.OLDER         = new MonthBuckets();
     }
@@ -142,7 +143,7 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
       }
 
       boolean inRange(long timestamp) {
-        return timestamp > startTime && timestamp <= endTime;
+        return timestamp >= startTime && timestamp < endTime;
       }
 
       boolean isEmpty() {
@@ -163,6 +164,10 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
 
       static long addToCalendar(int field, int amount) {
         Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
         calendar.add(field, amount);
         return calendar.getTimeInMillis();
       }


### PR DESCRIPTION
@r10s I could use some unpedantic pragmatism here. Current wording is confusing (at least to me & @adbenitez ).

Problem: In the Media Gallery "Today" means "The last 24 hours". In the Conversation view it means "Since 00:00.00" Similar for "Yesterday". Then they diverge even more: Conversation stays in the "Day" segmentation, Gallery changes to "This week" which means 7*24 h - 5*24 h timespan, and "This month" which is everything after that until 30*24h.

How would you name the tags & what timeframe do you think is good for it?