### PR TITLE
init mapbox only as needed and disable mapbox-telemetry

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -11,7 +11,6 @@ import android.support.annotation.NonNull;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEventCenter;
 import org.thoughtcrime.securesms.geolocation.DcLocationManager;
-import com.mapbox.mapboxsdk.Mapbox;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.crypto.PRNGFixes;
@@ -55,7 +54,7 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     initializeJobManager();
     initializeIncomingMessageNotifier();
     ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
-    Mapbox.getInstance(getApplicationContext(), BuildConfig.MAP_ACCESS_TOKEN);
+
     dcLocationManager = new DcLocationManager(this);
     try {
       DynamicLanguage.setContextLocale(this, DynamicLanguage.getSelectedLocale(this));


### PR DESCRIPTION
the current calls to mapbox seems to send some data to the mapbox-server as reported at https://support.delta.chat/t/end-of-privacy/393/7

this pr targets this issue by:

- initializing Mapbox only as needed
- calling functions to tell Mapbox not to send telemetry data

seems as if this is respected by Mapbox, however, if not, it might be needed to swich totally. there are a bunch of options, eg. at https://wiki.openstreetmap.org/wiki/Frameworks#Displaying_interactive_maps however, probably not all are _better_ options.

