### PR TITLE
allow sending large files and videos

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -251,8 +251,12 @@ public class AttachmentManager {
          if (slide == null) {
           attachmentViewStub.get().setVisibility(View.GONE);
           result.set(false);
-        } else if (!areConstraintsSatisfied(context, slide, constraints)) {
+        } else if (slide.getFileSize()>1*1024*1024*1024) {
+          // this is only a rough check, videos and images may be recoded
+          // and the core checks more carefully later.
           attachmentViewStub.get().setVisibility(View.GONE);
+          Log.w(TAG, "File too large.");
+          Toast.makeText(slide.context, "File too large.", Toast.LENGTH_LONG).show();
           result.set(false);
         } else {
           setSlide(slide);
@@ -505,15 +509,6 @@ public class AttachmentManager {
       Log.w(TAG, "couldn't complete ACTION_GET_CONTENT intent, no activity found. falling back.");
       Toast.makeText(activity, R.string.no_app_to_handle_data, Toast.LENGTH_LONG).show();
     }
-  }
-
-  private boolean areConstraintsSatisfied(final @NonNull  Context context,
-                                          final @Nullable Slide slide,
-                                          final @NonNull  MediaConstraints constraints)
-  {
-   return slide == null                                          ||
-          constraints.isSatisfied(context, slide.asAttachment()) ||
-          constraints.canResize(slide.asAttachment());
   }
 
   private void previewImageDraft(final @NonNull Slide slide) {

--- a/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
@@ -1,23 +1,12 @@
 package org.thoughtcrime.securesms.mms;
 
 import android.content.Context;
-import android.net.Uri;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
-import android.util.Pair;
 
 import org.thoughtcrime.securesms.attachments.Attachment;
-import org.thoughtcrime.securesms.util.BitmapDecodingException;
-import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.MediaUtil;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 public abstract class MediaConstraints {
-  private static final String TAG = MediaConstraints.class.getSimpleName();
-
   public static MediaConstraints getPushMediaConstraints() {
     return new PushMediaConstraints();
   }
@@ -25,35 +14,6 @@ public abstract class MediaConstraints {
   public abstract int getImageMaxWidth(Context context);
   public abstract int getImageMaxHeight(Context context);
   public abstract int getImageMaxSize(Context context);
-
-  public abstract int getGifMaxSize(Context context);
-  public abstract int getVideoMaxSize(Context context);
-  public abstract int getAudioMaxSize(Context context);
-  public abstract int getDocumentMaxSize(Context context);
-
-  public boolean isSatisfied(@NonNull Context context, @NonNull Attachment attachment) {
-    try {
-      return (MediaUtil.isGif(attachment)    && attachment.getSize() <= getGifMaxSize(context)   && isWithinBounds(context, attachment.getDataUri())) ||
-             (MediaUtil.isImage(attachment)  && attachment.getSize() <= getImageMaxSize(context) && isWithinBounds(context, attachment.getDataUri())) ||
-             (MediaUtil.isAudio(attachment)  && attachment.getSize() <= getAudioMaxSize(context)) ||
-             (MediaUtil.isVideo(attachment)  && attachment.getSize() <= getVideoMaxSize(context)) ||
-             (MediaUtil.isFile(attachment) && attachment.getSize() <= getDocumentMaxSize(context));
-    } catch (IOException ioe) {
-      Log.w(TAG, "Failed to determine if media's constraints are satisfied.", ioe);
-      return false;
-    }
-  }
-
-  private boolean isWithinBounds(Context context, Uri uri) throws IOException {
-    try {
-      InputStream is = PartAuthority.getAttachmentStream(context, uri);
-      Pair<Integer, Integer> dimensions = BitmapUtil.getDimensions(is);
-      return dimensions.first  > 0 && dimensions.first  <= getImageMaxWidth(context) &&
-             dimensions.second > 0 && dimensions.second <= getImageMaxHeight(context);
-    } catch (BitmapDecodingException e) {
-      throw new IOException(e);
-    }
-  }
 
   public boolean canResize(@Nullable Attachment attachment) {
     return attachment != null && MediaUtil.isImage(attachment) && !MediaUtil.isGif(attachment);

--- a/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -25,24 +25,4 @@ public class PushMediaConstraints extends MediaConstraints {
   public int getImageMaxSize(Context context) {
     return 6 * MB;
   }
-
-  @Override
-  public int getGifMaxSize(Context context) {
-    return 25 * MB;
-  }
-
-  @Override
-  public int getVideoMaxSize(Context context) {
-    return 100 * MB;
-  }
-
-  @Override
-  public int getAudioMaxSize(Context context) {
-    return 100 * MB;
-  }
-
-  @Override
-  public int getDocumentMaxSize(Context context) {
-    return 100 * MB;
-  }
 }

--- a/src/org/thoughtcrime/securesms/profiles/ProfileMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/profiles/ProfileMediaConstraints.java
@@ -20,24 +20,4 @@ public class ProfileMediaConstraints extends MediaConstraints {
   public int getImageMaxSize(Context context) {
     return 5 * 1024 * 1024;
   }
-
-  @Override
-  public int getGifMaxSize(Context context) {
-    return 0;
-  }
-
-  @Override
-  public int getVideoMaxSize(Context context) {
-    return 0;
-  }
-
-  @Override
-  public int getAudioMaxSize(Context context) {
-    return 0;
-  }
-
-  @Override
-  public int getDocumentMaxSize(Context context) {
-    return 0;
-  }
 }


### PR DESCRIPTION
there was an old signal limit that disallows sending videos of more than 100 MB. 

as delta chat recodes videos, however, even larger files can be sent.

there were similar limits for other file types.

this pr removes these limits and does a generic check to avoid trying to recode/process files that are really huge (1 gb chosen by random)