### PR TITLE
change text body order back to latest text body on top

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -91,8 +91,8 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
       for (MessageBody body : messageBodies) {
         Recipient key = body.group == null ? body.sender : body.group;
         if(byGroup.containsKey(key)) {
-          List<MessageBody> messagebodies = byGroup.remove(key);
-          messagebodies.add(body);
+          LinkedList<MessageBody> messagebodies = (LinkedList<MessageBody>) byGroup.remove(key);
+          messagebodies.addFirst(body);
           byGroup.put(key, messagebodies);
         } else {
           byGroup.put(key, new LinkedList<>());

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -40,7 +40,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
 
   private static final String TAG = SingleRecipientNotificationBuilder.class.getSimpleName();
 
-  private final List<CharSequence> messageBodies = new LinkedList<>();
+  private final LinkedList<CharSequence> messageBodies = new LinkedList<>();
 
   private SlideDeck    slideDeck;
   private CharSequence contentTitle;
@@ -155,9 +155,9 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     }
 
     if (privacy.isDisplayMessage()) {
-      messageBodies.add(stringBuilder.append(messageBody == null ? "" : messageBody));
+      messageBodies.addFirst(stringBuilder.append(messageBody == null ? "" : messageBody));
     } else {
-      messageBodies.add(stringBuilder.append(context.getString(R.string.notify_new_message)));
+      messageBodies.addFirst(stringBuilder.append(context.getString(R.string.notify_new_message)));
     }
   }
 


### PR DESCRIPTION
In Delta Chat 0.510 the order of the text body of notifications starts from the oldest on top to the newest at the bottom. 
This results in invisible latest messages if there are many unread messages in one chat. The last incoming messages got cut off by Android's system components.  
With this PR I propose to change that behavior to the opposite - the newest message is on top, older ones are below.
I'll attach some images to show the state of the PR. 













