### PR TITLE
disable glide disk cache

### DIFF
--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -291,7 +291,7 @@ public class ThumbnailView extends FrameLayout {
 
   private GlideRequest buildThumbnailGlideRequest(@NonNull GlideRequests glideRequests, @NonNull Slide slide) {
     GlideRequest request = applySizing(glideRequests.load(new DecryptableUri(slide.getThumbnailUri()))
-                                          .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
+                                          .diskCacheStrategy(DiskCacheStrategy.NONE)
                                           .transition(withCrossFade()), new CenterCrop());
 
     if (slide.isInProgress()) return request;


### PR DESCRIPTION
the disk cache of the glide module seems to use some hashes or so.

just got the situation that a completely different image was shown in the chat. enlarging the image, the correct one was shown.

by disabling the disk cache (the memory cache is still active), the problem gone away.

i think we do not need the disk cache as all images are already locally, nothing gets downloaded from the ui side.

therefor this pr disables the disk cache (as already done for most other load processes) and avoids such problems.

might be related to https://github.com/bumptech/glide/issues/3544

caching is considered harmful.