### PR TITLE
less clicks on save-message and start-chat

### DIFF
--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -38,6 +38,7 @@ public class DcContext {
     public final static int DC_GCL_ARCHIVED_ONLY    = 0x01;
     public final static int DC_GCL_NO_SPECIALS      = 0x02;
     public final static int DC_GCL_ADD_ALLDONE_HINT = 0x04;
+    public final static int DC_GCL_FOR_FORWARDING   = 0x08;
 
     public final static int DC_GCM_ADDDAYMARKER = 0x01;
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -603,18 +603,22 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleForwarding() {
     DcChat dcChat = dcContext.getChat(chatId);
-    String name = dcChat.getName();
-    if( !dcChat.isGroup() ) {
-      int[] contactIds = dcContext.getChatContacts(chatId);
-      if( contactIds.length==1 || contactIds.length==2 ) {
-        name = dcContext.getContact(contactIds[0]).getNameNAddr();
+    if (dcChat.isSelfTalk()) {
+      new RelayingTask(this, chatId).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    } else {
+      String name = dcChat.getName();
+      if (!dcChat.isGroup()) {
+        int[] contactIds = dcContext.getChatContacts(chatId);
+        if (contactIds.length == 1 || contactIds.length == 2) {
+          name = dcContext.getContact(contactIds[0]).getNameNAddr();
+        }
       }
+      new AlertDialog.Builder(this)
+              .setMessage(getString(R.string.ask_forward, name))
+              .setPositiveButton(R.string.ok, (dialogInterface, i) -> new RelayingTask(this, chatId).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR))
+              .setNegativeButton(R.string.cancel, (dialogInterface, i) -> finish())
+              .show();
     }
-    new AlertDialog.Builder(this)
-            .setMessage(getString(R.string.ask_forward, name))
-            .setPositiveButton(R.string.ok, (dialogInterface, i) -> new RelayingTask(this, chatId).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR))
-            .setNegativeButton(R.string.cancel, (dialogInterface, i) -> finish())
-            .show();
   }
 
   private void handleSharing() {

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -90,7 +90,10 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     searchToolbar            = findViewById(R.id.search_toolbar);
     searchAction             = findViewById(R.id.search_action);
     fragmentContainer        = findViewById(R.id.fragment_container);
-    conversationListFragment = initFragment(R.id.fragment_container, new ConversationListFragment(), dynamicLanguage.getCurrentLocale());
+
+    Bundle bundle = new Bundle();
+    bundle.putBoolean(ConversationListFragment.FORWARDING, isForwarding(this));
+    conversationListFragment = initFragment(R.id.fragment_container, new ConversationListFragment(), dynamicLanguage.getCurrentLocale(), bundle);
 
     initializeSearchListener();
 

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -80,6 +80,7 @@ public class ConversationListFragment extends Fragment
   implements LoaderManager.LoaderCallbacks<DcChatlist>, ActionMode.Callback, ItemClickListener, DcEventCenter.DcEventDelegate
 {
   public static final String ARCHIVE = "archive";
+  public static final String FORWARDING = "for_forwarding";
 
   @SuppressWarnings("unused")
   private static final String TAG = ConversationListFragment.class.getSimpleName();
@@ -93,12 +94,14 @@ public class ConversationListFragment extends Fragment
   private Locale                      locale;
   private String                      queryFilter  = "";
   private boolean                     archive;
+  private boolean                     forwarding;
 
   @Override
   public void onCreate(Bundle icicle) {
     super.onCreate(icicle);
     locale  = (Locale) getArguments().getSerializable(PassphraseRequiredActionBarActivity.LOCALE_EXTRA);
     archive = getArguments().getBoolean(ARCHIVE, false);
+    forwarding = getArguments().getBoolean(FORWARDING, false);
 
     ApplicationDcContext dcContext = DcHelper.getContext(getActivity());
     dcContext.eventCenter.addObserver(DcContext.DC_EVENT_CHAT_MODIFIED, this);
@@ -347,10 +350,11 @@ public class ConversationListFragment extends Fragment
   @Override
   public Loader<DcChatlist> onCreateLoader(int arg0, Bundle arg1) {
     int listflags = 0;
-    if(archive) {
+    if (archive) {
       listflags |= DcContext.DC_GCL_ARCHIVED_ONLY;
-    }
-    else {
+    } else if (forwarding) {
+      listflags |= DcContext.DC_GCL_FOR_FORWARDING;
+    } else {
       listflags |= DcContext.DC_GCL_ADD_ALLDONE_HINT;
     }
     return new DcChatlistLoader(getActivity(), listflags, queryFilter.isEmpty()? null : queryFilter, 0);


### PR DESCRIPTION
this pr streamlines the ui, by removing some superfluous alerts and by re-ordering the forward-dialog so that "saved messages" is always one of the first entries.

the pr relies on https://github.com/deltachat/deltachat-core-rust/pull/1336 , so that should be merged before and the core should be updated afterwards.

closes #1007

<img width="338" alt="Screen Shot 2020-03-11 at 13 28 31" src="https://user-images.githubusercontent.com/9800740/76416975-4f050b00-639c-11ea-96d1-a8f144ce75ca.png">
