### PR TITLE
discard (accidental) taps outside the autodel-confirmation dialog

### DIFF
--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -179,6 +179,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
                   }
                 })
                 .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> initAutodelFromCore())
+                .setCancelable(false)
                 .show();
       } else {
         updateListSummary(preference, newValue);


### PR DESCRIPTION
closes #1300 
