### PR TITLE
Attachments with spaces in file name are not handled correctly #854

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -179,6 +179,7 @@ public class ApplicationDcContext extends DcContext {
 
   private String checkMime(String path, String mimeType) {
     if(mimeType == null || mimeType.equals("application/octet-stream")) {
+      path = path.replaceAll(" ", "");
       String extension = MimeTypeMap.getFileExtensionFromUrl(path);
       String newType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
       if(newType != null) return newType;


### PR DESCRIPTION
MimeTypeMap.getFileExtensionFromUrl() doesn't handle white spaces correctly (which is kind of hilarious). I thought about ditching the method and writing one myself, but the easiest and safest solution is probably to just remove white spaces from the path string. As the string is only used for parsing the extension is does not matter that the replaceAll call changes the string in general.