### PR TITLE
Ask the core for the selfavatar directory, fix "backup export/import loses self-avatar"

### DIFF
--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -48,6 +48,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.LinkedList;
@@ -264,7 +265,7 @@ public class CreateProfileActivity extends BaseActionBarActivity {
         @Override
         protected byte[] doInBackground(Void... params) {
           try {
-            return Util.readFully(AvatarHelper.getInputStreamFor(CreateProfileActivity.this));
+            return Util.readFully(new FileInputStream(AvatarHelper.getSelfAvatarFile(CreateProfileActivity.this)));
           } catch (IOException e) {
             Log.w(TAG, e);
             return null;

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -259,12 +259,12 @@ public class CreateProfileActivity extends BaseActionBarActivity {
   private void initializeProfileAvatar() {
     String address = DcHelper.get(this, DcHelper.CONFIG_ADDRESS);
 
-    if (AvatarHelper.getSelfAvatarFile(this, address).exists() && AvatarHelper.getSelfAvatarFile(this, address).length() > 0) {
+    if (AvatarHelper.getSelfAvatarFile(this).exists() && AvatarHelper.getSelfAvatarFile(this).length() > 0) {
       new AsyncTask<Void, Void, byte[]>() {
         @Override
         protected byte[] doInBackground(Void... params) {
           try {
-            return Util.readFully(AvatarHelper.getInputStreamFor(CreateProfileActivity.this, address));
+            return Util.readFully(AvatarHelper.getInputStreamFor(CreateProfileActivity.this));
           } catch (IOException e) {
             Log.w(TAG, e);
             return null;

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -375,7 +375,7 @@ public class CreateProfileActivity extends BaseActionBarActivity {
         setStatusText();
 
         try {
-          AvatarHelper.setSelfAvatar(CreateProfileActivity.this, DcHelper.get(context, DcHelper.CONFIG_ADDRESS), avatarBytes);
+          AvatarHelper.setSelfAvatar(CreateProfileActivity.this, avatarBytes);
           Prefs.setProfileAvatarId(CreateProfileActivity.this, new SecureRandom().nextInt());
         } catch (IOException e) {
           Log.w(TAG, e);

--- a/src/org/thoughtcrime/securesms/contacts/avatars/LocalFileContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/LocalFileContactPhoto.java
@@ -42,7 +42,7 @@ public abstract class LocalFileContactPhoto implements ContactPhoto {
 
     @Override
     public @Nullable Uri getUri(@NonNull Context context) {
-        return isProfilePhoto() ? Uri.fromFile(AvatarHelper.getSelfAvatarFile(context, address)) : null;
+        return isProfilePhoto() ? Uri.fromFile(AvatarHelper.getSelfAvatarFile(context)) : null;
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/contacts/avatars/MyProfileContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/MyProfileContactPhoto.java
@@ -24,13 +24,14 @@ public class MyProfileContactPhoto implements ContactPhoto {
 
     @Override
     public InputStream openInputStream(Context context) throws IOException {
-        return AvatarHelper.getInputStreamFor(context, address);
+        return AvatarHelper.getInputStreamFor(context);
     }
 
     @Override
     public @Nullable
     Uri getUri(@NonNull Context context) {
-        return Uri.fromFile(AvatarHelper.getSelfAvatarFile(context, address));
+
+        return Uri.fromFile(AvatarHelper.getSelfAvatarFile(context));
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/contacts/avatars/MyProfileContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/MyProfileContactPhoto.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 
 import org.thoughtcrime.securesms.profiles.AvatarHelper;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
@@ -24,13 +25,12 @@ public class MyProfileContactPhoto implements ContactPhoto {
 
     @Override
     public InputStream openInputStream(Context context) throws IOException {
-        return AvatarHelper.getInputStreamFor(context);
+        return new FileInputStream(AvatarHelper.getSelfAvatarFile(context));
     }
 
     @Override
     public @Nullable
     Uri getUri(@NonNull Context context) {
-
         return Uri.fromFile(AvatarHelper.getSelfAvatarFile(context));
     }
 

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -72,9 +72,8 @@ public class AvatarHelper {
     }
 
     public static File getSelfAvatarFile(@NonNull Context context, @NonNull String address) {
-        File avatarDirectory = new File(context.getFilesDir(), AVATAR_DIRECTORY);
-        avatarDirectory.mkdirs();
-        return new File(avatarDirectory, address+".jpg");
+        String dirString = DcHelper.getContext(context).getConfig(DcHelper.CONFIG_SELF_AVATAR);
+        return new File(dirString);
     }
 
     public static void setSelfAvatar(@NonNull Context context, @NonNull String address, @Nullable byte[] data) throws IOException {

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -24,7 +24,7 @@ public class AvatarHelper {
             dcContext.setChatProfileImage(chatId, null);
         } else {
             try {
-                File avatar = File.createTempFile("groupavatar", "jpg", context.getCacheDir());
+                File avatar = File.createTempFile("groupavatar", ".jpg", context.getCacheDir());
                 FileOutputStream out = new FileOutputStream(avatar);
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 85, out);
                 out.close();
@@ -46,7 +46,7 @@ public class AvatarHelper {
         if (data == null) {
             DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, null);
         } else {
-            File avatar = File.createTempFile("selfavatar", "jpg", context.getCacheDir());
+            File avatar = File.createTempFile("selfavatar", ".jpg", context.getCacheDir());
             FileOutputStream out = new FileOutputStream(avatar);
             out.write(data);
             out.close();

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -72,11 +72,10 @@ public class AvatarHelper {
     }
 
     public static void setSelfAvatar(@NonNull Context context, @NonNull String address, @Nullable byte[] data) throws IOException {
-        File avatar = getSelfAvatarFile(context);
         if (data == null) {
-            avatar.delete();
             DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, null);
         } else {
+            File avatar = File.createTempFile("prefix", "extension", context.getCacheDir());
             FileOutputStream out = new FileOutputStream(avatar);
             if (data != null) {
                 out.write(data);
@@ -84,6 +83,7 @@ public class AvatarHelper {
             out.close();
             String path = avatar.getPath();
             DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, path);
+            avatar.delete();
         }
     }
 }

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -61,23 +61,18 @@ public class AvatarHelper {
         }
     }
 
-    public static InputStream getInputStreamFor(@NonNull Context context, @NonNull String address)
+    public static InputStream getInputStreamFor(@NonNull Context context)
             throws IOException {
-        return new FileInputStream(getSelfAvatarFile(context, address));
+        return new FileInputStream(getSelfAvatarFile(context));
     }
 
-    public static File getSelfAvatarFile(@NonNull Context context, @NonNull Address address) {
-        String name = new File(address.serialize()).getName();
-        return getSelfAvatarFile(context, name);
-    }
-
-    public static File getSelfAvatarFile(@NonNull Context context, @NonNull String address) {
+    public static File getSelfAvatarFile(@NonNull Context context) {
         String dirString = DcHelper.getContext(context).getConfig(DcHelper.CONFIG_SELF_AVATAR);
         return new File(dirString);
     }
 
     public static void setSelfAvatar(@NonNull Context context, @NonNull String address, @Nullable byte[] data) throws IOException {
-        File avatar = getSelfAvatarFile(context, address);
+        File avatar = getSelfAvatarFile(context);
         if (data == null) {
             avatar.delete();
             DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, null);

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -1,63 +1,39 @@
 package org.thoughtcrime.securesms.profiles;
 
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.database.Address;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 public class AvatarHelper {
 
-    private static final String GROUP_TEMPLATE = "group_chat_avatar_%s_%o.jpg";
-
-    private static final String AVATAR_DIRECTORY = "avatars";
-
-    @SuppressLint("DefaultLocale")
-    private static String getFilePathForGroupAvatar(Context context, int chatId, long timestamp) {
-        return getAvatarDirectoryPath(context) + String.format(GROUP_TEMPLATE, chatId, timestamp);
-    }
-
-    @NonNull
-    private static String getAvatarDirectoryPath(Context context) {
-        return context.getFilesDir().getAbsolutePath() + File.separator + AVATAR_DIRECTORY + File.separator;
-    }
-
     public static void setGroupAvatar(Context context, int chatId, Bitmap bitmap) {
-        if (bitmap == null) {
-            return;
-        }
-        //noinspection ResultOfMethodCallIgnored
-        new File(getAvatarDirectoryPath(context)).mkdirs();
         DcContext dcContext = DcHelper.getContext(context);
-        String avatarPath = dcContext.getChat(chatId).getProfileImage();
-        if (avatarPath != null && !avatarPath.isEmpty()) {
-            File oldImage = new File(avatarPath);
-            if (oldImage.exists()) {
+
+        if (bitmap == null) {
+            dcContext.setChatProfileImage(chatId, null);
+        } else {
+            try {
+                File avatar = File.createTempFile("groupavatar", "jpg", context.getCacheDir());
+                FileOutputStream out = new FileOutputStream(avatar);
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 85, out);
+                out.close();
+                dcContext.setChatProfileImage(chatId, avatar.getPath()); // The avatar is copied to the blobs directory here...
                 //noinspection ResultOfMethodCallIgnored
-                oldImage.delete();
+                avatar.delete(); // ..., now we can delete it.
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-        }
-        avatarPath = getFilePathForGroupAvatar(context, chatId, System.currentTimeMillis());
-        FileOutputStream outStream;
-        try {
-            outStream = new FileOutputStream(avatarPath);
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream);
-            dcContext.setChatProfileImage(chatId, avatarPath);
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
         }
     }
 
@@ -66,19 +42,17 @@ public class AvatarHelper {
         return new File(dirString);
     }
 
-    public static void setSelfAvatar(@NonNull Context context, @NonNull String address, @Nullable byte[] data) throws IOException {
+    public static void setSelfAvatar(@NonNull Context context, @Nullable byte[] data) throws IOException {
         if (data == null) {
             DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, null);
         } else {
-            File avatar = File.createTempFile("prefix", "extension", context.getCacheDir());
+            File avatar = File.createTempFile("selfavatar", "jpg", context.getCacheDir());
             FileOutputStream out = new FileOutputStream(avatar);
-            if (data != null) {
-                out.write(data);
-            }
+            out.write(data);
             out.close();
-            String path = avatar.getPath();
-            DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, path);
-            avatar.delete();
+            DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, avatar.getPath()); // The avatar is copied to the blobs directory here...
+            //noinspection ResultOfMethodCallIgnored
+            avatar.delete(); // ..., now we can delete it.
         }
     }
 }

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -61,11 +61,6 @@ public class AvatarHelper {
         }
     }
 
-    public static InputStream getInputStreamFor(@NonNull Context context)
-            throws IOException {
-        return new FileInputStream(getSelfAvatarFile(context));
-    }
-
     public static File getSelfAvatarFile(@NonNull Context context) {
         String dirString = DcHelper.getContext(context).getConfig(DcHelper.CONFIG_SELF_AVATAR);
         return new File(dirString);


### PR DESCRIPTION
Ask the core for the selfavatar directory, fix https://github.com/deltachat/deltachat-core-rust/issues/1381 backup export/import loses self-avatar

The problem was: DC-Android did not care about what the core said about the self-avatar, it just put a file with the own email address into a folder called "avatars". Of course, this folder was not backed up. Also, we had the self avatar multiple times, once in the blobs directory and once in the directory called "avatars" (probably a leftover of the Signal code).