### PR TITLE
remove unused SET_WALLPAPER permission

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,7 +30,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.SET_WALLPAPER" />
     <uses-permission android:name="android.permission.RAISED_THREAD_PRIORITY" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />


### PR DESCRIPTION
this pr removes the probably unneeded [SET_WALLPAPER](https://developer.android.com/reference/android/Manifest.permission.html#SET_WALLPAPER) permission that seems to be needed for [setWallpaper()](https://developer.android.com/reference/android/content/ContextWrapper#setWallpaper(android.graphics.Bitmap)) only, which, however, is not used by delta currently - and there are also no plans to do so - esp. as the mentioned function is already deprectated ... ;)

cmp https://github.com/deltachat/deltachat-pages/pull/217