### PR TITLE
Fix #999 swiping a notification away should not mark things as "noticed"

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -253,7 +253,6 @@ abstract class MessageNotifier {
                 firstItem.getText(""), firstItem.getSlideDeck());
         builder.setContentIntent(firstItem.getPendingIntent(context));
         builder.setGroup(NOTIFICATION_GROUP);
-        builder.setDeleteIntent(notificationState.getMarkAsReadIntent(context, chatId, notificationId));
 
         long timestamp = firstItem.getTimestamp();
         if (timestamp != 0) builder.setWhen(timestamp);
@@ -313,7 +312,6 @@ abstract class MessageNotifier {
         builder.setMessageCount(notificationState.getMessageCount(), notificationState.getChatCount());
         builder.setMostRecentSender(firstItem.getIndividualRecipient());
         builder.setGroup(NOTIFICATION_GROUP);
-        builder.setDeleteIntent(notificationState.getMarkAsReadIntent(context, 0, SUMMARY_NOTIFICATION_ID));
 
         long timestamp = firstItem.getTimestamp();
         if (timestamp != 0) builder.setWhen(timestamp);


### PR DESCRIPTION
I looked around in the code a bit to see what implications my change might have.

The only one I found is that `NotificationState.removeNotificationsForChat(int)` is not called and `NotificationState.notificationCount` is not decreased. This should be just fine because `notificationCount` is used to show an unread message count. Here, it is expected behavior that the unread message count does not decrease just because the message was swiped away.