### PR TITLE
Fix #1028, make sharing directly to a chat work always

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -98,20 +98,19 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     initializeSearchListener();
 
     TooltipCompat.setTooltipText(searchAction, getText(R.string.search_explain));
-    if (isRelayingMessageContent(this)) {
-      title.setText(isForwarding(this) ? R.string.forward_to : R.string.chat_share_with_title);
-      getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-      if (isDirectSharing(this)) {
-        openConversation(getDirectSharingChatId(this), -1);
-      }
-    }
-    handleOpenpgp4fpr();
+    refresh();
   }
 
   @Override
   protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
     setIntent(intent);
+    refresh();
+    conversationListFragment.onNewIntent();
+    invalidateOptionsMenu();
+  }
+
+  private void refresh() {
     if (isRelayingMessageContent(this)) {
       title.setText(isForwarding(this) ? R.string.forward_to : R.string.chat_share_with_title);
       getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -122,8 +121,6 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       title.setText(R.string.app_name);
       getSupportActionBar().setDisplayHomeAsUpEnabled(false);
     }
-    conversationListFragment.onNewIntent();
-    invalidateOptionsMenu();
     handleOpenpgp4fpr();
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -115,6 +115,9 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     if (isRelayingMessageContent(this)) {
       title.setText(isForwarding(this) ? R.string.forward_to : R.string.chat_share_with_title);
       getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+      if (isDirectSharing(this)) {
+        openConversation(getDirectSharingChatId(this), -1);
+      }
     } else {
       title.setText(R.string.app_name);
       getSupportActionBar().setDisplayHomeAsUpEnabled(false);


### PR DESCRIPTION
I found it out.
How to reproduce:
- uninstall and re-install Delta Chat
- login
- click "Share" in another app
- select "Saved Messages"

We now have a code duplicate (in onNewIntent and in onCreate), but I was unsure if both codes should go into another method and how it should be called. `refresh`? `init`?(also, the codes of these were already very similar before this PR).