### PR TITLE
Forwarding image from image viewer doesn't work #805

### DIFF
--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -68,6 +68,9 @@ import org.thoughtcrime.securesms.util.Util;
 import java.io.IOException;
 import java.util.WeakHashMap;
 
+import static org.thoughtcrime.securesms.ShareActivity.EXTRA_FORWARD;
+import static org.thoughtcrime.securesms.ShareActivity.EXTRA_MSG_IDS;
+
 /**
  * Activity for displaying media attachments in-app
  */
@@ -255,8 +258,9 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
     if (mediaItem != null) {
       Intent composeIntent = new Intent(this, ShareActivity.class);
-      composeIntent.putExtra(Intent.EXTRA_STREAM, mediaItem.uri);
-      composeIntent.setType(mediaItem.type);
+      int[] msgIds = new int[]{mediaItem.msgId};
+      composeIntent.putExtra(EXTRA_MSG_IDS, msgIds);
+      composeIntent.putExtra(EXTRA_FORWARD, true);
       startActivity(composeIntent);
       overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
     }


### PR DESCRIPTION
I adjusted the forwarding of media view items, to be handled like forwarding is done on other screens (based on the message id).