### PR TITLE
move doze reminder to device-chat

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -575,6 +575,7 @@
     <string name="perm_explain_access_to_location_denied">To attach a location, go to the app settings, select \"Permissions\", and enable \"Location\".</string>
     <string name="perm_enable_bg_reminder_title">Tap here to receive messages while Delta Chat is in the background.</string>
     <string name="perm_enable_bg_reminder_text">Delta Chat uses few resources and takes care not to drain your battery.</string>
+    <string name="perm_enable_bg_already_done">You already allowed Delta Chat to receive messages in the background.\n\nIf messages still do not arrive in background, please also check your system settings.</string>
 
     <!-- dc_str_* resources -->
     <string name="encrypted_message">Encrypted message</string>

--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -3,7 +3,8 @@ package com.b44t.messenger;
 public class DcContact {
 
     public final static int DC_CONTACT_ID_SELF               = 1;
-    public final static int DC_CONTACT_ID_DEVICE             = 2;
+    public final static int DC_CONTACT_ID_INFO               = 2;
+    public final static int DC_CONTACT_ID_DEVICE             = 5;
     public final static int DC_CONTACT_ID_LAST_SPECIAL       = 9;
     public final static int DC_CONTACT_ID_NEW_CONTACT        = -1; // used by the UI, not valid to the core
     public final static int DC_CONTACT_ID_NEW_GROUP          = -2; //      - " -

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -59,6 +59,7 @@ import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcMsg;
 
 import org.thoughtcrime.securesms.ConversationAdapter.ItemClickListener;
+import org.thoughtcrime.securesms.components.reminder.DozeReminder;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.database.Address;
@@ -705,6 +706,9 @@ public class ConversationFragment extends Fragment
             }
             else if(messageRecord.isSetupMessage()) {
                 querySetupCode(messageRecord,null);
+            }
+            else if(DozeReminder.isDozeReminderMsg(getContext(), messageRecord)) {
+                DozeReminder.dozeReminderTapped(getContext());
             }
         }
 

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -190,7 +190,8 @@ public class ConversationListFragment extends Fragment
 //          return Optional.of(new OutdatedBuildReminder(context));
 //        } else
           if (DozeReminder.isEligible(context)) {
-            return Optional.of(new DozeReminder(context));
+            DozeReminder.addDozeReminderDeviceMsg(context);
+            return Optional.absent();
           } else if (OutdatedReminder.isEligible(context)) {
             return Optional.of(new OutdatedReminder(context));
           }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -184,20 +184,18 @@ public class ConversationListFragment extends Fragment
       @Override
       protected Optional<? extends Reminder> doInBackground(Context... params) {
         final Context context = params[0];
-//        if (ExpiredBuildReminder.isEligible()) {
-//          return Optional.of(new ExpiredBuildReminder(context));
-//        } else if (OutdatedBuildReminder.isEligible()) {
-//          return Optional.of(new OutdatedBuildReminder(context));
-//        } else
+        try {
           if (DozeReminder.isEligible(context)) {
             DozeReminder.addDozeReminderDeviceMsg(context);
             return Optional.absent();
           } else if (OutdatedReminder.isEligible(context)) {
             return Optional.of(new OutdatedReminder(context));
           }
-          else {
-            return Optional.absent();
-          }
+        } catch(Exception e) {
+          e.printStackTrace();
+        }
+
+        return Optional.absent();
       }
 
       @Override

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -47,7 +47,7 @@ public class Prefs {
   public  static final String SCREEN_LOCK_TIMEOUT_PREF         = "pref_timeout_passphrase";
   public  static final String SCREEN_SECURITY_PREF             = "pref_screen_security";
   private static final String ENTER_SENDS_PREF                 = "pref_enter_sends";
-  private static final String PROMPTED_OPTIMIZE_DOZE_PREF      = "pref_prompted_optimize_doze";
+  private static final String PROMPTED_DOZE_MSG_ID_PREF        = "pref_prompted_doze_msg_id";
   private static final String IN_THREAD_NOTIFICATION_PREF      = "pref_key_inthread_notifications";
   public  static final String MESSAGE_BODY_TEXT_SIZE_PREF      = "pref_message_body_text_size";
 
@@ -160,12 +160,12 @@ public class Prefs {
     setStringPreference(context, LANGUAGE_PREF, language);
   }
 
-  public static void setPromptedOptimizeDoze(Context context, boolean value) {
-    setBooleanPreference(context, PROMPTED_OPTIMIZE_DOZE_PREF, value);
+  public static void setPromptedDozeMsgId(Context context, int msg_id) {
+    setIntegerPrefrence(context, PROMPTED_DOZE_MSG_ID_PREF, msg_id);
   }
 
-  public static boolean hasPromptedOptimizeDoze(Context context) {
-    return getBooleanPreference(context, PROMPTED_OPTIMIZE_DOZE_PREF, false);
+  public static int getPrompteDozeMsgId(Context context) {
+    return getIntegerPreference(context, PROMPTED_DOZE_MSG_ID_PREF, 0);
   }
 
   public static boolean isNotificationsEnabled(Context context) {


### PR DESCRIPTION
this pr moves the doze-reminder from a system-thing that users typically click away fast to a device-message.

this way, the user can come back to the information when the problem actually arise for them.

also, things are re-doable this way (the user can change the setting several times)

maybe the text needs some adaption, however, as the current text is already translated in most languages and we're close to a release, i do not change that.

also, it may make some sense to link to https://dontkillmyapp.com if the message is clicked although background-things are already allowed.

closes #1152

<img width="339" alt="Screen Shot 2019-12-16 at 14 13 16" src="https://user-images.githubusercontent.com/9800740/70909719-5bccc980-200e-11ea-92d6-f39a8c57d784.png">
