### PR TITLE
use cacheDir if externalCacheDir is not available

### DIFF
--- a/src/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
@@ -201,8 +201,13 @@ public class PersistentBlobProvider {
   }
 
   private static @NonNull File getExternalDir(Context context) throws IOException {
-    final File externalDir = context.getExternalCacheDir();
-    if (externalDir == null) throw new IOException("no external files directory");
+    File externalDir = context.getExternalCacheDir();
+    if (externalDir==null) {
+      externalDir = context.getCacheDir();
+    }
+    if (externalDir == null) {
+      throw new IOException("no external files directory");
+    }
     return externalDir;
   }
 


### PR DESCRIPTION
just had this situation in an emulator, this commit fixes the issue. i think it cannot harm much as it is executed only if the first attempt fails (instead of throwing an error).

however, apart from that, the PersistenBlobProvider needs some more love anyway, see eg. #901