### PR TITLE
add verified group hint

### DIFF
--- a/res/layout/group_create_activity.xml
+++ b/res/layout/group_create_activity.xml
@@ -6,71 +6,49 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="20dp"
+        android:layout_height="106dp"
+        android:paddingStart="14dp"
+        android:paddingEnd="18dp"
+        android:paddingTop="14dp"
+        android:orientation="horizontal"
         android:gravity="center_vertical">
 
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="106dp"
-            android:paddingLeft="14dp"
-            android:paddingRight="18dp"
-            android:paddingTop="14dp"
-            android:orientation="horizontal"
-            android:gravity="center_vertical">
+        <org.thoughtcrime.securesms.components.ImageDivet android:id="@+id/avatar"
+            android:layout_width="70dp"
+            android:layout_height="70dp"
+            position="bottom_right"
+            android:layout_marginEnd="10dp"
+            android:contentDescription="@string/group_avatar" />
 
-            <org.thoughtcrime.securesms.components.ImageDivet android:id="@+id/avatar"
-                android:layout_width="70dp"
-                android:layout_height="70dp"
-                position="bottom_right"
-                android:layout_marginRight="10dp"
-                android:contentDescription="@string/group_avatar" />
+        <org.thoughtcrime.securesms.components.emoji.EmojiEditText
+            android:id="@+id/group_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:padding="10dp"
+            android:lines="1"
+            android:maxLength="255"
+            android:inputType="textAutoCorrect"
+            android:hint="@string/group_name" />
+    </LinearLayout>
 
-            <org.thoughtcrime.securesms.components.emoji.EmojiEditText
-                android:id="@+id/group_name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:padding="10dp"
-                android:lines="1"
-                android:maxLength="255"
-                android:inputType="textAutoCorrect"
-                android:hint="@string/group_name" />
-            </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="106dp"
-            android:paddingLeft="18dp"
-            android:paddingRight="18dp"
-            android:paddingTop="18dp"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
-            android:visibility="gone">
-
-            <ProgressBar
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="10dp"
-                style="@android:style/Widget.ProgressBar"
-                android:indeterminate="true" />
-
-            <org.thoughtcrime.securesms.components.emoji.EmojiTextView
-                android:id="@+id/creating_group_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:padding="10dp"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-        </LinearLayout>
-
-    </RelativeLayout>
+    <TextView
+        android:id="@+id/group_hints"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:text="@string/verified_group_explain" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
         android:orientation="horizontal">
 
         <Button

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -543,6 +543,7 @@
     <string name="contact_not_verified">Cannot verify %1$s.</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Changed setup for %1$s.</string>
+    <string name="verified_group_explain">Verified groups (experimental) provide safety against active attacks. Members are verified with a second factor by other members and messages are always end-to-end-encrypted.</string>
 
 
     <!-- notifications  -->

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -204,6 +204,10 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     ViewUtil.findById(this, R.id.verify_button).setOnClickListener(new ShowQrButtonListener());
     initializeAvatarView();
 
+    if (!verified) {
+      ViewUtil.findById(this, R.id.group_hints).setVisibility(View.GONE);
+    }
+
     if(isEdit()) {
       lv.setVisibility(View.GONE);
       findViewById(R.id.add_member_button).setVisibility(View.GONE);


### PR DESCRIPTION
this pr adds a small text that explains what is a "verified group". up to now, this was completely missing.

moreover, as there may be os-stores that do not allow beta/experimental stuff, we removed the string "experimental" from the main option, it lives on, a bit tuned down, in the explanation.

cc @hpk42 

<img width="363" alt="Screen Shot 2020-01-02 at 21 45 16" src="https://user-images.githubusercontent.com/9800740/71692389-02a0bc00-2daa-11ea-88b5-f82e9ce98b1c.png">
