### PR TITLE
Mailto still partly broken #1005

### DIFF
--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -32,6 +32,7 @@ import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
 
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -117,12 +118,12 @@ public class NewConversationActivity extends ContactSelectionActivity {
 
   private Map<String, String> getMailtoQueryMap(Uri uri) {
     Map<String, String> mailtoQueryMap = new HashMap<>();
-    String query =  uri.getQuery();
+    String query =  uri.getEncodedQuery();
     if (query != null && !query.isEmpty()) {
       String[] queryArray = query.split(QUERY_SEPARATOR);
       for(String queryEntry : queryArray) {
         String[] queryEntryArray = queryEntry.split(KEY_VALUE_SEPARATOR);
-        mailtoQueryMap.put(queryEntryArray[0], queryEntryArray[1]);
+        mailtoQueryMap.put(queryEntryArray[0], URLDecoder.decode(queryEntryArray[1]));
       }
     }
     return mailtoQueryMap;


### PR DESCRIPTION
Fixed by performing the initial mapping (body=content / subject=content) on the encoded string loaded from the URI and decoding the already mapped values afterwards.

Also verified against https://github.com/deltachat/deltachat-android/issues/937 that all cases provided within that issue are still working.