### PR TITLE
do not recode when attaching files

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -993,7 +993,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
             msg = new DcMsg(dcContext,
                 attachment.isVoiceNote()? DcMsg.DC_MSG_VOICE : DcMsg.DC_MSG_AUDIO);
           }
-          else if (MediaUtil.isVideoType(contentType)) {
+          else if (MediaUtil.isVideoType(contentType) && slideDeck.getDocumentSlide()==null) {
             msg = new DcMsg(dcContext, DcMsg.DC_MSG_VIDEO);
             recompress = DcMsg.DC_MSG_VIDEO;
           }


### PR DESCRIPTION
do not try to recode videos when attached as files; esp. if the detection with isVideoType() fails (videos may be images with wrong extension/mimetype), this gets annoying

closes #1174