### PR TITLE
add an experimental feature for high image compression

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -165,6 +165,16 @@
     <item>2</item>
   </string-array>
 
+  <string-array name="pref_compression_entries">
+    <item>Balanced</item>
+    <item>Worse quality, small size</item>
+  </string-array>
+
+  <string-array name="pref_compression_values">
+    <item>0</item>
+    <item>1</item>
+  </string-array>
+
   <!-- discrete MIME type (the part before the "/") -->
 
 

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -52,6 +52,21 @@
     </PreferenceCategory>
     <PreferenceCategory android:layout="@layout/preference_divider" />
 
+
+    <PreferenceCategory android:title="Experimental features">
+
+        <org.thoughtcrime.securesms.preferences.widgets.ListPreferenceWithSummary
+            android:key="pref_compression"
+            android:title="Outgoing image quality"
+            android:dependency="pref_compression"
+            android:entries="@array/pref_compression_entries"
+            android:entryValues="@array/pref_compression_values"
+            android:defaultValue="0" />
+
+    </PreferenceCategory>
+    <PreferenceCategory android:layout="@layout/preference_divider" />
+
+
     <PreferenceCategory android:title="@string/pref_other">
         <Preference android:key="pref_backup"
                     android:title="@string/pref_backup"

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -91,6 +91,9 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       return true;
     });
 
+    this.findPreference("pref_compression")
+      .setOnPreferenceChangeListener(new ListSummaryListener());
+
     Preference backup = this.findPreference("pref_backup");
     backup.setOnPreferenceClickListener(new BackupListener());
 
@@ -143,6 +146,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     mvboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt("mvbox_watch"));
     mvboxMoveCheckbox.setChecked(0!=dcContext.getConfigInt("mvbox_move"));
     updateListSummary(showEmails, Integer.toString(dcContext.getConfigInt("show_emails")));
+    initializeListSummary((ListPreferenceWithSummary) findPreference("pref_compression"));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -379,7 +379,13 @@ public class BitmapUtil {
 
   public static void recodeImageMsg(Context context, DcMsg msg)
   {
-    final int desiredWH = 1280;
+    int desiredWH = 1280;
+    int desiredJpegQuality = 85;
+
+    if (Prefs.isHardCompressionEnabled(context)) {
+      desiredWH = 640;
+      desiredJpegQuality = 75;
+    }
 
     try {
       String inPath = msg.getFile();
@@ -432,7 +438,7 @@ public class BitmapUtil {
 
       String outPath = DcHelper.getContext(context).getBlobdirFile(inPath);
       FileOutputStream outStream = new FileOutputStream(outPath);
-      if(!outBitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream)) {
+      if(!outBitmap.compress(Bitmap.CompressFormat.JPEG, desiredJpegQuality, outStream)) {
         return;
       }
 

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -229,6 +229,15 @@ public class Prefs {
     return getBooleanPreference(context, NOTIFICATION_PREF, true);
   }
 
+  public static boolean isHardCompressionEnabled(Context context) {
+    try {
+      return getStringPreference(context, "pref_compression", "0").equals("1");
+    }
+    catch(Exception e) {
+      return false;
+    }
+  }
+
   // ringtone
 
   public static @NonNull Uri getNotificationRingtone(Context context) {


### PR DESCRIPTION
this pr adds an experimental feature that introduces a much higher compression for jpeg images to save some bandwidth.

<img src=https://user-images.githubusercontent.com/9800740/53683689-1734a380-3d04-11e9-91d1-7283d082fc23.png width=200> <img src=https://user-images.githubusercontent.com/9800740/53683688-1734a380-3d04-11e9-8c6a-efa57fc7808d.png width=200>

while the compression is still okay-ish for many images, eg. for photos containing text, the text typically gets less readable so that i would not change the defaults for "balanced" currently.

the real resulting image size always depends a bit on the content, however, the example above is a typical one; most images i've tried with the new settings are about 50K, however, there may be some that are still larger, jpeg does not give you an guarantee here.