### PR TITLE
access member-profiles from chat-profine

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -211,7 +211,6 @@
     <activity android:name=".ProfileActivity"
               android:theme="@style/TextSecure.LightNoActionBar"
               android:windowSoftInputMode="stateHidden"
-              android:launchMode="singleTask"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".DummyActivity"

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -187,19 +187,9 @@ public class ProfileSettingsFragment extends Fragment
       onQrInvite();
     }
     else if(contactId>DcContact.DC_CONTACT_ID_LAST_SPECIAL) {
-      new AlertDialog.Builder(getContext())
-          .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-            int chatId = dcContext.createChatByContactId(contactId);
-            if( chatId != 0 ) {
-              Intent intent = new Intent(getContext(), ConversationActivity.class);
-              intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
-              getContext().startActivity(intent);
-              getActivity().finish();
-            }
-          })
-          .setNegativeButton(android.R.string.cancel, null)
-          .setMessage(getString(R.string.ask_start_chat_with, dcContext.getContact(contactId).getDisplayName()))
-          .show();
+      Intent intent = new Intent(getContext(), ProfileActivity.class);
+      intent.putExtra(ProfileActivity.CONTACT_ID_EXTRA, contactId);
+      startActivity(intent);
     }
   }
 


### PR DESCRIPTION
this pr changes be behavior of a tap on a member in the chat-profile.

instead of asking whether to start a new chat, the member-profile is shown. from there, with a second tap, a new chat can be started.

this behavior-change allows to "browse around" while still allowing starting new chats easily enough (the second tap is always on the same place, no scrolling or so required)

cc @hpk42 :)