### PR TITLE
sharing files does not work #434

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -81,6 +81,18 @@
             <data android:mimeType="*/*"/>
         </intent-filter>
 
+        <intent-filter>
+            <action android:name="android.intent.action.SEND_MULTIPLE" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <data android:mimeType="audio/*" />
+            <data android:mimeType="image/*" />
+            <data android:mimeType="text/plain" />
+            <data android:mimeType="video/*" />
+            <data android:mimeType="application/*"/>
+            <data android:mimeType="text/*"/>
+            <data android:mimeType="*/*"/>
+        </intent-filter>
+
         <meta-data
                 android:name="android.service.chooser.chooser_target_service"
                 android:value=".service.DirectShareService" />

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -292,6 +292,8 @@
     <!-- share and forward messages -->
     <!-- Translators: Title shown above a chat/contact list; the user selects the recipient of the messages he wants to forward to -->
     <string name="forward_to">Forward to …</string>
+    <string name="share_multiple_attachments">Do you want to sent %1$d files to the selected chat?</string>
+    <string name="share_abort">Sharing aborted due to missing permissions.</string>
 
 
     <!-- preferences -->
@@ -489,6 +491,7 @@
     <string name="perm_explain_need_for_camera_access">To capture photos and video, allow Delta Chat access to the camera.</string>
     <string name="perm_explain_need_for_mic_access">To send audio messages, allow Delta Chat access to your microphone.</string>
     <string name="perm_explain_need_for_storage_access">Delta Chat needs access to your files in order to export files or to create backups.</string>
+    <string name="perm_explain_need_for_storage_access_share">Delta Chat needs access to your files in order to share the selected files.</string>
     <string name="perm_explain_access_to_camera_denied">Delta Chat requires the Camera permission in order to take photos or videos, but it has been permanently denied. Please continue to the app settings menu, select \"Permissions\", and enable \"Camera\".</string>
     <string name="perm_explain_access_to_mic_denied">Delta Chat requires the Microphone permission in order to send audio messages, but it has been permanently denied. Please continue to app settings, select \"Permissions\", and enable \"Microphone\".</string>
     <string name="perm_explain_access_to_storage_denied">Delta Chat requires the Storage permission in order to attach or export photos, videos, or audio, but it has been permanently denied. Please continue to the app settings menu, select \"Permissions\", and enable \"Storage\".</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -292,7 +292,7 @@
     <!-- share and forward messages -->
     <!-- Translators: Title shown above a chat/contact list; the user selects the recipient of the messages he wants to forward to -->
     <string name="forward_to">Forward to …</string>
-    <string name="share_multiple_attachments">Do you want to sent %1$d files to the selected chat?</string>
+    <string name="share_multiple_attachments">Do you want to sent %1$d files to the selected chat?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
     <string name="share_abort">Sharing aborted due to missing permissions.</string>
 
 


### PR DESCRIPTION
Bigger changes than expected ahead:

- Added an intent filter for sharing of multiple files to the manifest
- Added strings for the required dialogs ("permissions" and "should send multiple files")
- Added handling for sharing via file paths (that's what e.g. Amaze does @r10s)
- Added permission handling if sharing via file paths is used, instead of content providers (otherwise the app would crash here)
- Added sharing of multiple files to the ShareActivity (a dialog comes up, asking the user if it's fine to send the files right away, as we can't show a preview / draft for multiple files at once)
  - General separation between one / multi file handling added
  - Logic added for message creation and message sending
- Cleanup for the resolving of attachements

In general i tried to keep all the existing logic of the "single file sending" and wrapped the "multi file sending" and "file paths sending" around it. I tested every case I could imagine extensively, so I hope no existing features broke.