### PR TITLE
add comment about badge-count hint

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -54,7 +54,7 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
     setSubText(context.getString(R.string.notify_n_messages_in_m_chats,
                                  messageCount, chatCount));
     setContentInfo(String.valueOf(messageCount));
-    setNumber(messageCount);
+    setNumber(messageCount); // this also sets badges on android8 and newer
   }
 
   void setMostRecentSender(Recipient recipient) {

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -92,7 +92,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
 
   public void setMessageCount(int messageCount) {
     setContentInfo(String.valueOf(messageCount));
-    setNumber(messageCount);
+    setNumber(messageCount); // this also sets badges on android8 and newer
   }
 
   public void setPrimaryMessageBody(@NonNull  Recipient chatRecipients,


### PR DESCRIPTION
just that we do not forget about that when we rework the notification issues.

setNumber() does the trick with the badges on newer androids, see https://github.com/deltachat/deltachat-android/issues/1189