### PR TITLE
remove group icon from chatlist

### DIFF
--- a/res/layout/conversation_list_item_view.xml
+++ b/res/layout/conversation_list_item_view.xml
@@ -38,36 +38,18 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content">
 
-            <LinearLayout
-                android:orientation="horizontal"
-                android:layout_marginBottom="2dp"
+            <org.thoughtcrime.securesms.components.FromTextView
+                android:id="@+id/from_text"
+                style="@style/Signal.Text.Body"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
-
-                <ImageView
-                    android:id="@+id/group_indicator"
-                    android:layout_width="16dp"
-                    android:layout_height="16dp"
-                    android:layout_gravity="center_vertical"
-                    android:src="@drawable/ic_group_white_24dp"
-                    android:visibility="gone"
-                    android:layout_marginTop="1dp"
-                    android:layout_marginRight="5dp"
-                    android:layout_marginEnd="5dp" />
-
-                <org.thoughtcrime.securesms.components.FromTextView
-                    android:id="@+id/from_text"
-                    style="@style/Signal.Text.Body"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:drawablePadding="5dp"
-                    android:ellipsize="end"
-                    android:fontFamily="sans-serif-medium"
-                    android:maxLines="1"
-                    android:textColor="?attr/conversation_list_item_contact_color"
-                    tools:text="Jules Bonnot" />
-
-            </LinearLayout>
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="2dp"
+                android:drawablePadding="5dp"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:maxLines="1"
+                android:textColor="?attr/conversation_list_item_contact_color"
+                tools:text="Jules Bonnot" />
 
             <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                 android:id="@+id/subject"

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -109,7 +109,6 @@
     <attr name="menu_lock_icon" format="reference" />
     <attr name="menu_lock_icon_small" format="reference" />
     <attr name="menu_trash_icon" format="reference" />
-    <attr name="menu_group_icon" format="reference" />
     <attr name="menu_map_icon" format="reference" />
     <attr name="menu_accept_icon" format="reference" />
     <attr name="menu_copy_icon" format="reference" />

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -184,7 +184,6 @@
         <item name="import_export_item_card_background">@drawable/clickable_card_light</item>
 
         <item name="menu_new_conversation_icon">@drawable/ic_add_white_24dp</item>
-        <item name="menu_group_icon">@drawable/ic_group_white_24dp</item>
         <item name="menu_map_icon">@android:drawable/ic_dialog_map</item>
         <item name="menu_search_icon">@drawable/ic_search_white_24dp</item>
         <item name="menu_popup_expand">@drawable/ic_launch_white_24dp</item>
@@ -331,7 +330,6 @@
         <item name="quick_mic_icon">@drawable/ic_mic_white_24dp</item>
 
         <item name="menu_new_conversation_icon">@drawable/ic_add_white_24dp</item>
-        <item name="menu_group_icon">@drawable/ic_group_white_24dp</item>
         <item name="menu_map_icon">@android:drawable/ic_dialog_map</item>
         <item name="menu_search_icon">@drawable/ic_search_white_24dp</item>
         <item name="menu_popup_expand">@drawable/ic_launch_white_24dp</item>

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -80,7 +80,6 @@ public class ConversationListItem extends RelativeLayout
   private TextView           archivedView;
   private DeliveryStatusView deliveryStatusIndicator;
   private ImageView          unreadIndicator;
-  private ImageView          groupIndicator;
 
   private int             unreadCount;
   private AvatarImageView contactPhotoImage;
@@ -103,7 +102,6 @@ public class ConversationListItem extends RelativeLayout
     this.contactPhotoImage       = findViewById(R.id.contact_photo_image);
     this.archivedView            = findViewById(R.id.archived);
     this.unreadIndicator         = findViewById(R.id.unread_indicator);
-    this.groupIndicator          = findViewById(R.id.group_indicator);
 
     ViewUtil.setTextViewGravityStart(this.fromView, getContext());
     ViewUtil.setTextViewGravityStart(this.subjectView, getContext());
@@ -178,11 +176,6 @@ public class ConversationListItem extends RelativeLayout
         0,
         thread.isVerified()? R.drawable.ic_verified : 0,
         0);
-
-    boolean isGroup = recipient.isGroupRecipient();
-    groupIndicator.setVisibility(isGroup ? VISIBLE : GONE);
-    int color = ResUtil.getColor(getContext(), R.attr.conversation_list_item_contact_color);
-    groupIndicator.setColorFilter(color);
   }
 
   public void bind(@NonNull  DcContact     contact,
@@ -202,7 +195,6 @@ public class ConversationListItem extends RelativeLayout
     archivedView.setVisibility(GONE);
     unreadIndicator.setVisibility(GONE);
     deliveryStatusIndicator.setNone();
-    groupIndicator.setVisibility(GONE);
 
     setBatchState(false);
     setBgColor();
@@ -235,7 +227,6 @@ public class ConversationListItem extends RelativeLayout
     archivedView.setVisibility(GONE);
     unreadIndicator.setVisibility(GONE);
     deliveryStatusIndicator.setNone();
-    groupIndicator.setVisibility(GONE);
 
     setBatchState(false);
     setBgColor();


### PR DESCRIPTION
the group-icon (the two small ppl) was not really used consistently inside the app - it was shown the in chatlist but it was not shown in the group title and on other places.

same on desktop, where it is additionally shown too small compared to the font.

ios did never show it anywhere.

@Jikstra and me came to the conclusion that it is better to not use a group icon at all:
- it is pretty clear to the user, what is a group and what not
- less noise on the screen
- also, many users use an emoticon as the fist character in a group name, this now looks better
- one thing less to explain
- the other icons stand out more, eg. the verification-icon
- it is some work to maintain a group icon for all situations, this can be better spent for other things
- also, neither telegram, nor signal, nor whatsapp use a group icon

