### PR TITLE
upgrade targetSdkVersion

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,12 +15,15 @@
     <uses-feature android:name="android.hardware.portrait" android:required="false"/>
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 
+    <!-- dangerous permissions - we need to as the user with a PermissionsRequest -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <!-- normal permissions - adding them here is enough -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -32,6 +35,7 @@
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
     <uses-permission android:name="android.permission.RAISED_THREAD_PRIORITY" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application android:name=".ApplicationContext"
                  android:icon="@mipmap/ic_launcher"

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
 
 android {
     flavorDimensions "none"
-    compileSdkVersion 27
+    compileSdkVersion 28
     useLibrary 'org.apache.http.legacy'
 
     dexOptions {
@@ -102,7 +102,7 @@ android {
         multiDexEnabled true
 
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
 
         vectorDrawables.useSupportLibrary = true
 

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -254,7 +254,7 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
   @Override
   protected boolean drawChild(@NonNull Canvas canvas, @NonNull View child, long drawingTime) {
     boolean result;
-    final int save = canvas.save(Canvas.CLIP_SAVE_FLAG);
+    final int save = canvas.save();
 
     canvas.getClipBounds(drawChildrenRect);
     if (child == coverView) {

--- a/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
+++ b/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
@@ -56,7 +56,15 @@ public class KeepAliveService extends Service {
         // there's nothing more to do here as all initialisation stuff is already done in
         // ApplicationLoader.onCreate() which is called before this broadcast is sended.
         s_this = this;
-        setSelfAsForeground();
+
+        // set self as foreground
+        try {
+            stopForeground(true);
+            startForeground(FG_NOTIFICATION_ID, createNotification());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -76,11 +84,6 @@ public class KeepAliveService extends Service {
     public void onDestroy() {
         Log.i("DeltaChat", "*** KeepAliveService.onDestroy()");
         // the service will be restarted due to START_STICKY automatically, there's nothing more to do.
-    }
-
-    private void setSelfAsForeground() {
-        stopForeground(true);
-        startForeground(FG_NOTIFICATION_ID, createNotification());
     }
 
     static public KeepAliveService getInstance()


### PR DESCRIPTION
this pr targets issues related to android9 and targetSdk29

- [x] make the app compile again
- [x] check https://developer.android.com/distribute/best-practices/develop/target-sdk.html#prepie wrt notification-issue in #1008

with chance, both issues are done. i could reproduce the problem in the emulator, startForeground() throws an exception as the corresponding permission was not granted using android9. this is fixed by this pr.
on android8, probably, the foreground was not started at all, not sure though.

closes #1064
closes #1008