### PR TITLE
reword 'enter email address'

### DIFF
--- a/res/layout/contact_filter_toolbar.xml
+++ b/res/layout/contact_filter_toolbar.xml
@@ -21,7 +21,7 @@
                 android:contentDescription="@string/email_address"
                 android:fontFamily="sans-serif"
                 android:gravity="center_vertical"
-                android:hint="@string/contacts_enter_name_or_email"
+                android:hint="@string/contacts_enter_email"
                 android:ellipsize="end"
                 android:inputType="textPersonName"
                 android:textCursorDrawable="@null"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -182,6 +182,7 @@
 
     <!-- contact list -->
     <string name="contacts_title">Contacts</string>
+    <string name="contacts_enter_email">Enter email address</string>
     <string name="contacts_enter_name_or_email">Enter name or email address</string>
     <string name="contacts_type_email_above">Type email address above</string>
     <string name="contacts_empty_hint">No contacts.</string>


### PR DESCRIPTION
this pr simplifies the hint in the 'add chat' activity from `enter name or email address` to just `enter email address`.

the reason for this is that entering a name only works for email-addresses already known (through system address book or received mails) while entering an email address _always_ works.
so, the hint that entering a _name_ always works is misleading.

also the text is shorter and won't be truncated.