### PR TITLE
Changed Notification level for Android8+

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -158,7 +158,7 @@ abstract class AbstractNotificationBuilder extends NotificationCompat.Builder {
         // we cannot change the settings, however, this is handled by using different values for chId
         if(!channelExists) {
           NotificationChannel channel = new NotificationChannel(chId,
-                  "New messages", NotificationManager.IMPORTANCE_DEFAULT);
+                  "New messages", NotificationManager.IMPORTANCE_HIGH);
           channel.setDescription("Informs about new messages.");
 
           if (!ledColor.equals("none")) {


### PR DESCRIPTION
Enable heads-up notification and fix notification delay on android 9 (if device is muted)