### PR TITLE
add a switch to set the bcc_self option

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -441,6 +441,7 @@
     <string name="pref_watch_inbox_folder">Watch Inbox folder</string>
     <string name="pref_watch_sent_folder">Watch Sent folder</string>
     <string name="pref_watch_mvbox_folder">Watch DeltaChat folder</string>
+    <string name="pref_send_copy_to_self">Send copy to self</string>
     <string name="pref_auto_folder_moves">Automatic moves to DeltaChat folder</string>
     <string name="pref_auto_folder_moves_explain">Chat conversations are moved to avoid cluttering the Inbox folder</string>
     <string name="pref_email_interaction_title">Email interaction</string>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -34,6 +34,11 @@
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="true"
+            android:key="pref_bcc_self"
+            android:title="@string/pref_send_copy_to_self"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="true"
             android:key="pref_mvbox_move"
             android:title="@string/pref_auto_folder_moves"
             android:summary="@string/pref_auto_folder_moves_explain"/>

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -27,6 +27,7 @@ public class DcHelper {
     public static final String CONFIG_SENTBOX_WATCH = "sentbox_watch";
     public static final String CONFIG_MVBOX_WATCH = "mvbox_watch";
     public static final String CONFIG_MVBOX_MOVE = "mvbox_move";
+    public static final String CONFIG_BCC_SELF = "bcc_self";
     public static final String CONFIG_SHOW_EMAILS = "show_emails";
 
     public static ApplicationDcContext getContext(Context context) {

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -28,6 +28,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.views.ProgressDialog;
 
 import static android.app.Activity.RESULT_OK;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_BCC_SELF;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_E2EE_ENABLED;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_INBOX_WATCH;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_MVBOX_MOVE;
@@ -47,6 +48,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   CheckBoxPreference inboxWatchCheckbox;
   CheckBoxPreference sentboxWatchCheckbox;
   CheckBoxPreference mvboxWatchCheckbox;
+  CheckBoxPreference bccSelfCheckbox;
   CheckBoxPreference mvboxMoveCheckbox;
 
   @Override
@@ -73,6 +75,13 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     mvboxWatchCheckbox.setOnPreferenceChangeListener((preference, newValue) ->
       handleImapCheck(preference, newValue, CONFIG_MVBOX_WATCH)
     );
+
+    bccSelfCheckbox = (CheckBoxPreference) this.findPreference("pref_bcc_self");
+    bccSelfCheckbox.setOnPreferenceChangeListener((preference, newValue) -> {
+      boolean enabled = (Boolean) newValue;
+      dcContext.setConfigInt(CONFIG_BCC_SELF, enabled? 1 : 0);
+      return true;
+    });
 
     mvboxMoveCheckbox = (CheckBoxPreference) this.findPreference("pref_mvbox_move");
     mvboxMoveCheckbox.setOnPreferenceChangeListener((preference, newValue) -> {
@@ -127,6 +136,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     inboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_INBOX_WATCH));
     sentboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_SENTBOX_WATCH));
     mvboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_MVBOX_WATCH));
+    bccSelfCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_BCC_SELF));
     mvboxMoveCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_MVBOX_MOVE));
   }
 


### PR DESCRIPTION
this pr adds an option to the "Advances settings" dialog that allows to set the bcc_self option in the core.

this allows users to _not_ send messages to theirself which may be useful in some situations (eg. safe traffic, avoid double notifications)

screenshot:

<img src=https://user-images.githubusercontent.com/9800740/66611321-660dba00-ebbe-11e9-9759-e8243087f717.png width=320>
