### PR TITLE
apply a hack that removes the padding from the settings screens

### DIFF
--- a/res/values-sw360dp-v13/values-preferences.xml
+++ b/res/values-sw360dp-v13/values-preferences.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <bool name="config_materialPreferenceIconSpaceReserved" tools:ignore="MissingDefaultResource,PrivateResource">false</bool>
+    <dimen name="preference_category_padding_start" tools:ignore="MissingDefaultResource,PrivateResource">0dp</dimen>
+</resources>


### PR DESCRIPTION
found at https://stackoverflow.com/questions/51518758/preferencefragmentcompat-has-padding-on-preferencecategory-that-i-cant-get-rid/52960668#52960668