### PR TITLE
bring back Shortcut badge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     implementation 'com.journeyapps:zxing-android-embedded:3.4.0' // QR Code scanner
 
-    implementation "me.leolin:ShortcutBadger:1.1.16" // display messagecount on the home screen icon.
+    implementation "me.leolin:ShortcutBadger:1.1.22@aar" // display messagecount on the home screen icon.
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9' // used in the emoji selector for the tab selection.
     implementation 'com.github.chrisbanes:PhotoView:2.1.3' // does the zooming on photos / media
     implementation 'com.github.bumptech.glide:glide:4.5.0'

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -17,6 +17,7 @@ import org.thoughtcrime.securesms.geolocation.DcLocationManager;
 import org.thoughtcrime.securesms.jobmanager.JobManager;
 import org.thoughtcrime.securesms.notifications.MessageNotifierCompat;
 import org.thoughtcrime.securesms.util.AndroidSignalProtocolLogger;
+import org.thoughtcrime.securesms.util.BadgeUtil;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.SignalProtocolLoggerProvider;
@@ -98,6 +99,7 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
       @Override
       public void handleEvent(int eventId, Object data1, Object data2) {
         MessageNotifierCompat.updateNotification(((Long) data1).intValue(), ((Long) data2).intValue());
+        BadgeUtil.update(ApplicationContext.this, dcContext.getFreshMsgs().length);
       }
 
       @Override

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -29,6 +29,7 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
   public DcLocationManager      dcLocationManager;
   private JobManager            jobManager;
   private volatile boolean      isAppVisible;
+  private MessageNotifierCompat messageNotifier;
 
   public static ApplicationContext getInstance(Context context) {
     return (ApplicationContext)context.getApplicationContext();
@@ -53,7 +54,7 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
     initializeJobManager();
     initializeIncomingMessageNotifier();
     ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
-    MessageNotifierCompat.init(this);
+    messageNotifier = new MessageNotifierCompat(this);
 
     dcLocationManager = new DcLocationManager(this);
     try {

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -66,6 +66,7 @@ import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.BadgeUtil;
 import org.thoughtcrime.securesms.util.Debouncer;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask;
 import org.thoughtcrime.securesms.util.StickyHeaderDecoration;
@@ -77,6 +78,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+
+import me.leolin.shortcutbadger.ShortcutBadger;
 
 import static com.b44t.messenger.DcContact.DC_CONTACT_ID_SELF;
 import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
@@ -204,6 +207,7 @@ public class ConversationFragment extends Fragment
         super.onResume();
 
         dcContext.marknoticedChat((int) chatId);
+        BadgeUtil.update(this.getContext(), dcContext.getFreshMsgs().length);
         if (list.getAdapter() != null) {
             list.getAdapter().notifyDataSetChanged();
         }
@@ -611,6 +615,7 @@ public class ConversationFragment extends Fragment
             }
         }
         dcContext.markseenMsgs(ids);
+        BadgeUtil.update(this.getContext(), dcContext.getFreshMsgs().length);
     }
 
 

--- a/src/org/thoughtcrime/securesms/notifications/MarkAsNoticedAsyncTask.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkAsNoticedAsyncTask.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.notifications;
 import android.os.AsyncTask;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.util.BadgeUtil;
 
 /**
  * This marks the messages the user has acknowledged as noticed.
@@ -33,6 +34,7 @@ public  class MarkAsNoticedAsyncTask extends AsyncTask<Void, Void, Void> {
       else
         dcContext.marknoticedChat(dcContext.getMsg(id).getChatId());
     }
+    BadgeUtil.update(dcContext.context, dcContext.getFreshMsgs().length);
 
     return null;
   }

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -90,8 +90,7 @@ abstract class MessageNotifier {
         boolean isVisible = visibleChatId == chatId;
 
         if (!Prefs.isNotificationsEnabled(appContext) ||
-                Prefs.isChatMuted(appContext, chatId))
-        {
+                Prefs.isChatMuted(appContext, chatId)) {
             return;
         }
 

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifierCompat.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifierCompat.java
@@ -14,11 +14,7 @@ public class MessageNotifierCompat {
 
     private static MessageNotifier instance;
 
-    public static void init(Context context) {
-        if (instance != null) {
-            return;
-        }
-
+    public MessageNotifierCompat(Context context) {
         if (Build.VERSION.SDK_INT < 23) {
             instance = new MessageNotifierPreApi23(context);
         } else {
@@ -49,6 +45,5 @@ public class MessageNotifierCompat {
     public static void removeNotifications(int chatId) {
         Util.runOnAnyBackgroundThread(() -> instance.removeNotifications(chatId));
     }
-
 
 }

--- a/src/org/thoughtcrime/securesms/util/BadgeUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BadgeUtil.java
@@ -1,0 +1,19 @@
+package org.thoughtcrime.securesms.util;
+
+import android.content.Context;
+import android.util.Log;
+
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+public class BadgeUtil {
+    public static void update(Context context, int count) {
+        try {
+            if (count == 0) ShortcutBadger.removeCount(context);
+            else            ShortcutBadger.applyCount(context, count);
+        } catch (RuntimeException t) {
+            // NOTE :: I don't totally trust this thing, so I'm catching
+            // everything.
+            Log.w("MessageNotifier", t);
+        }
+    }
+}


### PR DESCRIPTION
fixes #962
* implements unread message counter for launcher icons of several launchers
* unread messages != new notification count

I think we should rethink the approach of having two different counters - one that reflects the notification state (representing new incoming messages since last app start) and unread messages (representing the number of not marked seen messages) since this might cause confusion.
I've implemented the launcher icon badge as unread message counter instead of a new notification counter since the former is a much more reliable information. For example, if the app gets killed by the system all notifications get automatically removed but there's no guaranteed hook (onDestroy() is not necessarily called)  to reset the badge counter. In this scenario there would be chances that the badge counter is inconsistent with the notification counter but also with the overall unread message counter. 
