### PR TITLE
rename 'new chat' to 'send message'

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -300,6 +300,7 @@
     <string name="tab_gallery_empty_hint">Images and videos shared in this chat will be displayed here.</string>
     <string name="tab_docs_empty_hint">Documents, music and other files shared in this chat will be displayed here.</string>
     <string name="media_preview">Media preview</string>
+    <string name="send_message">Send message</string>
 
 
     <!-- welcome and login -->

--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -275,7 +275,7 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
       itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_CONTACT_ADDR,dcContact.getAddr()));
 //      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_CONTACT_NAME, context.getString(R.string.menu_edit_name)));
 //      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_ENCRYPTION, context.getString(R.string.profile_encryption)));
-      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_CHAT, context.getString(R.string.menu_new_chat)));
+      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_CHAT, context.getString(R.string.send_message)));
       itemDataSharedChats = sharedChats;
       int sharedChatsCnt = sharedChats.getCnt();
       for (int i = 0; i < sharedChatsCnt; i++) {


### PR DESCRIPTION
after discussing with @Simon-Laux, @Jikstra and others, we decided on renaming 'new chat' in the profile view to 'send message'. 'new chat' (and also 'open chat' on desktop) is a bit misleading as the corresponding chat may or may not exist.

also, the wording 'send message' in the profile is also used on other messengers eg. in telegram.