### PR TITLE
don't allow to remove yourself from the multiselect contact list, 

### DIFF
--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -19,6 +19,7 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEventCenter;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -47,6 +48,8 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
+import static com.b44t.messenger.DcContact.DC_CONTACT_ID_SELF;
 
 public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
                                  implements OnRecipientDeletedListener, DcEventCenter.DcEventDelegate
@@ -190,7 +193,10 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     lv           = ViewUtil.findById(this, R.id.selected_contacts_list);
     avatar       = ViewUtil.findById(this, R.id.avatar);
     groupName    = ViewUtil.findById(this, R.id.group_name);
-    SelectedRecipientsAdapter adapter = new SelectedRecipientsAdapter(this);
+    List<Recipient> initList = new LinkedList<>();
+    DcContact self = dcContext.getContact(DC_CONTACT_ID_SELF);
+    initList.add(dcContext.getRecipient(self));
+    SelectedRecipientsAdapter adapter = new SelectedRecipientsAdapter(this, initList);
     adapter.setOnRecipientDeletedListener(this);
     lv.setAdapter(adapter);
 

--- a/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
@@ -314,6 +314,7 @@ public class ContactSelectionListAdapter extends RecyclerView.Adapter
     } else {
       boolean selected = actionModeSelection.indexOfValue(id) > -1;
       holder.setSelected(selected);
+      enabled = !(dcContact.getId() == DcContact.DC_CONTACT_ID_SELF && itemMultiSelect);
     }
     holder.bind(glideRequests, id, dcContact, name, addr, label, itemMultiSelect, enabled);
     holder.setChecked(selectedContacts.contains(addr));

--- a/src/org/thoughtcrime/securesms/contacts/ContactSelectionListItem.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactSelectionListItem.java
@@ -13,7 +13,6 @@ import com.b44t.messenger.DcContact;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.AvatarImageView;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientModifiedListener;
@@ -62,7 +61,7 @@ public class ContactSelectionListItem extends LinearLayout implements RecipientM
   public void set(@NonNull GlideRequests glideRequests, int specialId, DcContact contact, String name, String number, String label, boolean multiSelect, boolean enabled) {
     this.glideRequests = glideRequests;
     this.specialId     = specialId;
-    this.name        = name;
+    this.name          = name;
     this.number        = number;
 
     if (specialId==DcContact.DC_CONTACT_ID_NEW_CONTACT || specialId==DcContact.DC_CONTACT_ID_NEW_GROUP || specialId==DcContact.DC_CONTACT_ID_NEW_VERIFIED_GROUP
@@ -79,6 +78,7 @@ public class ContactSelectionListItem extends LinearLayout implements RecipientM
     this.contactPhotoImage.setAvatar(glideRequests, recipient, false);
 
     setText(name, number, label, contact);
+    setEnabled(enabled);
 
     if (multiSelect) this.checkBox.setVisibility(View.VISIBLE);
     else             this.checkBox.setVisibility(View.GONE);


### PR DESCRIPTION
fixes #833
!!! This PR doesn't allow to remove yourself from any multiselect contact list !!!
- this means using the "add members" item in profile -> group tab will not allow the user anymore to leave a group
- leaving a group is restricted to the corresponding menu item "Leave group"