### PR TITLE
tweak "switching" to already selected account

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -239,9 +239,14 @@ public class AccountManager {
                         activity.finishAffinity();
                         activity.startActivity(new Intent(activity, WelcomeActivity.class));
                     } else { // switch account
-                        switchAccount(activity, accounts.get(which));
-                        activity.finishAffinity();
-                        activity.startActivity(new Intent(activity.getApplicationContext(), ConversationListActivity.class));
+                        Account account = accounts.get(which);
+                        if (account.isCurrent()) {
+                            dialog.dismiss();
+                        } else {
+                            switchAccount(activity, account);
+                            activity.finishAffinity();
+                            activity.startActivity(new Intent(activity.getApplicationContext(), ConversationListActivity.class));
+                        }
                     }
                 });
         if (accounts.size() > 1) {


### PR DESCRIPTION
in the account switcher, do nothing if switching no new account was selected

prevent switching accounts if the currently selected account was tapped,
just close the dialog in this case.
(ux wise, it is better to show the current account - to get some overview
and also to easily see what the current account is)