### PR TITLE
adapt to ndk r20b

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,8 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.thoughtcrime.securesms">
 
-    <uses-sdk tools:overrideLibrary="com.amulyakhare.textdrawable,com.astuetz.pagerslidingtabstrip,pl.tajchert.waitingdots,com.h6ah4i.android.multiselectlistpreferencecompat,android.support.v13,com.davemorrissey.labs.subscaleview,com.tomergoldst.tooltips,com.klinker.android.send_message,com.takisoft.colorpicker,android.support.v14.preference"/>
-
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
     <uses-feature android:name="android.hardware.location" android:required="false"/>

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ android {
         applicationId "com.b44t.messenger"
         multiDexEnabled true
 
-        minSdkVersion 14
+        minSdkVersion 21 // when changing minSdkVersion here, also adapt AndroidManifest.xml!
         targetSdkVersion 28
 
         vectorDrawables.useSupportLibrary = true

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ android {
         applicationId "com.b44t.messenger"
         multiDexEnabled true
 
-        minSdkVersion 21 // when changing minSdkVersion here, also adapt AndroidManifest.xml!
+        minSdkVersion 18
         targetSdkVersion 28
 
         vectorDrawables.useSupportLibrary = true

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -20,13 +20,11 @@ include $(CLEAR_VARS)
 LOCAL_MODULE     := native-utils
 
 LOCAL_C_INCLUDES := $(JNI_DIR)/utils/
-LOCAL_LDLIBS 	:= -ljnigraphics -llog -lz -latomic
+LOCAL_LDLIBS 	:= -ljnigraphics -llog -lz
 LOCAL_STATIC_LIBRARIES :=  deltachat-core
-# if you get "undefined reference" errors, the reason for this may be the _order_! Eg. libiconv as the first library does not work!
-# "breakpad" was placed after "crypto", NativeLoader.cpp after dc_wrapper.c
 
 LOCAL_CFLAGS 	:= -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Os -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
-LOCAL_CFLAGS 	+= -Drestrict='' -D__EMX__ -DOPUS_BUILD -DFIXED_POINT -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -fno-math-errno -std=c99
+LOCAL_CFLAGS 	+= -Drestrict='' -D__EMX__ -DFIXED_POINT -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -fno-math-errno
 LOCAL_CFLAGS 	+= -DANDROID_NDK -DDISABLE_IMPORTGL -fno-strict-aliasing -DAVOID_TABLES -DANDROID_TILE_BASED_DECODE -DANDROID_ARMV6_IDCT -ffast-math -D__STDC_CONSTANT_MACROS
 
 LOCAL_SRC_FILES := \

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_PLATFORM := android-21
+APP_PLATFORM := android-18
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_STL := c++_static
 

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,4 @@
-APP_PLATFORM := android-14
+APP_PLATFORM := android-21
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
-NDK_TOOLCHAIN_VERSION := 4.9
-APP_STL := gnustl_static
+APP_STL := c++_static
 

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -59,7 +59,7 @@ static char* char_ref__(JNIEnv* env, jstring a) {
         return NULL;
     }
 
-    char* cstr = strndup(pBytes, length);
+    char* cstr = strndup((const char*)pBytes, length);
 
     (*env)->ReleaseByteArrayElements(env, stringJbytes, pBytes, JNI_ABORT);
     (*env)->DeleteLocalRef(env, stringJbytes);
@@ -92,7 +92,7 @@ static jstring jstring_new__(JNIEnv* env, const char* a)
 
 	int a_bytes = strlen(a);
 	jbyteArray array = (*env)->NewByteArray(env, a_bytes);
-		(*env)->SetByteArrayRegion(env, array, 0, a_bytes, a);
+		(*env)->SetByteArrayRegion(env, array, 0, a_bytes, (const jbyte*)a);
 		jstring ret = (jstring) (*env)->NewObject(env, s_strCls, s_strCtor, array, s_strEncode);
 	(*env)->DeleteLocalRef(env, array); /* we have to delete the reference as it is not returned to Java, AFAIK */
 

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -1,38 +1,42 @@
+#!/bin/sh
+set -e
 echo "starting time: `date`"
+
 cd jni/deltachat-core-rust
 
 # to setup the toolchains (from https://medium.com/visly/rust-on-android-19f34a2fb43 )
 # run the following in `jni/deltachat-core-rust`:
 # $ rustup target add armv7-linux-androideabi aarch64-linux-android  i686-linux-android x86_64-linux-android
-#
-# then:
-# $ mkdir ~/.NDK
-# $ $ANDROID_NDK/build/tools/make_standalone_toolchain.py --api 14 --arch arm --install-dir ~/.NDK/arm
-# $ $ANDROID_NDK/build/tools/make_standalone_toolchain.py --api 21 --arch arm64 --install-dir ~/.NDK/arm64
-# $ $ANDROID_NDK/build/tools/make_standalone_toolchain.py --api 14 --arch x86 --install-dir ~/.NDK/x86
-# $ $ANDROID_NDK/build/tools/make_standalone_toolchain.py --api 21 --arch x86_64 --install-dir ~/.NDK/x86_64
-# (--api should be aligned with APP_PLATFORM from Application.mk and with minSdkVersion)
-# this installs toolchains in `~/.NDK`
+# after that, add PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin to your $PATH
+# and add the correct clang-linkers to `~/.cargo/config`:
+# ```
+# [target.armv7-linux-androideabi]
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/armv7a-linux-androideabi21-clang"
+# [target.aarch64-linux-android]
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/aarch64-linux-android21-clang"
+# [target.i686-linux-android]
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/i686-linux-android21-clang"
+# [target.x86_64-linux-android]
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/x86_64-linux-android21-clang"
+# ```
 # then, the following should work:
 
+export CFLAGS=-D__ANDROID_API__=21
+
 echo "-- cross compiling to armv7-linux-androideabi (arm) --"
-export RUSTFLAGS="-C linker=$HOME/.NDK/arm/bin/clang";
-export PATH=~/.NDK/arm/bin:$PATH;
+TARGET_CC=armv7a-linux-androideabi21-clang \
 cargo build --release --target armv7-linux-androideabi -p deltachat_ffi
 
 echo "-- cross compiling to aarch64-linux-android (arm64) --"
-export RUSTFLAGS="-C linker=$HOME/.NDK/arm64/bin/clang";
-export PATH=~/.NDK/arm64/bin:$PATH;
+TARGET_CC=aarch64-linux-android21-clang \
 cargo build --release --target aarch64-linux-android -p deltachat_ffi
 
 echo "-- cross compiling to i686-linux-android (x86) --"
-export RUSTFLAGS="-C linker=$HOME/.NDK/x86/bin/clang";
-export PATH=~/.NDK/x86/bin:$PATH;
+TARGET_CC=i686-linux-android21-clang \
 cargo build --release --target i686-linux-android -p deltachat_ffi
 
 echo "-- cross compiling to x86_64-linux-android (x86_64) --"
-export RUSTFLAGS="-C linker=$HOME/.NDK/x86_64/bin/clang";
-export PATH=~/.NDK/x86_64/bin:$PATH;
+TARGET_CC=x86_64-linux-android21-clang \
 cargo build --release --target x86_64-linux-android -p deltachat_ffi
 
 echo -- copy generated .a files --

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -11,31 +11,33 @@ cd jni/deltachat-core-rust
 # and add the correct clang-linkers to `~/.cargo/config`:
 # ```
 # [target.armv7-linux-androideabi]
-# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/armv7a-linux-androideabi21-clang"
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/armv7a-linux-androideabi18-clang"
 # [target.aarch64-linux-android]
 # linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/aarch64-linux-android21-clang"
 # [target.i686-linux-android]
-# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/i686-linux-android21-clang"
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/i686-linux-android18-clang"
 # [target.x86_64-linux-android]
 # linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/x86_64-linux-android21-clang"
 # ```
 # then, the following should work:
 
-export CFLAGS=-D__ANDROID_API__=21
-
 echo "-- cross compiling to armv7-linux-androideabi (arm) --"
-TARGET_CC=armv7a-linux-androideabi21-clang \
+export CFLAGS=-D__ANDROID_API__=18
+TARGET_CC=armv7a-linux-androideabi18-clang \
 cargo build --release --target armv7-linux-androideabi -p deltachat_ffi
 
 echo "-- cross compiling to aarch64-linux-android (arm64) --"
+export CFLAGS=-D__ANDROID_API__=21
 TARGET_CC=aarch64-linux-android21-clang \
 cargo build --release --target aarch64-linux-android -p deltachat_ffi
 
 echo "-- cross compiling to i686-linux-android (x86) --"
-TARGET_CC=i686-linux-android21-clang \
+export CFLAGS=-D__ANDROID_API__=18
+TARGET_CC=i686-linux-android18-clang \
 cargo build --release --target i686-linux-android -p deltachat_ffi
 
 echo "-- cross compiling to x86_64-linux-android (x86_64) --"
+export CFLAGS=-D__ANDROID_API__=21
 TARGET_CC=x86_64-linux-android21-clang \
 cargo build --release --target x86_64-linux-android -p deltachat_ffi
 


### PR DESCRIPTION
because of issues as https://github.com/deltachat/deltachat-android/issues/1116 , but also to not use too outdated libraries, we have to change the used ndk from the used r14b or so to the most recent r20b.

this requires some adaptions:

- r20b does support a minimal sdk16 only, so we can no longer got for minSdkVersion=14
- 64bit supports minSdkVersion=21, not sure if that can be mixed
- there is no longer a script to install a toolchain, instead r20b comes with some predefined toolchains
- r20b seems to look in AndroidManifest.xml for minSdkVersion, not sure, however.
- clang is used as linker, c++_static as standard library

so, currently, we're using minSdkVersion=21 everywhere - which makes things compiling and working. this would drop support for android4 (ice cream sandwich, jelly bean, kitkat) completely, according to https://developer.android.com/about/dashboards/ , in sum 10.4% of android-devices :/

but maybe we can bring back support for kitkat (6.9%) and jelly bean (3.2%) - the ndk supports compiling down to sdk16 =  jelly bean. however, due to the needed 64 bit support, this may become tricky. not sure if and how this is doable.

EDIT: support for kitkat 4.4 and partly jelly bean 4.3 is back :). 
also, tested: we could support jelly bean fully by lowering sdk from 18 to 16, however, [the rust "ring" crate does not support that currenty](https://github.com/briansmith/ring/blob/2a3230cb6346a1249354a07395246a28b4904c5b/BUILDING.md#supported-toolchains).

**in summary, this pr changes the supported user base from 99.7% to 96.7%.** the advantage is having a supported and maintained ndk base and better support for libs (eg. ring did not work out of the box on ndk14). if we manage to target sdk16 again, we can again reach 99.4%. getting higher is only doable by using outdated libs.

closes #1116