### PR TITLE
Wrong group picture shown in group settings #817

### DIFF
--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -170,7 +170,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
     glideRequests.load(recipient.getContactPhoto(this))
                  .fallback(recipient.getFallbackContactPhoto().asCallCard(this))
                  .error(recipient.getFallbackContactPhoto().asCallCard(this))
-                 .diskCacheStrategy(DiskCacheStrategy.ALL)
+                 .diskCacheStrategy(DiskCacheStrategy.NONE)
                  .into(this.avatar);
 
     if (recipient.getContactPhoto(this) == null) this.avatar.setScaleType(ImageView.ScaleType.CENTER_INSIDE);

--- a/src/org/thoughtcrime/securesms/components/AvatarImageView.java
+++ b/src/org/thoughtcrime/securesms/components/AvatarImageView.java
@@ -12,7 +12,6 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import org.thoughtcrime.securesms.ProfileActivity;
 import org.thoughtcrime.securesms.R;
-import org.thoughtcrime.securesms.RecipientPreferenceActivity;
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.thoughtcrime.securesms.contacts.avatars.GeneratedContactPhoto;
 import org.thoughtcrime.securesms.mms.GlideRequests;
@@ -52,7 +51,7 @@ public class AvatarImageView extends AppCompatImageView {
       requestManager.load(contactPhoto)
                     .fallback(recipient.getFallbackAvatarDrawable(getContext()))
                     .error(recipient.getFallbackAvatarDrawable(getContext()))
-                    .diskCacheStrategy(DiskCacheStrategy.ALL)
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
                     .circleCrop()
                     .into(this);
       if(quickContactEnabled) {

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -74,7 +74,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
         try {
           setLargeIcon(GlideApp.with(context.getApplicationContext())
                                .load(contactPhoto)
-                               .diskCacheStrategy(DiskCacheStrategy.ALL)
+                               .diskCacheStrategy(DiskCacheStrategy.NONE)
                                .circleCrop()
                                .submit(context.getResources().getDimensionPixelSize(android.R.dimen.notification_large_icon_width),
                                        context.getResources().getDimensionPixelSize(android.R.dimen.notification_large_icon_height))

--- a/src/org/thoughtcrime/securesms/preferences/widgets/ProfilePreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/widgets/ProfilePreference.java
@@ -77,7 +77,7 @@ public class ProfilePreference extends Preference {
             .load(profileImage)
             .error(new ResourceContactPhoto(R.drawable.ic_camera_alt_white_24dp).asDrawable(getContext(), getContext().getResources().getColor(R.color.grey_400)))
             .circleCrop()
-            .diskCacheStrategy(DiskCacheStrategy.ALL)
+            .diskCacheStrategy(DiskCacheStrategy.NONE)
             .into(avatarView);
 
     if (!TextUtils.isEmpty(profileName)) {


### PR DESCRIPTION
Sadly I wasn't able to reproduce neither the group image problem nor the "me" image problem. But I found some Glide caching stuff (https://bumptech.github.io/glide/doc/caching.html#skipping-the-cache) which could produce those problems. I disabled the disk caching as DCC provides the images anyway "on disk" and we don't need additional caching there. I kept the in memory caching as this definitely speeds up the repeated loading of images in our use case. @r10s could you check if these adjustments are fixing the problem?