### PR TITLE
Fix Null-Pointer-Exception

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -449,7 +449,10 @@ public class ConversationListFragment extends Fragment
     getListAdapter().initializeBatchMode(true);
     getListAdapter().toggleThreadInBatchSet(item.getChatId());
     getListAdapter().notifyDataSetChanged();
-    updateActionModeItems(actionMode.getMenu());
+    Menu menu = actionMode.getMenu();
+    if (menu != null) {
+        updateActionModeItems(menu);
+    }
   }
 
   @Override


### PR DESCRIPTION
Just by chance, I got DC to crash. I must somehow have long-pressed an item while it was finishing. Anyway, I found the responsible line in the logs and this should not happen anymore with this fix.