### PR TITLE
Open files via intent didn't work for old android versions.

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -155,13 +155,21 @@ public class ApplicationDcContext extends DcContext {
         mimeType = checkMime(path, mimeType);
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setDataAndType(uri, mimeType);
-        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        if( Build.VERSION.SDK_INT <= 23 ) {
+          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_ACTIVITY_NEW_TASK);
+        } else {
+          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        }
         context.startActivity(intent);
       } else {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType(mimeType);
         intent.putExtra(Intent.EXTRA_STREAM, uri);
-        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        if( Build.VERSION.SDK_INT <= 23 ) {
+          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_ACTIVITY_NEW_TASK);
+        } else {
+          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        }
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.chat_share_with_title)));
       }
     } catch (RuntimeException e) {


### PR DESCRIPTION
For android SDK versions 23 and below `startActivity` throws a RuntimeException if called from a context other then an activity. To circumvent this, the flag FLAG_ACTIVITY_NEW_TASK has to be added to the intent.

Edit: I've just seen there has just been #740 opened at last partly on this. The corresponding [forum thread](https://support.delta.chat/t/unrecognized-attachments/279) describes the exactly same behaviour a friend of mine had and the mentioned devices (Samsung Note 2..5) all run android versions older than SDK 23, so I think this one fixes this.