### PR TITLE
add missing includes to jni

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -24,6 +24,8 @@
 
 
 #include <jni.h>
+#include <stdlib.h>
+#include <string.h>
 #include "deltachat-core-rust/deltachat-ffi/deltachat.h"
 
 


### PR DESCRIPTION
add missing includes to jni, without them, args default to int which fails on 64bit. for whatever reason, the android compiler does not throw a warning.

a testing apk is at https://testrun.org/deltachat-gplay-release-0.930.2.apk

good catch, @link2xt :)