### PR TITLE
[wip] revert utf 8 fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,8 @@ android {
     }
 
     defaultConfig {
-        versionCode 554
-        versionName "0.930.0"
+        versionCode 555
+        versionName "0.930.1"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -29,16 +29,8 @@
 
 static dc_msg_t* get_dc_msg(JNIEnv *env, jobject obj);
 
-
-// passing a NULL-jstring results in a NULL-ptr - this is needed by functions using eg. NULL for "delete"
 #define CHAR_REF(a) \
-	const char* a##Ptr = char_ref__(env, (a));
-static const char* char_ref__(JNIEnv* env, jstring a) {
-    if (a==NULL) {
-        return NULL;
-    }
-    return (*env)->GetStringUTFChars(env, a, 0);
-}
+	const char* a##Ptr = (a)? (*env)->GetStringUTFChars(env, (a), 0) : NULL; // passing a NULL-jstring results in a NULL-ptr - this is needed by functions using eg. NULL for "delete"
 
 #define CHAR_UNREF(a) \
 	if(a) { (*env)->ReleaseStringUTFChars(env, (a), a##Ptr); }

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -33,40 +33,15 @@ static dc_msg_t* get_dc_msg(JNIEnv *env, jobject obj);
 // passing a NULL-jstring results in a NULL-ptr - this is needed by functions using eg. NULL for "delete"
 #define CHAR_REF(a) \
 	const char* a##Ptr = char_ref__(env, (a));
-static char* char_ref__(JNIEnv* env, jstring a) {
+static const char* char_ref__(JNIEnv* env, jstring a) {
     if (a==NULL) {
         return NULL;
     }
-
-    /* we do not use the JNI functions GetStringUTFChars()/ReleaseStringUTFChars()
-    as they do not work on some older systems for code points >0xffff, eg. emojos.
-    as a workaround, we're calling back to java-land's String.getBytes() which works as expected */
-    static jclass    s_strCls    = NULL;
-    static jmethodID s_getBytes  = NULL;
-    static jclass    s_strEncode = NULL;
-    if (s_getBytes==NULL) {
-        s_strCls    = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/String"));
-        s_getBytes  = (*env)->GetMethodID(env, s_strCls, "getBytes", "(Ljava/lang/String;)[B");
-        s_strEncode = (*env)->NewGlobalRef(env, (*env)->NewStringUTF(env, "UTF-8"));
-    }
-
-    const jbyteArray stringJbytes = (jbyteArray)(*env)->CallObjectMethod(env, a, s_getBytes, s_strEncode);
-    const jsize length = (*env)->GetArrayLength(env, stringJbytes);
-    const jbyte* pBytes = (*env)->GetByteArrayElements(env, stringJbytes, NULL);
-    if (pBytes==NULL) {
-        return NULL;
-    }
-
-    const char* cstr = strndup(pBytes, length);
-
-    (*env)->ReleaseByteArrayElements(env, stringJbytes, pBytes, JNI_ABORT);
-    (*env)->DeleteLocalRef(env, stringJbytes);
-
-    return cstr;
+    return (*env)->GetStringUTFChars(env, a, 0);
 }
 
 #define CHAR_UNREF(a) \
-	free(a##Ptr);
+	if(a) { (*env)->ReleaseStringUTFChars(env, (a), a##Ptr); }
 
 #define JSTRING_NEW(a) jstring_new__(env, (a))
 static jstring jstring_new__(JNIEnv* env, const char* a)
@@ -82,7 +57,7 @@ static jstring jstring_new__(JNIEnv* env, const char* a)
 	static jclass    s_strCls    = NULL;
 	static jmethodID s_strCtor   = NULL;
 	static jclass    s_strEncode = NULL;
-	if (s_strCtor==NULL) {
+	if (s_strCls==NULL) {
 		s_strCls    = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "java/lang/String"));
 		s_strCtor   = (*env)->GetMethodID(env, s_strCls, "<init>", "([BLjava/lang/String;)V");
 		s_strEncode = (*env)->NewGlobalRef(env, (*env)->NewStringUTF(env, "UTF-8"));


### PR DESCRIPTION
the changes from #1072 seems to lead to crashes on android 64bit, not sure if it is related to strndup, at least this function is suspicious :)

cc @link2xt