### PR TITLE
[wip] collapsing header

### DIFF
--- a/res/layout/profile_activity.xml
+++ b/res/layout/profile_activity.xml
@@ -10,31 +10,45 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
+        <!-- has to be a direct child of AppBarLayout -->
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/toolbar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"
+            app:contentScrim="?attr/colorPrimary"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+        <ImageView
+            android:id="@+id/expandedImage"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/background_hd"
+            app:layout_collapseMode="parallax"
+            app:layout_collapseParallaxMultiplier="0.7" />
+
         <android.support.v7.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                android:minHeight="?attr/actionBarSize"
-                android:background="?attr/colorPrimary"
-                app:contentInsetStart="14dp"
-                app:contentInsetLeft="14dp"
-                android:elevation="4dp"
-                android:theme="?attr/actionBarStyle"/>
+                app:layout_collapseMode="pin" />
 
         <android.support.design.widget.TabLayout
                 android:id="@+id/tab_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:elevation="4dp"
-                android:layout_gravity="top"
-                android:background="?attr/colorPrimary"
+                android:layout_gravity="bottom"
+                android:background="@color/transparent"
                 app:tabMode="fixed"
                 app:tabPaddingStart="3dp"
                 app:tabPaddingEnd="3dp"
-                app:tabBackground="?attr/colorPrimary"
+                app:tabBackground="@color/transparent"
                 app:tabIndicatorColor="@color/white"
                 app:tabTextColor="@color/gray10"
                 app:tabSelectedTextColor="@color/white"/>
+
+        </android.support.design.widget.CollapsingToolbarLayout>
 
     </android.support.design.widget.AppBarLayout>
 

--- a/res/layout/profile_activity.xml
+++ b/res/layout/profile_activity.xml
@@ -15,26 +15,26 @@
             android:id="@+id/toolbar_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
-            app:contentScrim="?attr/colorPrimary"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
-        <ImageView
-            android:id="@+id/expandedImage"
-            android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:scaleType="centerCrop"
-            android:src="@drawable/background_hd"
-            app:layout_collapseMode="parallax"
-            app:layout_collapseParallaxMultiplier="0.7" />
+            <ImageView
+                android:id="@+id/avatar"
+                android:layout_width="match_parent"
+                android:layout_height="240dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/background_hd"
+                app:layout_collapseMode="parallax"
+                app:layout_collapseParallaxMultiplier="0.7" />
 
-        <android.support.v7.widget.Toolbar
+            <android.support.v7.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:layout_gravity="top"
+                android:layout_marginBottom="48dp"
                 app:layout_collapseMode="pin" />
 
-        <android.support.design.widget.TabLayout
+            <android.support.design.widget.TabLayout
                 android:id="@+id/tab_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -46,7 +46,8 @@
                 app:tabBackground="@color/transparent"
                 app:tabIndicatorColor="@color/white"
                 app:tabTextColor="@color/gray10"
-                app:tabSelectedTextColor="@color/white"/>
+                app:tabSelectedTextColor="@color/white"
+                app:layout_collapseMode="pin"/>
 
         </android.support.design.widget.CollapsingToolbarLayout>
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -17,14 +17,19 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.EditText;
+import android.widget.ImageView;
 
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEventCenter;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.mms.GlideRequests;
+import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
@@ -65,6 +70,8 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   private Toolbar            toolbar;
   private TabLayout          tabLayout;
   private ViewPager          viewPager;
+  private ImageView          avatar;
+  private GlideRequests      glideRequests;
 
   @Override
   protected void onPreCreate() {
@@ -76,6 +83,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   @Override
   protected void onCreate(Bundle bundle, boolean ready) {
     setContentView(R.layout.profile_activity);
+    glideRequests = GlideApp.with(this);
 
     initializeResources();
     initializeToolbar();
@@ -173,6 +181,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     this.viewPager = ViewUtil.findById(this, R.id.pager);
     this.toolbar   = ViewUtil.findById(this, R.id.toolbar);
     this.tabLayout = ViewUtil.findById(this, R.id.tab_layout);
+    this.avatar    = ViewUtil.findById(this, R.id.avatar);
   }
 
   private void initializeToolbar()
@@ -183,6 +192,21 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void updateToolbar() {
+    Recipient recipient = new Recipient(this, chatId!=0? dcContext.getChat(chatId) : null, (chatId==0&&contactId!=0)? dcContext.getContact(contactId) : null);;
+    glideRequests.load(recipient.getContactPhoto(this))
+        .fallback(recipient.getFallbackContactPhoto().asCallCard(this))
+        .error(recipient.getFallbackContactPhoto().asCallCard(this))
+        .diskCacheStrategy(DiskCacheStrategy.NONE)
+        .into(this.avatar);
+
+    if (recipient.getContactPhoto(this) == null) this.avatar.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+    else                                     this.avatar.setScaleType(ImageView.ScaleType.CENTER_CROP);
+
+//    this.avatar.setBackgroundColor(recipient.getFallbackAvatarColor(this));
+//    this.toolbarLayout.setTitle(recipient.toShortString());
+//    this.toolbarLayout.setContentScrimColor(recipient.getFallbackAvatarColor(this));
+
+
     if (isGlobalProfile()){
       getSupportActionBar().setTitle(R.string.menu_all_media);
     }


### PR DESCRIPTION
this is attempt to use a collapsing header with a large group image in the new profile.

while this works, with the help of https://developer.android.com/reference/android/support/design/widget/CollapsingToolbarLayout and https://blog.iamsuleiman.com/parallax-scrolling-tabs-design-support-library/ generally (it's a bit tricky because of the tabs), it has some drawbacks:

- tabs are not the clear recognizable, same for the dot-menu
- initially lots of screen space is wasted
- the largest problem: it requires a list or so that has an end atop - this won't work eg. with a map which is already part of our plans for another tab

the advantage, however, is the large display of the group image, we can mitigate this by showing the enlarged image as large as the screen by another tap on the avatar.

so, we vote for the more boring method - form follows function ;)