### PR TITLE
Logcat with date+time for all Android versions

### DIFF
--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -86,7 +86,7 @@ public class LogViewFragment extends Fragment {
 
   private static String grabLogcat() {
     try {
-      final Process         process        = Runtime.getRuntime().exec("logcat -d");
+      final Process         process        = Runtime.getRuntime().exec("logcat -v time -d");
       final BufferedReader  bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
       final StringBuilder   log            = new StringBuilder();
       final String          separator      = System.getProperty("line.separator");

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -86,7 +86,7 @@ public class LogViewFragment extends Fragment {
 
   private static String grabLogcat() {
     try {
-      final Process         process        = Runtime.getRuntime().exec("logcat -v time -d");
+      final Process         process        = Runtime.getRuntime().exec("logcat -v threadtime -d");
       final BufferedReader  bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
       final StringBuilder   log            = new StringBuilder();
       final String          separator      = System.getProperty("line.separator");


### PR DESCRIPTION
Improve the log view - as reported in #857

Edit: Tested with Android 4.4.2 where date+time was not shown before, but now is.