### PR TITLE
use Intent.ACTION_VIEW from an Activity-context

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -648,7 +648,7 @@ public class ConversationItem extends LinearLayout
 
         context.startActivity(intent);
       } else if (slide.getUri() != null) {
-        ApplicationDcContext.openForViewOrShare(context, dcContext, slide.getDcMsgId(), Intent.ACTION_VIEW);
+        dcContext.openForViewOrShare(context, slide.getDcMsgId(), Intent.ACTION_VIEW);
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -648,7 +648,7 @@ public class ConversationItem extends LinearLayout
 
         context.startActivity(intent);
       } else if (slide.getUri() != null) {
-        dcContext.openForViewOrShare(slide.getDcMsgId(), Intent.ACTION_VIEW);
+        ApplicationDcContext.openForViewOrShare(context, dcContext, slide.getDcMsgId(), Intent.ACTION_VIEW);
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -158,7 +158,7 @@ public class ProfileDocumentsFragment
       return;
     }
 
-    ApplicationDcContext.openForViewOrShare(getActivity(), dcContext, dcMsg.getId(), Intent.ACTION_VIEW);
+    dcContext.openForViewOrShare(getActivity(), dcMsg.getId(), Intent.ACTION_VIEW);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -158,7 +158,7 @@ public class ProfileDocumentsFragment
       return;
     }
 
-    dcContext.openForViewOrShare(dcMsg.getId(), Intent.ACTION_VIEW);
+    ApplicationDcContext.openForViewOrShare(getActivity(), dcContext, dcMsg.getId(), Intent.ACTION_VIEW);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -187,21 +187,13 @@ public class ApplicationDcContext extends DcContext {
         mimeType = dcContext.checkMime(path, mimeType);
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setDataAndType(uri, mimeType);
-        if( Build.VERSION.SDK_INT <= 23 ) {
-          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_ACTIVITY_NEW_TASK);
-        } else {
-          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        }
+        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         context.startActivity(intent);
       } else {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType(mimeType);
         intent.putExtra(Intent.EXTRA_STREAM, uri);
-        if( Build.VERSION.SDK_INT <= 23 ) {
-          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_ACTIVITY_NEW_TASK);
-        } else {
-          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        }
+        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.chat_share_with_title)));
       }
     } catch (RuntimeException e) {

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -149,11 +149,10 @@ public class ApplicationDcContext extends DcContext {
 
   public static HashMap<String, Integer> sharedFiles = new HashMap<>();
 
-  public static void openForViewOrShare(Context context,
-                                 ApplicationDcContext dcContext,
+  public void openForViewOrShare(Context activity,
                                  int msg_id, String cmd) {
 
-    if(!(context instanceof Activity)) {
+    if(!(activity instanceof Activity)) {
       // would be nicer to accepting only Activity objects,
       // however, typically in Android just Context objects are passed around (as this normally does not make a difference).
       // Accepting only Activity here would force callers to cast, which would easily result in even more ugliness.
@@ -161,7 +160,7 @@ public class ApplicationDcContext extends DcContext {
       return;
     }
 
-    DcMsg msg = dcContext.getMsg(msg_id);
+    DcMsg msg = getMsg(msg_id);
     String path = msg.getFile();
     String mimeType = msg.getFilemime();
     try {
@@ -172,7 +171,7 @@ public class ApplicationDcContext extends DcContext {
       }
 
       Uri uri;
-      if (path.startsWith(dcContext.getBlobdir())) {
+      if (path.startsWith(getBlobdir())) {
         uri = Uri.parse("content://" + BuildConfig.APPLICATION_ID + ".attachments/" + file.getName());
         sharedFiles.put("/" + file.getName(), 1); // as different Android version handle uris in putExtra differently, we also check them on our own
       } else {
@@ -184,17 +183,17 @@ public class ApplicationDcContext extends DcContext {
       }
 
       if (cmd.equals(Intent.ACTION_VIEW)) {
-        mimeType = dcContext.checkMime(path, mimeType);
+        mimeType = checkMime(path, mimeType);
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setDataAndType(uri, mimeType);
         intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        context.startActivity(intent);
+        activity.startActivity(intent);
       } else {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType(mimeType);
         intent.putExtra(Intent.EXTRA_STREAM, uri);
         intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.chat_share_with_title)));
+        activity.startActivity(Intent.createChooser(intent, context.getString(R.string.chat_share_with_title)));
       }
     } catch (RuntimeException e) {
       Toast.makeText(context, String.format("%s (%s)", context.getString(R.string.no_app_to_handle_data), mimeType), Toast.LENGTH_LONG).show();


### PR DESCRIPTION
fixes #1154 by force using an Activity-context. this seems to be needed for Android 9, tried opening a pdf in an emulator with Android 9 and this works - without this fix it fails as described in #1154

i am unsure if FLAG_ACTIVITY_NEW_TASK is still needed for SDK <= 23 (Android 6, Marshmallow), the documentation is unclear to me here, https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NEW_TASK, and it was introduced for some reasons at https://github.com/deltachat/deltachat-android/pull/741 ,  however, probably it is fine. but i will try to test this explicitly.

