### PR TITLE
received .webp image are not shown #748

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -944,7 +944,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
             msg = new DcMsg(dcContext, DcMsg.DC_MSG_FILE);
           }
           String path = getRealPathFromAttachment(attachment);
-          msg.setFile(path, null);
+          String fileMime = null;
+          if (MediaUtil.isWebp(contentType)) {
+            fileMime = "image/webp";
+          }
+          msg.setFile(path, fileMime);
           msg.setText(body);
         }
       }

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -30,7 +30,6 @@ import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -219,6 +218,10 @@ public class MediaUtil {
 
   public static boolean isGif(String contentType) {
     return !TextUtils.isEmpty(contentType) && contentType.trim().equals("image/gif");
+  }
+
+  public static boolean isWebp(String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().equals("image/webp");
   }
 
   public static boolean isJpegType(String contentType) {


### PR DESCRIPTION
The sending of the message went totally fine, but on the receiving side the type "file" (instead of "image") is returned. To avoid that I set the correct mime type for WebP images. 
We can also consider adding the WebP format to the dc_msg_guess_msgtype_from_suffix method of DCC (https://github.com/deltachat/deltachat-core/blob/master/src/dc_msg.c#L904).