### PR TITLE
make input field 25% larger :)

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -71,7 +71,7 @@
     <style name="ComposeEditText" parent="@style/Signal.Text.Body">
         <item name="android:padding">2dp</item>
         <item name="android:background">@null</item>
-        <item name="android:maxLines">4</item>
+        <item name="android:maxLines">5</item>
         <item name="android:maxLength">64000</item>
         <item name="android:textColor">?conversation_item_outgoing_text_primary_color</item>
         <item name="android:capitalize">sentences</item>


### PR DESCRIPTION
replaces #970 

we cannot use more lines without getting problems or limited functionality on displays smaller 4 inches.

so using 6 or even 10 lines or resizable field (i think i would not really like that, too fiddly) would require some larger refactoring. maybe we can also use smaller padding atop and abottom of the field, however, also this is out of scope for a "fast fix today"