### PR TITLE
use larger input-view and smaller chat-view

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -71,7 +71,7 @@
     <style name="ComposeEditText" parent="@style/Signal.Text.Body">
         <item name="android:padding">2dp</item>
         <item name="android:background">@null</item>
-        <item name="android:maxLines">4</item>
+        <item name="android:maxLines">10</item>
         <item name="android:maxLength">64000</item>
         <item name="android:textColor">?conversation_item_outgoing_text_primary_color</item>
         <item name="android:capitalize">sentences</item>


### PR DESCRIPTION
Extend size of message text input field from 4 to 10 lines max.