### PR TITLE
revert the mp4-parser-upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'  // number of unread messages,
          // the one-letter circle for the contacts (when there is not avatar) and a white background.
     implementation 'com.google.zxing:core:3.2.1' // QR Code scanner
-    implementation 'com.googlecode.mp4parser:isoparser:1.1.22' // MP4 recoding in MP4Builder and related classes
+    implementation 'com.googlecode.mp4parser:isoparser:1.0.6' // MP4 recoding; upgrading eg. to 1.1.22 breaks recoding, however, i have not investigated further, just reset to 1.0.6
     implementation ('com.davemorrissey.labs:subsampling-scale-image-view:3.6.0') { // for the zooming on photos / media
         exclude group: 'com.android.support', module: 'support-annotations'
     }


### PR DESCRIPTION
i think 1.0 is fine as well :)

currently, i am not up for further investigations, however, also others apps are still using 1.0.x so at least we're not alone :)