### PR TITLE
Use Googles repositories first

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
     repositories {
         maven {
-            url "https://repo1.maven.org/maven2"
-            jcenter()
-        }
-        maven {
             url 'https://maven.google.com/'
             name 'Google'
+        }
+        maven {
+            url "https://repo1.maven.org/maven2"
+            jcenter()
         }
     }
     dependencies {
@@ -19,13 +19,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'witness' // for dependencyVerification
 
 repositories {
+    google()
     mavenCentral()
     maven {
         // Used only for PhotoView
         url "https://jitpack.io"
         name 'JitPack Github wrapper'
     }
-    google()
     jcenter()
 }
 


### PR DESCRIPTION
We should use the Google repositories at first in the order to resolve dependencies, as sometimes the sync between Googles repos and Maven.org / MavenCentral ones fails and builds will fail. E.g. right now for me with _Could not find manifest-merger.jar (com.android.tools.build:manifest-merger:26.0.1)_).