### PR TITLE
show a hint that qr-verification cannot be done without network #756

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -479,6 +479,8 @@
     <string name="qrshow_join_group_hint">Scan this to join the group \"%1$s\".</string>
     <string name="qrshow_join_contact_title">QR invite code</string>
     <string name="qrshow_join_contact_hint">Scan this to set up a contact with %1$s</string>
+    <string name="qrshow_join_contact_no_connection_hint">QR code setup requires an internet connection. Please connect to a network before proceeding.</string>
+    <string name="qrshow_join_contact_no_connection_toast">No internet connection, can\'t perform QR code setup.</string>
     <string name="contact_verified">%1$s verified.</string>
     <string name="contact_not_verified">Cannot verify %1$s</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->


### PR DESCRIPTION
- Added a toast when entering / reentering the view
- Changed the hint text to inform about the network requirement (only if no internet connection is available)
- Added a connection listener to adjust the hint text if the connection type changes while in the view 
- Tested for general and group QR view