### PR TITLE
[wip] using rpgp in android

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "jni/messenger-backend"]
 	path = jni/messenger-backend
 	url = https://github.com/deltachat/deltachat-core
+[submodule "jni/rpgp"]
+	path = jni/rpgp
+	url = https://github.com/rpgp/rpgp

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ For the core library and other common information, please refer to the
 # Build
 
 When checking out _deltachat-android_, make sure also to check out the
-subproject _deltachat-core_:
+subprojects [deltachat-core](https://github.com/deltachat/deltachat-core)
+and [rpgp](https://github.com/rpgp/rpgp):
 
 - When using Git, you can do this initially by
   `$ git clone --recursive https://github.com/deltachat/deltachat-android`
   or later by `git submodule update --init --recursive`. If you do this in your
   home directory, this results in the folder `~/deltachat-android` which is just fine.
-
-- Alternatively, you can download the [deltachat-android zip-file](https://github.com/deltachat/deltachat-android/archive/master.zip); in this case, also download the [deltachat-core zip-file](https://github.com/deltachat/deltachat-core/archive/master.zip) and place its contents to `jni/messenger-backend`
 
 Then, call `ndk-build` in the root directory to build the C-part; 
 this also builds deltachat-core.  Afterwards run the project in Android Studio.

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -883,7 +883,6 @@ LOCAL_MODULE     := native-utils
 LOCAL_C_INCLUDES := $(JNI_DIR)/utils/ \
 $(JNI_DIR)/messenger-backend/libs/openssl/include \
 $(JNI_DIR)/messenger-backend/libs/libetpan/include \
-$(JNI_DIR)/messenger-backend/libs/netpgp/include \
 $(JNI_DIR)/messenger-backend/libs/sqlite
 
 LOCAL_LDLIBS 	:= -ljnigraphics -llog -lz -latomic
@@ -899,19 +898,6 @@ LOCAL_C_INCLUDES += $(JNI_DIR)/../../rpgp/pgp-ffi/
 
 LOCAL_SRC_FILES := \
 utils/org_thoughtcrime_securesms_util_FileUtils.cpp \
-messenger-backend/libs/netpgp/src/compress.c \
-messenger-backend/libs/netpgp/src/create.c \
-messenger-backend/libs/netpgp/src/crypto.c \
-messenger-backend/libs/netpgp/src/keyring.c \
-messenger-backend/libs/netpgp/src/misc.c \
-messenger-backend/libs/netpgp/src/openssl_crypto.c \
-messenger-backend/libs/netpgp/src/packet-parse.c \
-messenger-backend/libs/netpgp/src/packet-show.c \
-messenger-backend/libs/netpgp/src/reader.c \
-messenger-backend/libs/netpgp/src/signature.c \
-messenger-backend/libs/netpgp/src/symmetric.c \
-messenger-backend/libs/netpgp/src/validate.c \
-messenger-backend/libs/netpgp/src/writer.c \
 messenger-backend/src/dc_aheader.c \
 messenger-backend/src/dc_apeerstate.c \
 messenger-backend/src/dc_array.c \

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -867,7 +867,13 @@ include $(BUILD_STATIC_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := librpgp
-LOCAL_SRC_FILES := ../../rpgp/target/armv7-linux-androideabi/release/libpgp_ffi.a
+
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+	LOCAL_SRC_FILES := ../../rpgp/target/armv7-linux-androideabi/release/libpgp_ffi.a
+endif
+ifeq ($(TARGET_ARCH_ABI),x86)
+	LOCAL_SRC_FILES := ../../rpgp/target/i686-linux-android/release/libpgp_ffi.a
+endif
 
 include $(PREBUILT_STATIC_LIBRARY)
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -851,6 +851,27 @@ LOCAL_SRC_FILES     := \
 
 include $(BUILD_STATIC_LIBRARY)
 
+
+################################################################################
+# rpgp
+################################################################################
+
+# rpgp must be cloned to the same directory where deltachat-android is
+# (not: inside deltachat-android)
+#
+# you can then cross-compile rpgp to android using
+# > cross build --release --target armv7-linux-androideabi -p pgp-ffi --features nightly
+#
+# TODO: x86 and other processor targets are still missing, automation, -droid script
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE    := librpgp
+LOCAL_SRC_FILES := ../../rpgp/target/armv7-linux-androideabi/release/libpgp_ffi.a
+
+include $(PREBUILT_STATIC_LIBRARY)
+
+
 ################################################################################
 # main shared library as used from Java (includes the static ones)
 ################################################################################
@@ -866,13 +887,15 @@ $(JNI_DIR)/messenger-backend/libs/netpgp/include \
 $(JNI_DIR)/messenger-backend/libs/sqlite
 
 LOCAL_LDLIBS 	:= -ljnigraphics -llog -lz -latomic
-LOCAL_STATIC_LIBRARIES :=  etpan sasl2 sqlite crypto libiconv
+LOCAL_STATIC_LIBRARIES :=  etpan sasl2 sqlite crypto libiconv librpgp
 # if you get "undefined reference" errors, the reason for this may be the _order_! Eg. libiconv as the first library does not work!
 # "breakpad" was placed after "crypto", NativeLoader.cpp after dc_wrapper.c
 
 LOCAL_CFLAGS 	:= -w -Os -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
 LOCAL_CFLAGS 	+= -Drestrict='' -D__EMX__ -DOPUS_BUILD -DFIXED_POINT -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -fno-math-errno -std=c99
 LOCAL_CFLAGS 	+= -DANDROID_NDK -DDISABLE_IMPORTGL -fno-strict-aliasing -fprefetch-loop-arrays -DAVOID_TABLES -DANDROID_TILE_BASED_DECODE -DANDROID_ARMV6_IDCT -ffast-math -D__STDC_CONSTANT_MACROS
+LOCAL_CFLAGS    += -DDC_USE_RPGP
+LOCAL_C_INCLUDES += $(JNI_DIR)/../../rpgp/pgp-ffi/
 
 LOCAL_SRC_FILES := \
 utils/org_thoughtcrime_securesms_util_FileUtils.cpp \

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_PLATFORM := android-14
-APP_ABI := armeabi armeabi-v7a x86
+APP_ABI := armeabi-v7a
 NDK_TOOLCHAIN_VERSION := 4.9
 APP_STL := gnustl_static
 

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_PLATFORM := android-14
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a x86
 NDK_TOOLCHAIN_VERSION := 4.9
 APP_STL := gnustl_static
 


### PR DESCRIPTION
todo

- [x] add rpgp as submodule, similar to deltachat-core
- [x] add at lest armeabi-v7a and x86; [armeabi"no-v7" seems to be deprecated](https://developer.android.com/ndk/guides/abis#sa))
- [ ] create librpgp.a's by automatically when calling ndk-build, gradle or so
- [ ] check, what to do for f-droid (maybe, this sould go to another pr. however)