### PR TITLE
also update locale of ApplicationContext

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -32,6 +32,7 @@ import org.thoughtcrime.securesms.crypto.PRNGFixes;
 import org.thoughtcrime.securesms.jobmanager.JobManager;
 import org.thoughtcrime.securesms.jobmanager.persistence.JavaJobSerializer;
 import org.thoughtcrime.securesms.notifications.MessageNotifier;
+import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.SignalProtocolLoggerProvider;
@@ -71,6 +72,13 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     initializeJobManager();
     initializeIncomingMessageNotifier();
     ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
+
+    try {
+      DynamicLanguage.setContextLocale(this, DynamicLanguage.getSelectedLocale(this));
+    }
+    catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppearancePreferenceFragment.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.Preference;
 
+import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
@@ -59,6 +60,11 @@ public class AppearancePreferenceFragment extends ListSummaryPreferenceFragment 
   public void onStop() {
     super.onStop();
     getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener((ApplicationPreferencesActivity) getActivity());
+
+    // update the locale of the applicationContext so that the core gets the correct strings
+    // (for pending activities, the locale is updated by calling DynamicLanguage.onResume)
+    Context applicationContext = this.getActivity().getApplicationContext();
+    DynamicLanguage.setContextLocale(applicationContext, DynamicLanguage.getSelectedLocale(applicationContext));
   }
 
   public static CharSequence getSummary(Context context) {

--- a/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
@@ -48,7 +48,7 @@ public class DynamicLanguage {
     return configuration.getLayoutDirection();
   }
 
-  private static void setContextLocale(Context context, Locale selectedLocale) {
+  public static void setContextLocale(Context context, Locale selectedLocale) {
     Configuration configuration = context.getResources().getConfiguration();
 
     if (!configuration.locale.equals(selectedLocale)) {


### PR DESCRIPTION
currently, the selected locale is updated for all activities calling DynamicLanguage.onResume

however, some strings are also needed by the core and the ApplicationContext that is not always bound to an activity.

this pr sets the locale of the ApplicationContext on startup and on locale changes.

(in the past, the locale was wrong only if the selected language was _not_ the system language, so, this bug was not really "in the face" :)