### PR TITLE
disable invite activity for now

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -147,8 +147,11 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
         .setOnPreferenceClickListener(new CategoryClickListener(PREFERENCE_CATEGORY_CHATS));
       this.findPreference(PREFERENCE_CATEGORY_ADVANCED)
         .setOnPreferenceClickListener(new CategoryClickListener(PREFERENCE_CATEGORY_ADVANCED));
-      this.findPreference(PREFERENCE_CATEGORY_INVITE)
-          .setOnPreferenceClickListener(new CategoryClickListener(PREFERENCE_CATEGORY_INVITE));
+
+      Preference invitePreference = this.findPreference(PREFERENCE_CATEGORY_INVITE);
+      invitePreference.setVisible(false);
+      invitePreference.setOnPreferenceClickListener(new CategoryClickListener(PREFERENCE_CATEGORY_INVITE));
+
       this.findPreference(PREFERENCE_CATEGORY_HELP)
           .setOnPreferenceClickListener(new CategoryClickListener(PREFERENCE_CATEGORY_HELP));
 

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -764,10 +764,6 @@ public class ConversationFragment extends Fragment
     @Override
     public void onInviteSharedContactClicked(@NonNull List<Recipient> choices) {
       if (getContext() == null) return;
-
-//      ContactUtil.selectRecipientThroughDialog(getContext(), choices, locale, recipient -> {
-//        CommunicationActions.composeSmsThroughDefaultApp(getContext(), recipient.getAddress(), getString(R.string.InviteActivity_lets_switch_to_signal, "https://sgnl.link/1KpeYmF"));
-//      });
     }
   }
 


### PR DESCRIPTION
via the "invite" activity, mainly phone-number-based-apps will be reached - there is no need to access email-based-apps as these can be contacted with delta directly.

however, as users may not have their email-credentials in mind, pushing them to switch from phone- to mail-based messengers directly, may cause more harm than success.

also, there is also the footer that already defaults to "hey, let's use delta chat".