### PR TITLE
sign-in vs. sign-up

### DIFF
--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -69,7 +69,7 @@
                 android:id="@+id/password_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/password"
+                android:hint="@string/existing_password"
                 android:inputType="textPassword" />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="email_address">Email address</string>
     <string name="bad_email_address">Bad email address.</string>
     <string name="password">Password</string>
+    <string name="existing_password">Existing password</string>
     <string name="now">Now</string>
     <!-- Translators: used as a headline in sections with actions that cannot be undone. could also be "Caution" or "Cave" or so. -->
     <string name="danger">Danger</string>


### PR DESCRIPTION
improve wording to make more clear, this is sign-in, not-sign up.

this pr changes the text "password" to "existing password".

<img width="407" alt="Screen Shot 2020-02-21 at 18 31 13" src="https://user-images.githubusercontent.com/9800740/75057099-8e94b180-54d8-11ea-972b-de5815dac1c4.png">

the idea was also to change the text below the field to "Please login to your e-mail server using your existing e-mail address and password" or - however, this would at least partly only repeat the headline and the labels. also the existing hint seems to be important and, we're talking about ppl that do not really read hints, so adding more of them is maybe not helpful

so, i think, we can maybe just go for the small change and see if this already helps. it is also not that we get tons of complains to that - but i think the "no delta servers" actually helped to avoid scaring people.