### PR TITLE
add device msgs

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -674,6 +674,12 @@ JNIEXPORT jboolean Java_com_b44t_messenger_DcContext_wasDeviceMsgEverAdded(JNIEn
 }
 
 
+JNIEXPORT void Java_com_b44t_messenger_DcContext_updateDeviceChats(JNIEnv *env, jobject obj)
+{
+	dc_update_device_chats(get_dc_context(env, obj));
+}
+
+
 /* DcContext - handle config */
 
 JNIEXPORT void Java_com_b44t_messenger_DcContext_setConfig(JNIEnv *env, jobject obj, jstring key, jstring value /*may be NULL*/)

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -158,6 +158,7 @@ public class DcContext {
     public native int          sendTextMsg          (int chat_id, String text);
     public native int          addDeviceMsg         (String label, DcMsg msg);
     public native boolean      wasDeviceMsgEverAdded(String label);
+    public native void         updateDeviceChats    ();
     public @NonNull DcLot      checkQr              (String qr) { return new DcLot(checkQrCPtr(qr)); }
     public native String       getSecurejoinQr      (int chat_id);
     public native int          joinSecurejoin       (String qr);

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -34,6 +34,7 @@ import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 
 import org.thoughtcrime.securesms.components.SearchToolbar;
+import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.map.MapActivity;
 import org.thoughtcrime.securesms.qr.QrCodeHandler;
 import org.thoughtcrime.securesms.search.SearchFragment;
@@ -78,6 +79,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
 
   @Override
   protected void onCreate(Bundle icicle, boolean ready) {
+    DcHelper.getContext(this).updateDeviceChats();
     setContentView(R.layout.conversation_list_activity);
 
     Toolbar toolbar = findViewById(R.id.toolbar);

--- a/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -61,11 +61,11 @@ public class DozeReminder extends Reminder {
       return false;
     }
 
-    // if the chatlist is empty, just after installation,
+    // if the chatlist only contains device-talk and self-talk, just after installation,
     // do not bother with battery, let the user check out other things first.
     try {
       int numberOfChats = DcHelper.getContext(context).getChatlist(0, null, 0).getCnt();
-      if (numberOfChats == 0) {
+      if (numberOfChats <= 2) {
         return false;
       }
     }

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -178,6 +178,12 @@ abstract class MessageNotifier {
             lastAudibleNotification = System.currentTimeMillis();
         }
 
+        if (dcContext.getChat(chatId).isDeviceTalk()) {
+            // currently, we just never notify on device chat.
+            // esp. on first start, this is annoying.
+            return;
+        }
+
         synchronized (lock) {
             addMessageToNotificationState(dcContext, chatId, messageId);
             if (notificationState.hasMultipleChats()) {


### PR DESCRIPTION
todo:
- [x] add initial messages to the correct place
- [x] for some reason, the first added message is shown in the chatlist summary, it should be the second imho
- [x] the battery-dialog should maybe appear if the first message is sent or so
- [x] there should be no system-notification just when the app is started
- [x] maybe add saved-mesages-chat on new installation

once things are settled on android, it should be pretty easy to port them to ios and desktop

later on, we can add also move the the old-version-thingie as well as the battery-question to the device-msg.

needs https://github.com/deltachat/deltachat-core-rust/pull/854 and https://github.com/deltachat/deltachat-core-rust/pull/856 and https://github.com/deltachat/deltachat-core-rust/pull/939 to be merged first.