### PR TITLE
Let manually downloaded and not updated APKs expire #885

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -103,6 +103,11 @@
     <string name="message_delivered">Message delivered</string>
     <string name="message_read">Message read</string>
 
+    <string name="information_outdated_app_title">Your app version is outdated.</string>
+    <string name="information_outdated_app_text">It seems that you installed Delta Chat from a source without auto updates (e.g. GitHub). Please switch to a store version to receive the latest features and bug fixes.</string>
+    <string name="information_outdated_app_dialog_title">Update sources</string>
+    <string name="information_outdated_app_dialog_text">Delta Chat is available on:\nF-Droid: https://f-droid.org/packages/com.b44t.messenger \nGoogle Play: https://play.google.com/store/apps/details?id=chat.delta\</string>
+
 
     <!-- menu labels (or icon, buttons...) -->
     <string name="menu_new_contact">New contact</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -106,7 +106,7 @@
     <string name="information_outdated_app_title">Your app version is outdated.</string>
     <string name="information_outdated_app_text">It seems that you installed Delta Chat from a source without auto updates (e.g. GitHub). Please switch to a store version to receive the latest features and bug fixes.</string>
     <string name="information_outdated_app_dialog_title">Update sources</string>
-    <string name="information_outdated_app_dialog_text">Delta Chat is available on:\nF-Droid: https://f-droid.org/packages/com.b44t.messenger \nGoogle Play: https://play.google.com/store/apps/details?id=chat.delta\</string>
+    <string name="information_outdated_app_dialog_text">Delta Chat is available on:</string>
 
 
     <!-- menu labels (or icon, buttons...) -->

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -59,6 +59,7 @@ import org.thoughtcrime.securesms.ConversationListAdapter.ItemClickListener;
 import org.thoughtcrime.securesms.components.recyclerview.DeleteItemAnimator;
 import org.thoughtcrime.securesms.components.registration.PulsingFloatingActionButton;
 import org.thoughtcrime.securesms.components.reminder.DozeReminder;
+import org.thoughtcrime.securesms.components.reminder.OutdatedReminder;
 import org.thoughtcrime.securesms.components.reminder.Reminder;
 import org.thoughtcrime.securesms.components.reminder.ReminderView;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
@@ -209,6 +210,8 @@ public class ConversationListFragment extends Fragment
 //        } else
           if (DozeReminder.isEligible(context)) {
             return Optional.of(new DozeReminder(context));
+          } else if (OutdatedReminder.isEligible(context)) {
+            return Optional.of(new OutdatedReminder(context));
           }
           else {
             return Optional.absent();

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -199,6 +199,9 @@ public class LogViewFragment extends Fragment {
              .append(BuildConfig.FLAVOR)
              .append(BuildConfig.DEBUG? "-debug" : "")
              .append("\n");
+      builder.append("installer=")
+             .append(pm.getInstallerPackageName(context.getPackageName()))
+             .append("\n");
       if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         builder.append("ignoreBatteryOptimizations=").append(
             powerManager.isIgnoringBatteryOptimizations(context.getPackageName())).append("\n");

--- a/src/org/thoughtcrime/securesms/components/reminder/OutdatedReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/OutdatedReminder.java
@@ -47,8 +47,8 @@ public class OutdatedReminder extends Reminder {
         if (context == null) {
             return false;
         }
-        final PackageManager packageManager = context.getPackageManager();
         try {
+            final PackageManager packageManager = context.getPackageManager();
             String packageName = context.getPackageName();
             if (packageManager.getInstallerPackageName(packageName) == null) {
                 long lastUpdateTime = packageManager
@@ -59,7 +59,7 @@ public class OutdatedReminder extends Reminder {
                 long diffInDays = TimeUnit.MILLISECONDS.toDays(diff);
                 return diffInDays >= OUTDATED_THRESHOLD_IN_DAYS;
             }
-        } catch (final PackageManager.NameNotFoundException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return false;

--- a/src/org/thoughtcrime/securesms/components/reminder/OutdatedReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/OutdatedReminder.java
@@ -1,0 +1,67 @@
+package org.thoughtcrime.securesms.components.reminder;
+
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
+import android.text.util.Linkify;
+import android.widget.TextView;
+
+import org.thoughtcrime.securesms.R;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class OutdatedReminder extends Reminder {
+
+    private static final long OUTDATED_THRESHOLD_IN_DAYS = 90;
+
+    public OutdatedReminder(@NonNull final Context context) {
+        super(context.getString(R.string.information_outdated_app_title),
+                context.getString(R.string.information_outdated_app_text));
+
+        setOkListener(v -> {
+            AlertDialog sourceDialog = new AlertDialog.Builder(context)
+                    .setTitle(R.string.information_outdated_app_dialog_title)
+                    .setMessage(R.string.information_outdated_app_dialog_text)
+                    .setPositiveButton(R.string.ok, (dialog, which) -> dialog.cancel())
+                    .create();
+            sourceDialog.show();
+            Linkify.addLinks((TextView) Objects.requireNonNull(sourceDialog.findViewById(android.R.id.message)), Linkify.WEB_URLS);
+        });
+    }
+
+    @Override
+    public boolean isDismissable() {
+        return false;
+    }
+
+    @NonNull
+    @Override
+    public Importance getImportance() {
+        return Importance.ERROR;
+    }
+
+    public static boolean isEligible(Context context) {
+        if (context == null) {
+            return false;
+        }
+        final PackageManager packageManager = context.getPackageManager();
+        try {
+            String packageName = context.getPackageName();
+            if (packageManager.getInstallerPackageName(packageName) == null) {
+                long lastUpdateTime = packageManager
+                        .getPackageInfo(packageName, 0)
+                        .lastUpdateTime;
+                long nowTime = System.currentTimeMillis();
+                long diff = nowTime - lastUpdateTime;
+                long diffInDays = TimeUnit.MILLISECONDS.toDays(diff);
+                return diffInDays >= OUTDATED_THRESHOLD_IN_DAYS;
+            }
+        } catch (final PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/src/org/thoughtcrime/securesms/components/reminder/OutdatedReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/OutdatedReminder.java
@@ -24,7 +24,9 @@ public class OutdatedReminder extends Reminder {
         setOkListener(v -> {
             AlertDialog sourceDialog = new AlertDialog.Builder(context)
                     .setTitle(R.string.information_outdated_app_dialog_title)
-                    .setMessage(R.string.information_outdated_app_dialog_text)
+                    .setMessage(context.getString(R.string.information_outdated_app_dialog_text)
+                        +"\n\nF-Droid: https://f-droid.org/packages/com.b44t.messenger"
+                        +"\n\nGoogle Play: https://play.google.com/store/apps/details?id=chat.delta")
                     .setPositiveButton(R.string.ok, (dialog, which) -> dialog.cancel())
                     .create();
             sourceDialog.show();


### PR DESCRIPTION
Added the mentioned feature:

- A reminder (not dismissable) is shown in the chat list. It's marked with a special error color defined by the reminder class
- The reminder is only added if no other reminders are applied. I implemented it this way to avoid blocking of other reminders, as this one isn't dismissable
- It's shown only for apps where no installerPackageName is set and if the app wasn't updated within the last 90 days (I think this is a good value inbetween the suggested two vs. six months)
- If the user taps on the reminder a dialog is shown which allows the user to directly go to F-Droid or the Google Play store

Feel free to change the time frame value or the added strings. Please see the screenshots for more information.