### PR TITLE
call dc_maybe_network() from a worker thread.

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
+++ b/src/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
@@ -19,7 +19,15 @@ public class NetworkStateReceiver extends BroadcastReceiver {
             if (ni != null && ni.getState() == NetworkInfo.State.CONNECTED) {
                 Log.i("DeltaChat", "++++++++++++++++++ Connected ++++++++++++++++++");
                 ApplicationDcContext dcContext = DcHelper.getContext(context);
-                dcContext.maybeNetwork();
+                new Thread(() -> {
+                    // call dc_maybe_network() from a worker thread.
+                    // theoretically, dc_maybe_network() can be called from the main thread and returns at once,
+                    // however, in reality, it does currently halt things for some seconds.
+                    // this is a workaround that make things usable for now.
+                    Log.i("DeltaChat", "calling maybeNetwork()");
+                    dcContext.maybeNetwork();
+                    Log.i("DeltaChat", "maybeNetwork() returned");
+                }).start();
             }
         }
         catch (Exception e) {


### PR DESCRIPTION
theoretically, dc_maybe_network() can be called from the main thread and returns at once,
however, in reality, it does currently halt things for some seconds.
this is a workaround that make things usable for now.

closes #1176 