### PR TITLE
email interactions

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -599,7 +599,7 @@ JNIEXPORT void Java_com_b44t_messenger_DcContext_setConfig(JNIEnv *env, jobject 
 }
 
 
-JNIEXPORT jstring Java_com_b44t_messenger_DcContext_getConfig(JNIEnv *env, jobject obj, jstring key, jstring def/*may be NULL*/)
+JNIEXPORT jstring Java_com_b44t_messenger_DcContext_getConfig(JNIEnv *env, jobject obj, jstring key)
 {
 	CHAR_REF(key);
 		char* temp = dc_get_config(get_dc_context(env, obj), keyPtr);

--- a/res/layout/preference_divider.xml
+++ b/res/layout/preference_divider.xml
@@ -8,7 +8,7 @@
 
     <View
             android:layout_width="match_parent"
-            android:layout_height="10dp"
+            android:layout_height="20dp"
             android:background="?pref_divider"/>
 
 </LinearLayout>

--- a/res/layout/preference_right_summary_widget.xml
+++ b/res/layout/preference_right_summary_widget.xml
@@ -10,6 +10,6 @@
               android:layout_gravity="right|center_vertical"
               android:gravity="right|center_vertical"
               android:textSize="16sp"
-              android:textColor="@color/delta_primary_dark"/>
+              android:textColor="@color/delta_accent"/>
 
 </FrameLayout>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -153,6 +153,18 @@
       <item>none</item>
   </string-array>
 
+  <string-array name="pref_show_emails_entries">
+    <item>@string/pref_show_emails_no</item>
+    <item>@string/pref_show_emails_accepted_contacts</item>
+    <item>@string/pref_show_emails_all</item>
+  </string-array>
+
+  <string-array name="pref_show_emails_values">
+    <item>0</item>
+    <item>1</item>
+    <item>2</item>
+  </string-array>
+
   <!-- discrete MIME type (the part before the "/") -->
 
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -206,6 +206,8 @@
     <string name="chat_archived_label">Archived</string>
     <string name="chat_no_messages">No messages.</string>
     <string name="chat_self_talk_subtitle">Messages I sent to myself</string>
+    <string name="chat_contact_request">Contact request</string>
+    <string name="chat_no_contact_requests">No contact requests.\n\nIf you want classic emails to appear here as contact requests, you can change the corresponding setting in the app settings.</string>
 
     <!-- search -->
     <string name="search">Search</string>
@@ -382,6 +384,11 @@
     <string name="pref_watch_mvbox_folder">Watch DeltaChat folder</string>
     <string name="pref_auto_folder_moves">Automatic Moves to DeltaChat folder</string>
     <string name="pref_auto_folder_moves_explain">Chat conversations are moved to avoid cluttering the Inbox folder</string>
+    <string name="pref_email_interaction_title">Email interaction</string>
+    <string name="pref_show_emails">Show classic emails</string>
+    <string name="pref_show_emails_no">No, chats only</string>
+    <string name="pref_show_emails_accepted_contacts">For accepted contacts</string>
+    <string name="pref_show_emails_all">All</string>
 
 
     <!-- autocrypt -->
@@ -611,6 +618,5 @@
     <string name="qrshow_join_verified_group_title">QR invite code</string>
     <!-- see qrshow_join_group_hint -->
     <string name="qrshow_join_verified_group_hint">Scan this to join the group \"%1$s\".</string>
-
 
 </resources>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -14,6 +14,17 @@
     </PreferenceCategory>
     <PreferenceCategory android:layout="@layout/preference_divider_explain_autocrypt"/>
 
+    <PreferenceCategory android:title="@string/pref_email_interaction_title">
+
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
+            android:key="pref_show_emails"
+            android:title="@string/pref_show_emails"
+            android:dependency="pref_show_emails"
+            android:entries="@array/pref_show_emails_entries"
+            android:entryValues="@array/pref_show_emails_values" />
+
+    </PreferenceCategory>
+    <PreferenceCategory android:layout="@layout/preference_divider" />
 
     <PreferenceCategory android:title="@string/pref_imap_folder_handling">
 

--- a/res/xml/preferences_appearance.xml
+++ b/res/xml/preferences_appearance.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+    <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
             android:key="pref_theme"
             android:title="@string/pref_theme"
             android:entries="@array/pref_theme_entries"
             android:entryValues="@array/pref_theme_values"
             android:defaultValue="light">
-    </org.thoughtcrime.securesms.preferences.widgets.SignalListPreference>
+    </org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary>
 
     <org.thoughtcrime.securesms.preferences.widgets.SignalPreference
         android:key="pref_chat_background"
         android:title="@string/pref_background"
         />
 
-    <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+    <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
             android:key="pref_language"
             android:title="@string/pref_language"
             android:entries="@array/language_entries"

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -3,13 +3,13 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
                   xmlns:tools="http://schemas.android.com/tools">
     <PreferenceCategory android:title="@string/pref_chats">
-        <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
                 android:key="pref_message_body_text_size"
                 android:title="@string/pref_message_text_size"
                 android:entries="@array/pref_message_font_size_entries"
                 android:entryValues="@array/pref_message_font_size_values"
                 android:defaultValue="16">
-        </org.thoughtcrime.securesms.preferences.widgets.SignalListPreference>
+        </org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary>
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                 android:defaultValue="false"

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -30,7 +30,7 @@
             android:entries="@array/pref_led_color_entries"
             android:entryValues="@array/pref_led_color_values" />
 
-        <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
             android:key="pref_led_blink"
             android:defaultValue="500,2000"
             android:title="@string/pref_led_pattern"
@@ -44,7 +44,7 @@
                             android:dependency="pref_key_enable_notifications"
                             android:defaultValue="true" />
 
-        <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
                 android:key="pref_repeat_alerts"
                 android:defaultValue="0"
                 android:title="@string/pref_repeat_notify"
@@ -52,7 +52,7 @@
                 android:entries="@array/pref_repeat_alerts_entries"
                 android:entryValues="@array/pref_repeat_alerts_values" />
 
-        <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
                 android:key="pref_notification_privacy"
                 android:title="@string/pref_notifications_show"
                 android:dependency="pref_key_enable_notifications"
@@ -60,7 +60,7 @@
                 android:entries="@array/pref_notification_privacy_entries"
                 android:entryValues="@array/pref_notification_privacy_values"/>
 
-        <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
                 android:key="pref_notification_priority"
                 android:title="@string/pref_notifications_priority"
                 android:dependency="pref_key_enable_notifications"

--- a/res/xml/recipient_preferences.xml
+++ b/res/xml/recipient_preferences.xml
@@ -42,7 +42,7 @@
             android:title="@string/pref_sound"
             android:persistent="false"/>
 
-        <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
             android:dependency="pref_key_recipient_mute"
             android:key="pref_key_recipient_vibrate"
             android:title="@string/pref_vibrate"

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -5,7 +5,6 @@ import android.support.annotation.Nullable;
 
 public class DcContext {
 
-    public final static int DC_PREF_DEFAULT_E2EE_ENABLED = 1;
     public final static int DC_PREF_DEFAULT_MDNS_ENABLED = 1;
     public final static int DC_PREF_DEFAULT_TRIM_ENABLED = 0;
     public final static int DC_PREF_DEFAULT_TRIM_LENGTH  = 500;
@@ -64,6 +63,10 @@ public class DcContext {
     public final static int DC_LP_SMTP_SOCKET_STARTTLS = 0x10000;
     public final static int DC_LP_SMTP_SOCKET_SSL      = 0x20000;
     public final static int DC_LP_SMTP_SOCKET_PLAIN    = 0x40000;
+
+    public final static int DC_SHOW_EMAILS_OFF               = 0;
+    public final static int DC_SHOW_EMAILS_ACCEPTED_CONTACTS = 1;
+    public final static int DC_SHOW_EMAILS_ALL               = 2;
 
     public DcContext(String osName) {
         handleEvent(0,0,0); // call handleEvent() to make sure it is not optimized away and JNI won't find it

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -91,8 +91,10 @@ public class DcContext {
     public native void         maybeNetwork         ();
     public native void         setConfig            (String key, String value);
     public void                setConfigInt         (String key, int value) { setConfig(key, Integer.toString(value)); }
-    public native String       getConfig            (String key, String def);
-    public int                 getConfigInt         (String key, int def) { try{return Integer.parseInt(getConfig(key, Integer.toString(def)));} catch(Exception e) {} return 0; }
+    public native String       getConfig            (String key);
+    public int                 getConfigInt         (String key) { try{return Integer.parseInt(getConfig(key));} catch(Exception e) {} return 0; }
+    @Deprecated public String  getConfig            (String key, String def) { return getConfig(key); }
+    @Deprecated public int     getConfigInt         (String key, int def) { return getConfigInt(key); }
     public native String       getInfo              ();
     public native String       getOauth2Url         (String addr, String redirectUrl);
     public native String       initiateKeyTransfer  ();

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -169,7 +169,12 @@ public class ConversationFragment extends Fragment
 
   private void setNoMessageText() {
     if(threadId==DcChat.DC_CHAT_ID_DEADDROP) {
-      noMessageTextView.setText(R.string.chat_no_messages);
+      if(DcHelper.getInt(getActivity(), "show_emails")!= DcContext.DC_SHOW_EMAILS_ALL) {
+        noMessageTextView.setText(R.string.chat_no_contact_requests);
+      }
+      else {
+        noMessageTextView.setText(R.string.chat_no_messages);
+      }
     }
     else if(getListAdapter().isGroupChat()){
       if( dcContext.getChat((int)threadId).isUnpromoted() ) {

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -27,10 +27,12 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import com.b44t.messenger.DcChat;
+import com.b44t.messenger.DcContext;
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 
 import org.thoughtcrime.securesms.components.SearchToolbar;
+import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.qr.QrScanHandler;
 import org.thoughtcrime.securesms.search.SearchFragment;
 import org.thoughtcrime.securesms.util.DynamicLanguage;

--- a/src/org/thoughtcrime/securesms/ConversationListAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationListAdapter.java
@@ -183,6 +183,16 @@ class ConversationListAdapter extends RecyclerView.Adapter {
     this.notifyDataSetChanged();
   }
 
+  int getDeaddropContactId()
+  {
+    for (int i = 0; i < dcChatlist.getCnt(); i++) {
+      if (dcChatlist.getChatId(i) == DcChat.DC_CHAT_ID_DEADDROP) {
+       return dcContext.getMsg(dcChatlist.getMsgId(i)).getFromId();
+      }
+    }
+    return 0;
+  }
+
   interface ItemClickListener {
     void onItemClick(ConversationListItem item);
     void onItemLongClick(ConversationListItem item);

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -337,6 +337,8 @@ public class ConversationListFragment extends Fragment
     return new DcChatlistLoader(getActivity(), listflags, queryFilter.isEmpty()? null : queryFilter, 0);
   }
 
+
+  boolean forceListRedraw;
   @Override
   public void onLoadFinished(Loader<DcChatlist> arg0, DcChatlist chatlist) {
     if (chatlist.getCnt() <= 0 && TextUtils.isEmpty(queryFilter) && !archive) {
@@ -356,7 +358,18 @@ public class ConversationListFragment extends Fragment
       fab.stopPulse();
     }
 
+    // this hack is needed as otherwise, for whatever reason,
+    // swiped contact request show an empty item if there pops up a new contact request imediately.
+    // anyone who wants to invesigate to this is very welcome :)
+    if (forceListRedraw) {
+      list.setLayoutManager(null);
+      list.getRecycledViewPool().clear();
+      list.setLayoutManager(new LinearLayoutManager(getActivity()));
+      forceListRedraw = false;
+    }
+
     getListAdapter().changeData(chatlist);
+
   }
 
   @Override
@@ -525,6 +538,7 @@ public class ConversationListFragment extends Fragment
         if (threadId==DcChat.DC_CHAT_ID_DEADDROP) {
           int contactId = ((ConversationListItem)viewHolder.itemView).getContactId();
           dcContext.marknoticedContact(contactId);
+          forceListRedraw = true;
           return;
         }
 

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -244,7 +244,12 @@ public class ConversationListFragment extends Fragment
       @Override
       protected void executeAction(@Nullable Void parameter) {
         for (long threadId : selectedConversations) {
-          dcContext.archiveChat((int)threadId, !archive? 1 : 0);
+          if (threadId==DcChat.DC_CHAT_ID_DEADDROP) {
+            dcContext.marknoticedContact(getListAdapter().getDeaddropContactId());
+          }
+          else {
+            dcContext.archiveChat((int)threadId, !archive? 1 : 0);
+          }
         }
       }
 
@@ -285,7 +290,12 @@ public class ConversationListFragment extends Fragment
           @Override
           protected Void doInBackground(Void... params) {
             for (long threadId : selectedConversations) {
-              dcContext.deleteChat((int)threadId);
+              if (threadId==DcChat.DC_CHAT_ID_DEADDROP) {
+                dcContext.marknoticedContact(getListAdapter().getDeaddropContactId());
+              }
+              else {
+                dcContext.deleteChat((int) threadId);
+              }
             }
             return null;
           }

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -99,12 +99,13 @@ public class ConversationTitleView extends RelativeLayout {
   }
 
   private void setRecipientTitle(DcChat dcChat) {
-    this.title.setText(dcChat.getName());
 
     if(dcChat.getId()==DcChat.DC_CHAT_ID_DEADDROP) {
+      this.title.setText(R.string.menu_deaddrop);
       this.subtitle.setText(R.string.menu_deaddrop_subtitle);
     }
     else {
+      this.title.setText(dcChat.getName());
       this.subtitle.setText(dcChat.getSubtitle());
     }
 

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -675,7 +675,7 @@ public class ApplicationDcContext extends DcContext {
           case  4: s = context.getResources().getQuantityString(R.plurals.n_members, (int)data2, (int)data2); break;
           case  6: s = context.getResources().getQuantityString(R.plurals.n_contacts, (int)data2, (int)data2); break;
           case  7: s = context.getString(R.string.voice_message); break;
-          case  8: s = context.getString(R.string.menu_deaddrop); break;
+          case  8: s = context.getString(R.string.chat_contact_request); break;
           case  9: s = context.getString(R.string.image); break;
           case 10: s = context.getString(R.string.video); break;
           case 11: s = context.getString(R.string.audio); break;

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -33,18 +33,22 @@ public class DcHelper {
         return dcContext.isConfigured() == 1;
     }
 
-    public static int getInt(Context context, String key, int defaultValue) {
+    public static int getInt(Context context, String key) {
         DcContext dcContext = getContext(context);
-        return dcContext.getConfigInt(key, defaultValue);
-    }
-
-    public static String get(Context context, String key, String defaultValue) {
-        DcContext dcContext = getContext(context);
-        return dcContext.getConfig(key, defaultValue);
+        return dcContext.getConfigInt(key);
     }
 
     public static String get(Context context, String key) {
-        return get(context, key, "");
+        DcContext dcContext = getContext(context);
+        return dcContext.getConfig(key);
+    }
+
+    @Deprecated public static int getInt(Context context, String key, int defaultValue) {
+        return getInt(context, key);
+    }
+
+    @Deprecated public static String get(Context context, String key, String defaultValue) {
+        return get(context, key);
     }
 
     public static void set(Context context, String key, String value) {

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -23,6 +23,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
+import org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.views.ProgressDialog;
@@ -30,7 +31,7 @@ import org.thoughtcrime.securesms.util.views.ProgressDialog;
 import static android.app.Activity.RESULT_OK;
 
 
-public class AdvancedPreferenceFragment extends CorrectedPreferenceFragment
+public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
                                         implements DcEventCenter.DcEventDelegate
 {
   private static final String TAG = AdvancedPreferenceFragment.class.getSimpleName();
@@ -46,6 +47,7 @@ public class AdvancedPreferenceFragment extends CorrectedPreferenceFragment
   CheckBoxPreference sentboxWatchCheckbox;
   CheckBoxPreference mvboxWatchCheckbox;
   CheckBoxPreference mvboxMoveCheckbox;
+  ListPreferenceWithSummary showEmails;
 
   @Override
   public void onCreate(Bundle paramBundle) {
@@ -79,6 +81,13 @@ public class AdvancedPreferenceFragment extends CorrectedPreferenceFragment
     mvboxMoveCheckbox.setOnPreferenceChangeListener((preference, newValue) -> {
       boolean enabled = (Boolean) newValue;
       dcContext.setConfigInt("mvbox_move", enabled? 1 : 0);
+      return true;
+    });
+
+    showEmails = (ListPreferenceWithSummary) this.findPreference("pref_show_emails");
+    showEmails.setOnPreferenceChangeListener((preference, newValue) -> {
+      updateListSummary(preference, newValue);
+      dcContext.setConfigInt("show_emails", Util.objectToInt(newValue));
       return true;
     });
 
@@ -128,11 +137,12 @@ public class AdvancedPreferenceFragment extends CorrectedPreferenceFragment
     super.onResume();
     ((ApplicationPreferencesActivity) getActivity()).getSupportActionBar().setTitle(R.string.menu_advanced);
 
-    preferE2eeCheckbox.setChecked(0!=dcContext.getConfigInt("e2ee_enabled", DcContext.DC_PREF_DEFAULT_E2EE_ENABLED));
-    inboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt("inbox_watch", 1));
-    sentboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt("sentbox_watch", 1));
-    mvboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt("mvbox_watch", 1));
-    mvboxMoveCheckbox.setChecked(0!=dcContext.getConfigInt("mvbox_move", 1));
+    preferE2eeCheckbox.setChecked(0!=dcContext.getConfigInt("e2ee_enabled"));
+    inboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt("inbox_watch"));
+    sentboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt("sentbox_watch"));
+    mvboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt("mvbox_watch"));
+    mvboxMoveCheckbox.setChecked(0!=dcContext.getConfigInt("mvbox_move"));
+    updateListSummary(showEmails, Integer.toString(dcContext.getConfigInt("show_emails")));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -13,14 +13,18 @@ public abstract class ListSummaryPreferenceFragment extends CorrectedPreferenceF
   protected class ListSummaryListener implements Preference.OnPreferenceChangeListener {
     @Override
     public boolean onPreferenceChange(Preference preference, Object value) {
-      ListPreference listPref   = (ListPreference) preference;
-      int            entryIndex = Arrays.asList(listPref.getEntryValues()).indexOf(value);
-
-      listPref.setSummary(entryIndex >= 0 && entryIndex < listPref.getEntries().length
-                          ? listPref.getEntries()[entryIndex]
-                          : getString(R.string.unknown));
+      updateListSummary(preference, value);
       return true;
     }
+  }
+
+  protected void updateListSummary(Preference preference, Object value) {
+    ListPreference listPref = (ListPreference) preference;
+    int entryIndex = Arrays.asList(listPref.getEntryValues()).indexOf(value);
+
+    listPref.setSummary(entryIndex >= 0 && entryIndex < listPref.getEntries().length
+        ? listPref.getEntries()[entryIndex]
+        : getString(R.string.unknown));
   }
 
   protected void initializeListSummary(ListPreference pref) {

--- a/src/org/thoughtcrime/securesms/preferences/widgets/ListPreferenceWithSummary.java
+++ b/src/org/thoughtcrime/securesms/preferences/widgets/ListPreferenceWithSummary.java
@@ -14,29 +14,29 @@ import android.widget.TextView;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
-public class SignalListPreference extends ListPreference {
+public class ListPreferenceWithSummary extends ListPreference {
 
   private TextView rightSummary;
   private CharSequence summary;
 
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-  public SignalListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+  public ListPreferenceWithSummary(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
     super(context, attrs, defStyleAttr, defStyleRes);
     initialize();
   }
 
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-  public SignalListPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+  public ListPreferenceWithSummary(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     initialize();
   }
 
-  public SignalListPreference(Context context, AttributeSet attrs) {
+  public ListPreferenceWithSummary(Context context, AttributeSet attrs) {
     super(context, attrs);
     initialize();
   }
 
-  public SignalListPreference(Context context) {
+  public ListPreferenceWithSummary(Context context) {
     super(context);
     initialize();
   }

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -349,6 +349,25 @@ public class Util {
     return (int)value;
   }
 
+  public static int objectToInt(Object value) {
+    try {
+      if(value instanceof String) {
+          return Integer.parseInt((String)value);
+      }
+      else if (value instanceof Boolean) {
+        return (Boolean)value? 1 : 0;
+      }
+      else if (value instanceof Integer) {
+        return (Integer)value;
+      }
+      else if (value instanceof Long) {
+        return toIntExact((Long)value);
+      }
+    } catch (Exception e) {
+    }
+    return 0;
+  }
+
   public static String getPrettyFileSize(long sizeBytes) {
     if (sizeBytes <= 0) return "0";
 


### PR DESCRIPTION
this pr will improve the interaction between chats and email

todo:

- [x] fix some annoyances with handling the popping up contact requests
- [x] add an advanced option "show emails" with the choices "no", "for active chats", "all".
- [x] if not "all" is selected as "show emails" option, the contact-request-activity and -menu-entry is completely hidden
- [x] rename the contact-request-activity to "emails"
- [x] wait for [core-part](https://github.com/deltachat/deltachat-core/pull/588) being ready

the option should be handled by the core, proposed name is `show_emails`.

@hpk42 wrt the default, meanwhile i also tend to not show emails but replies to chats by default.

<img src=https://user-images.githubusercontent.com/9800740/53350814-31473e00-3920-11e9-8a96-912792df3e8d.png width=200>