### PR TITLE
fix qr-code scanning on 64bit andoird

### DIFF
--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -158,7 +158,6 @@ public class DcContext {
     public native int          sendTextMsg          (int chat_id, String text);
     public native int          addDeviceMsg         (String label, DcMsg msg);
     public native boolean      wasDeviceMsgEverAdded(String label);
-    public native int          checkQrCPtr          (String qr);
     public @NonNull DcLot      checkQr              (String qr) { return new DcLot(checkQrCPtr(qr)); }
     public native String       getSecurejoinQr      (int chat_id);
     public native int          joinSecurejoin       (String qr);
@@ -192,4 +191,5 @@ public class DcContext {
     private native long getDraftCPtr    (int id);
     private native long getContactCPtr   (int id);
     private native long getLocationsCPtr (int chat_id, int contact_id, long timestamp_start, long timestamp_end);
+    private native long checkQrCPtr      (String qr);
 }


### PR DESCRIPTION
the issue was that the java-part of the wrapper function was declared as `int` where it should be `long`.

moreover, this pr moves `checkQrCPtr()` to the private part together with the other CPtr functions.

closes #1128