### PR TITLE
fix saving drafts

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -305,7 +305,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   @Override
   protected void onPause() {
     super.onPause();
-    // save draft on pause
     processComposeControls(ACTION_SAVE_DRAFT);
     MessageNotifierCompat.updateVisibleChat(MessageNotifierCompat.NO_VISIBLE_CHAT_ID);
     if (isFinishing()) overridePendingTransition(R.anim.fade_scale_in, R.anim.slide_to_right);
@@ -333,7 +332,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   protected void onDestroy() {
-    processComposeControls(ACTION_SAVE_DRAFT);
     dcContext.eventCenter.removeObservers(this);
     super.onDestroy();
   }


### PR DESCRIPTION
this is an addition to #1192:

by calling processComposeControls() twice, in onPause() and on Destroy(),
the seccond call gets an empty draft.

as onDestroy() is not guarateed to be executed anyway -
this was the intent of the move in pr #1192 -
we just remove this call and rely on onPause().

see https://developer.android.com/reference/android/app/Activity.html
for lifecycles and killable events.

closes #1220