### PR TITLE
fix avatar extension

### DIFF
--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -74,7 +74,7 @@ public class AvatarHelper {
     public static File getSelfAvatarFile(@NonNull Context context, @NonNull String address) {
         File avatarDirectory = new File(context.getFilesDir(), AVATAR_DIRECTORY);
         avatarDirectory.mkdirs();
-        return new File(avatarDirectory, address);
+        return new File(avatarDirectory, address+".jpg");
     }
 
     public static void setSelfAvatar(@NonNull Context context, @NonNull String address, @Nullable byte[] data) throws IOException {

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.annimon.stream.Stream;
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
@@ -19,19 +18,15 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.LinkedList;
-import java.util.List;
 
 public class AvatarHelper {
 
-    public static final String GROUP_TEMPLATE = "group_chat_avatar_%s_%o.jpg";
-
-    public static final String CONTACT_TEMPLATE = "contact_avatar_%s_%o.jpg";
+    private static final String GROUP_TEMPLATE = "group_chat_avatar_%s_%o.jpg";
 
     private static final String AVATAR_DIRECTORY = "avatars";
 
     @SuppressLint("DefaultLocale")
-    public static String getFilePathForGroupAvatar(Context context, int chatId, long timestamp) {
+    private static String getFilePathForGroupAvatar(Context context, int chatId, long timestamp) {
         return getAvatarDirectoryPath(context) + String.format(GROUP_TEMPLATE, chatId, timestamp);
     }
 
@@ -66,56 +61,9 @@ public class AvatarHelper {
         }
     }
 
-
-    @SuppressLint("DefaultLocale")
-    public static String getFilePathForContactAvatar(Context context, int contactId, long timestamp) {
-        return getAvatarDirectoryPath(context) + String.format(CONTACT_TEMPLATE, contactId, timestamp);
-    }
-
-    public static void setContactAvatar(Context context, int contactId, Bitmap bitmap) {
-        if (bitmap == null) {
-            return;
-        }
-        DcContext dcContext = DcHelper.getContext(context);
-        String avatarPath = dcContext.getContact(contactId).getProfileImage();
-        if (avatarPath != null && !avatarPath.isEmpty()) {
-            File oldImage = new File(avatarPath);
-            if (oldImage.exists()) {
-                //noinspection ResultOfMethodCallIgnored
-                oldImage.delete();
-            }
-        }
-        avatarPath = getFilePathForContactAvatar(context, contactId, System.currentTimeMillis());
-        FileOutputStream outStream;
-        try {
-            outStream = new FileOutputStream(avatarPath);
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream);
-            //dcContext.setContactProfileImage(contactId, avatarPath);
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        }
-    }
-
     public static InputStream getInputStreamFor(@NonNull Context context, @NonNull String address)
             throws IOException {
         return new FileInputStream(getSelfAvatarFile(context, address));
-    }
-
-    public static List<File> getAvatarFiles(@NonNull Context context) {
-        File avatarDirectory = new File(context.getFilesDir(), AVATAR_DIRECTORY);
-        File[] results = avatarDirectory.listFiles();
-
-        if (results == null) return new LinkedList<>();
-        else return Stream.of(results).toList();
-    }
-
-    public static void deleteSelfAvatar(@NonNull Context context, @NonNull Address address) {
-        deleteSelfAvatar(context, getSelfAvatarFile(context, address));
-    }
-
-    public static void deleteSelfAvatar(@NonNull Context context, @NonNull File avatar) {
-        avatar.delete();
-        DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, null);
     }
 
     public static File getSelfAvatarFile(@NonNull Context context, @NonNull Address address) {
@@ -129,33 +77,19 @@ public class AvatarHelper {
         return new File(avatarDirectory, address);
     }
 
-    public static void setSelfAvatar(@NonNull Context context, @NonNull Address address, @Nullable byte[] data)
-            throws IOException {
-        if (data == null) {
-            deleteSelfAvatar(context, address);
-        } else {
-            File avatar = getSelfAvatarFile(context, address);
-            writeSelfAvatarFile(context, avatar, data);
-        }
-    }
-
     public static void setSelfAvatar(@NonNull Context context, @NonNull String address, @Nullable byte[] data) throws IOException {
         File avatar = getSelfAvatarFile(context, address);
         if (data == null) {
-            deleteSelfAvatar(context, avatar);
+            avatar.delete();
+            DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, null);
         } else {
-            writeSelfAvatarFile(context, avatar, data);
+            FileOutputStream out = new FileOutputStream(avatar);
+            if (data != null) {
+                out.write(data);
+            }
+            out.close();
+            String path = avatar.getPath();
+            DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, path);
         }
     }
-
-    private static void writeSelfAvatarFile(@NonNull Context context, @NonNull File avatar, @Nullable byte[] data) throws IOException {
-        FileOutputStream out = new FileOutputStream(avatar);
-        if (data != null) {
-            out.write(data);
-        }
-        out.close();
-        String path = avatar.getPath();
-        DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, path);
-    }
-
 }


### PR DESCRIPTION
android currently use a cached file of the avatar that is the same as in the core (by some refactoring, we could use the same files, however, this is out of scope of this pr)

in the past, the filename of the avatar was the email address, so sth. as foo@example.org - which the results in avatar.org with unknown mime type.

this pr just adds the extension .jpg - this may result in core having a different file, however, _currently_ the core waits for a call to dc_set_config(selfavatar) before acutally sending files out, so things will be in sync then. the selfavatar is currently never _read_ from the core.

fixes #1156 