### PR TITLE
updated docker toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV PATH ${PATH}:/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/b
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH ${PATH}:/root/.cargo/bin
-RUN rustup default nightly-2019-11-06 \
+RUN rustup default nightly-2020-03-12 \
 && rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
 
 COPY docker/cargo-config /root/.cargo/config


### PR DESCRIPTION
In https://github.com/deltachat/deltachat-core-rust/pull/1398, the rust toolchain was changed back to 2020-03-12, but the Android Dockerfile even missed the update to 2020-04-10 in between.

We realized this when the Android Nightlies stopped building.

On this branch, the build on b1.delta.chat works again.