### PR TITLE
add result counters to in-chat and local-help searches

### DIFF
--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -8,6 +8,11 @@
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         app:showAsAction="collapseActionView|never" />
 
+    <item android:title="0/0"
+        android:id="@+id/menu_search_counter"
+        android:visible="false"
+        app:showAsAction="always"/>
+
     <item android:title="@string/back"
         android:id="@+id/menu_search_up"
         android:icon="@drawable/ic_search_up"

--- a/res/menu/local_help.xml
+++ b/res/menu/local_help.xml
@@ -7,6 +7,11 @@
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         app:showAsAction="collapseActionView|never" />
 
+    <item android:title="0/0"
+        android:id="@+id/menu_search_counter"
+        android:visible="false"
+        app:showAsAction="always"/>
+
     <item android:title="@string/back"
         android:id="@+id/menu_search_up"
         android:icon="@drawable/ic_search_up"

--- a/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -165,6 +165,8 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
       int id = item.getItemId();
       if (id==R.id.menu_search_up || id==R.id.menu_search_down) {
         item.setVisible(!visible);
+      } else if (id==R.id.menu_search_counter) {
+        item.setVisible(false);
       } else if (item != exception) {
         item.setVisible(visible);
       }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1545,12 +1545,27 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private int beforeSearchComposeVisibility = View.VISIBLE;
   private int beforeSearchAttachVisibility = View.GONE;
 
+  private Menu  searchMenu = null;
   private int[] searchResult = {};
   private int   searchResultPosition = -1;
 
   private Toast lastToast = null;
 
+  private void updateResultCounter(int curr, int total) {
+    if (searchMenu!=null) {
+      MenuItem item = searchMenu.findItem(R.id.menu_search_counter);
+      if (curr!=-1) {
+        item.setTitle(String.format("%d/%d", total==0? 0 : curr+1, total));
+        item.setVisible(true);
+      } else {
+        item.setVisible(false);
+      }
+    }
+  }
+
   private void searchExpand(final Menu menu, final MenuItem searchItem) {
+    searchMenu = menu;
+
     beforeSearchComposeVisibility = composePanel.getVisibility();
     composePanel.setVisibility(View.GONE);
 
@@ -1573,6 +1588,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       if(searchResultPosition<0) searchResultPosition = searchResult.length-1;
       if(searchResultPosition>=searchResult.length) searchResultPosition = 0;
       fragment.scrollToMsgId(searchResult[searchResultPosition]);
+      updateResultCounter(searchResultPosition, searchResult.length);
     } else {
       // no search, scroll to first/last message
       if(searchNext) {
@@ -1601,19 +1617,21 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if(searchResult.length>0) {
       searchResultPosition = 0;
       fragment.scrollToMsgId(searchResult[searchResultPosition]);
+      updateResultCounter(0, searchResult.length);
     } else {
       searchResultPosition = -1;
-      if (!normQuery.isEmpty()) {
+      if (normQuery.isEmpty()) {
+        updateResultCounter(-1, 0); // hide
+      } else {
         String msg = getString(R.string.search_no_result_for_x, normQuery);
         if (lastToast != null) {
           lastToast.cancel();
         }
         lastToast = Toast.makeText(this, msg, Toast.LENGTH_SHORT);
         lastToast.show();
+        updateResultCounter(0, 0); // show as "0/0"
       }
     }
     return true; // action handled by listener
   }
-
-
 }

--- a/src/org/thoughtcrime/securesms/LocalHelpActivity.java
+++ b/src/org/thoughtcrime/securesms/LocalHelpActivity.java
@@ -115,6 +115,7 @@ public class LocalHelpActivity extends PassphraseRequiredActionBarActivity
             searchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
                 @Override
                 public boolean onMenuItemActionExpand(final MenuItem item) {
+                    searchMenu = menu;
                     LocalHelpActivity.this.lastQuery = "";
                     LocalHelpActivity.this.makeSearchMenuVisible(menu, searchItem, false);
                     return true;
@@ -145,8 +146,24 @@ public class LocalHelpActivity extends PassphraseRequiredActionBarActivity
         return true;
     }
 
+
+    // search
+
+    private Menu   searchMenu = null;
     private String lastQuery = "";
-    private Toast lastToast = null;
+    private Toast  lastToast = null;
+
+    private void updateResultCounter(int curr, int total) {
+        if (searchMenu!=null) {
+            MenuItem item = searchMenu.findItem(R.id.menu_search_counter);
+            if (curr!=-1) {
+                item.setTitle(String.format("%d/%d", total==0? 0 : curr+1, total));
+                item.setVisible(true);
+            } else {
+                item.setVisible(false);
+            }
+        }
+    }
 
     @Override
     public boolean onQueryTextSubmit(String query) {
@@ -168,15 +185,27 @@ public class LocalHelpActivity extends PassphraseRequiredActionBarActivity
     @Override
     public void onFindResultReceived (int activeMatchOrdinal, int numberOfMatches, boolean isDoneCounting)
     {
-        if (isDoneCounting && numberOfMatches==0 && !lastQuery.isEmpty()) {
-            String msg = getString(R.string.search_no_result_for_x, lastQuery);
-            if (lastToast!=null) {
-                lastToast.cancel();
+        if (isDoneCounting) {
+            if (numberOfMatches>0) {
+                updateResultCounter(activeMatchOrdinal, numberOfMatches);
+            } else {
+                if (lastQuery.isEmpty()) {
+                    updateResultCounter(-1, 0); // hide
+                } else {
+                    String msg = getString(R.string.search_no_result_for_x, lastQuery);
+                    if (lastToast != null) {
+                        lastToast.cancel();
+                    }
+                    lastToast = Toast.makeText(this, msg, Toast.LENGTH_SHORT);
+                    lastToast.show();
+                    updateResultCounter(0, 0); // show as "0/0"
+                }
             }
-            lastToast = Toast.makeText(this, msg, Toast.LENGTH_SHORT);
-            lastToast.show();
         }
     }
+
+
+    // other actions
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {


### PR DESCRIPTION
the result counters are shown as `12/34` beside the arrows to loop through the result. for "no result", `0/0` is shown and for "no search", the counter is hidden.