### PR TITLE
c-core-64bit experiment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ android {
         buildConfigField "String", "MAP_ACCESS_TOKEN", '"pk.eyJ1IjoiZGVsdGFjaGF0IiwiYSI6ImNqc3c1aWczMzBjejY0M28wZmU0a3cwMzMifQ.ZPTH9dFJaav06RAu4rTYHw"'
 
         ndk {
-            abiFilters "armeabi", "armeabi-v7a", "x86"
+            abiFilters "arm64-v8a", "armeabi-v7a", "x86_64", "x86"
         }
     }
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -579,6 +579,11 @@ LOCAL_CFLAGS += $(local_c_flags) -DPURIFY
 LOCAL_C_INCLUDES += $(local_c_includes)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE:= libcrypto
+
+ifeq ($(TARGET_ARCH_ABI),x86_64)
+    LOCAL_CFLAGS += -DOPENSSL_NO_ASM
+endif
+
 include $(BUILD_STATIC_LIBRARY)
 
 #include $(CLEAR_VARS)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_PLATFORM := android-14
-APP_ABI := armeabi armeabi-v7a x86
+APP_ABI := arm64-v8a armeabi-v7a x86_64 x86
 NDK_TOOLCHAIN_VERSION := 4.9
 APP_STL := gnustl_static
 


### PR DESCRIPTION
this pr tries to build the c-core at 64bit.

in general, this works, the c-core as such is 64 bit compatible, however, it is not clear if the used openssl library is.

while testing, however, opening the "new chat" activity leads to a crash "Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR)" which seems to be releated to openssl used by MessageDigest, see:                                     
https://stackoverflow.com/questions/17840521/android-fatal-signal-11-sigsegv-at-0x636f7d89-code-1-how-can-it-be-tracked <- **so it might be an android issue, not related to core-c**

might also be related to emulator-only, searching around, i found some hints to that.

further tests:

- check if the arm64 works, however, this would require a emulator executing arm, this should be possilble, but i did not manage to create one (startup took forever)

in general, all this might not be required as we'll probably switch to rust. but it would be good to know if the issue is relate to the core or to android/emulator.