### PR TITLE
lower sdk to 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ android {
         applicationId "com.b44t.messenger"
         multiDexEnabled true
 
-        minSdkVersion 18
+        minSdkVersion 16
         targetSdkVersion 28
 
         vectorDrawables.useSupportLibrary = true

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_PLATFORM := android-18
+APP_PLATFORM := android-16
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_STL := c++_static
 

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -14,11 +14,11 @@ cd jni/deltachat-core-rust
 # and add the correct clang-linkers to `~/.cargo/config`:
 # ```
 # [target.armv7-linux-androideabi]
-# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/armv7a-linux-androideabi18-clang"
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/armv7a-linux-androideabi16-clang"
 # [target.aarch64-linux-android]
 # linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/aarch64-linux-android21-clang"
 # [target.i686-linux-android]
-# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/i686-linux-android18-clang"
+# linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/i686-linux-android16-clang"
 # [target.x86_64-linux-android]
 # linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/x86_64-linux-android21-clang"
 # ```
@@ -28,8 +28,8 @@ cd jni/deltachat-core-rust
 unset CPATH
 
 echo "-- cross compiling to armv7-linux-androideabi (arm) --"
-export CFLAGS=-D__ANDROID_API__=18
-TARGET_CC=armv7a-linux-androideabi18-clang \
+export CFLAGS=-D__ANDROID_API__=16
+TARGET_CC=armv7a-linux-androideabi16-clang \
 cargo build --release --target armv7-linux-androideabi -p deltachat_ffi
 
 echo "-- cross compiling to aarch64-linux-android (arm64) --"
@@ -38,8 +38,8 @@ TARGET_CC=aarch64-linux-android21-clang \
 cargo build --release --target aarch64-linux-android -p deltachat_ffi
 
 echo "-- cross compiling to i686-linux-android (x86) --"
-export CFLAGS=-D__ANDROID_API__=18
-TARGET_CC=i686-linux-android18-clang \
+export CFLAGS=-D__ANDROID_API__=16
+TARGET_CC=i686-linux-android16-clang \
 cargo build --release --target i686-linux-android -p deltachat_ffi
 
 echo "-- cross compiling to x86_64-linux-android (x86_64) --"


### PR DESCRIPTION
this pr lowers the sdk to 16 so that Android 4.1 Lollipop becomes fully available again (before, we target sdk18 (android 4.3, also Lollipop). in between, the change was needed because of some rust libraries that were use, however, they have been replaced by sth. else so that this is no longer a target. we cannot go lower than sdk16 as this is no longer supported by the used devlopment tools.

this should only be merged if there are no problems, esp. on newer androids (which are >90% compared to 3% this pr will gain in additiony)

targets #1212