### PR TITLE
fix builds for MacOSX Catalina

### DIFF
--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -21,6 +21,9 @@ cd jni/deltachat-core-rust
 # ```
 # then, the following should work:
 
+# fix build on MacOS Catalina
+unset CPATH
+
 echo "-- cross compiling to armv7-linux-androideabi (arm) --"
 export CFLAGS=-D__ANDROID_API__=18
 TARGET_CC=armv7a-linux-androideabi18-clang \


### PR DESCRIPTION
CPATH needs to be set in order to compile deltachat iOS whareas deltachat android builds fail if CPATH is set


@r10s can you please verify that this change has no effect on mojave?