### PR TITLE
Fix not trying to play a sound when -no sound- has been selected.

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -12,7 +12,6 @@ import androidx.annotation.NonNull;
 import androidx.core.app.NotificationManagerCompat;
 import android.text.TextUtils;
 import android.util.Log;
-import android.widget.Toast;
 
 import com.b44t.messenger.DcMsg;
 

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.core.app.NotificationManagerCompat;
 import android.text.TextUtils;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.b44t.messenger.DcMsg;
 
@@ -286,10 +287,13 @@ abstract class MessageNotifier {
     }
 
     private void playNotificationSound(Uri uri, boolean vibrate) {
-        Ringtone ringtone = RingtoneManager.getRingtone(appContext, uri);
-        if (ringtone!=null) {
-            ringtone.play();
-        }
+        if(uri != null) {
+            Ringtone ringtone = RingtoneManager.getRingtone(appContext, uri);
+            
+            if (ringtone != null) {
+                ringtone.play();
+            }
+        } // else we selected "no sound"
 
         if (vibrate) {
             Vibrator v = (Vibrator) appContext.getSystemService(Context.VIBRATOR_SERVICE);


### PR DESCRIPTION
fix #1197 
When the uri comes in with a `null` state the ringtone sometimes is build but with an internal ­­­­broken uri.
So this fix removes the creation and call to the ringtone altogether if it is null to begin with.

Should have no side effects.