### PR TITLE
Run ndk-build from Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,12 @@ android {
         release
     }
 
+    externalNativeBuild {
+        ndkBuild {
+            path "./jni/Android.mk"
+        }
+    }
+
     buildTypes {
         debug {
             minifyEnabled false

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -62,7 +62,4 @@ cp deltachat-core-rust/target/aarch64-linux-android/release/libdeltachat.a arm64
 cp deltachat-core-rust/target/i686-linux-android/release/libdeltachat.a x86
 cp deltachat-core-rust/target/x86_64-linux-android/release/libdeltachat.a x86_64
 
-echo -- ndk-build --
-cd ..
-ndk-build
 echo "ending time: `date`"


### PR DESCRIPTION
Now changes to JNI should result in recompilation.

ndk-make.sh still has to be run to compile libdeltachat.a