### PR TITLE
[wip] MessageNotifier: Cleanup and restructuring for #725

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -69,7 +69,7 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     initializeRandomNumberFix();
     initializeLogging();
     initializeJobManager();
-    initializeIncomingMessageNotifier();
+    MessageNotifier.initializeIncomingMessageNotifier(dcContext);
     ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
   }
 
@@ -98,29 +98,6 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
 
   private void initializeLogging() {
     SignalProtocolLoggerProvider.setProvider(new AndroidSignalProtocolLogger());
-  }
-
-  @SuppressLint("StaticFieldLeak")
-  private void initializeIncomingMessageNotifier() {
-
-    DcEventCenter dcEventCenter = dcContext.eventCenter;
-    dcEventCenter.addObserver(DcContext.DC_EVENT_INCOMING_MSG, new DcEventCenter.DcEventDelegate() {
-      @Override
-      public void handleEvent(int eventId, Object data1, Object data2) {
-        MessageNotifier.updateNotification(dcContext.context, ((Long) data1).intValue());
-      }
-
-      @Override
-      public boolean runOnMain() {
-        return false;
-      }
-    });
-
-    // in five seconds, the system should be up and ready so we can start issuing notifications.
-
-    Util.runOnBackgroundDelayed(() -> {
-      MessageNotifier.updateNotification(dcContext.context);
-      }, 5000);
   }
 
   private void initializeJobManager() {

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -284,7 +284,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     titleView.setTitle(glideRequests, dcChat);
 
     MessageNotifier.updateVisibleChat(this, threadId);
-    markThreadAsRead();
   }
 
   @Override
@@ -839,16 +838,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private MediaConstraints getCurrentMediaConstraints() {
     return MediaConstraints.getPushMediaConstraints();
-  }
-
-  private void markThreadAsRead() {
-    new AsyncTask<Integer, Void, Void>() {
-      @Override
-      protected Void doInBackground(Integer... params) {
-        MessageNotifier.updateNotification(ConversationActivity.this, threadId, false);
-        return null;
-      }
-    }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, threadId);
   }
 
   private String getRealPathFromAttachment(Attachment attachment) {


### PR DESCRIPTION
Two objectives:
1. Reduce the amount of entry points (and therefore complexity) of the Message Notifier.
2. fix #725 so that notifications are properly cleaned up.
