### PR TITLE
stop threads when switching between mupltiple accounts

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -387,6 +387,12 @@ JNIEXPORT void Java_com_b44t_messenger_DcContext_performSmtpIdle(JNIEnv *env, jo
 }
 
 
+JNIEXPORT void Java_com_b44t_messenger_DcContext_interruptSmtpIdle(JNIEnv *env, jobject obj)
+{
+	dc_interrupt_smtp_idle(get_dc_context(env, obj));
+}
+
+
 JNIEXPORT void Java_com_b44t_messenger_DcContext_maybeNetwork(JNIEnv *env, jobject obj)
 {
 	dc_maybe_network(get_dc_context(env, obj));

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -106,6 +106,7 @@ public class DcContext {
 
     public native void         performSmtpJobs      ();
     public native void         performSmtpIdle      ();
+    public native void         interruptSmtpIdle    ();
 
     public native void         maybeNetwork         ();
     public native void         setConfig            (String key, String value);

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -251,8 +251,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         AccountManager accountManager = AccountManager.getInstance();
         if (accountManager.canRollbackAccountCreation(this)) {
             accountManager.rollbackAccountCreation(this);
-            finish();
-            startActivity(new Intent(getApplicationContext(), ConversationListActivity.class));
         } else {
             super.onBackPressed();
         }

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -183,6 +183,8 @@ public class AccountManager {
         sharedPreferences.edit().putString("prev_account_db_name", "").apply();
         sharedPreferences.edit().putString("curr_account_db_name", prevDbName).apply();
 
+        resetDcContext(context);
+
         // delete the previous account, however, as a resilience check, make sure,
         // we do not delete already configured accounts (just in case sth. changes the flow of activities)
         DcContext testContext = new DcContext(null);
@@ -192,8 +194,6 @@ public class AccountManager {
                 deleteAccount(context, inCreationDbName);
             }
         }
-
-        resetDcContext(context);
     }
 
 

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -93,6 +93,8 @@ public class AccountManager {
         // create an empty DcContext object - this will be set up then, starting with
         // getSelectedAccount()
         ApplicationContext appContext = (ApplicationContext)context.getApplicationContext();
+        appContext.dcContext.stopThreads();
+        appContext.dcContext.close();
         appContext.dcContext = new ApplicationDcContext(context);
     }
 

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -404,21 +404,26 @@ public class ApplicationDcContext extends DcContext {
   }
 
   public void stopThreads() {
-    Log.i(TAG, "!!!!!!!!!!!! Stopping threads ...");
     run = false;
     synchronized (threadsCritical) {
-      if (imapThread!=null) { interruptImapIdle(); }
-      if (mvboxThread!=null) { interruptMvboxIdle(); }
-      if (sentboxThread!=null) { interruptSentboxIdle(); }
-      if (smtpThread!=null) { interruptSmtpIdle(); }
       while (true) {
-        if ( (imapThread==null || !imapThread.isAlive())
-          && (mvboxThread==null || !mvboxThread.isAlive())
+
+        // in theory, interrupting once outside the loop should be sufficient,
+        // but there are some corner cases, see https://github.com/deltachat/deltachat-core-rust/issues/925
+        Log.i(TAG, "!!!!!!!!!!!! Stopping threads ...");
+        if (imapThread!=null    && imapThread.isAlive())    { interruptImapIdle(); }
+        if (mvboxThread!=null   && mvboxThread.isAlive())   { interruptMvboxIdle(); }
+        if (sentboxThread!=null && sentboxThread.isAlive()) { interruptSentboxIdle(); }
+        if (smtpThread!=null    && smtpThread.isAlive())    { interruptSmtpIdle(); }
+
+        Util.sleep(300);
+
+        if ( (imapThread==null    || !imapThread.isAlive())
+          && (mvboxThread==null   || !mvboxThread.isAlive())
           && (sentboxThread==null || !sentboxThread.isAlive())
-          && (smtpThread==null || !smtpThread.isAlive())) {
+          && (smtpThread==null    || !smtpThread.isAlive())) {
           break;
         }
-        Util.sleep(100);
       }
     }
     Log.i(TAG, "!!!!!!!!!!!! threads stopped");

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -296,6 +296,8 @@ public class ApplicationDcContext extends DcContext {
 
   public final static int INTERRUPT_IDLE = 0x01; // interrupt idle if the thread is already running
 
+  public boolean run = true;
+
   public void startThreads(int flags) {
     synchronized (threadsCritical) {
 
@@ -303,7 +305,7 @@ public class ApplicationDcContext extends DcContext {
 
         imapThread = new Thread(() -> {
           Log.i(TAG, "###################### IMAP-Thread started. ######################");
-          while (true) {
+          while (run) {
             imapWakeLock.acquire();
             performImapJobs();
             performImapFetch();
@@ -313,6 +315,7 @@ public class ApplicationDcContext extends DcContext {
             }
             performImapIdle();
           }
+          Log.i(TAG, "!!!!!!!!!!!! IMAP-Thread stopped");
         }, "imapThread");
         imapThread.setPriority(Thread.NORM_PRIORITY);
         imapThread.start();
@@ -327,7 +330,7 @@ public class ApplicationDcContext extends DcContext {
 
         mvboxThread = new Thread(() -> {
           Log.i(TAG, "###################### MVBOX-Thread started. ######################");
-          while (true) {
+          while (run) {
             mvboxWakeLock.acquire();
             performMvboxJobs();
             performMvboxFetch();
@@ -337,6 +340,7 @@ public class ApplicationDcContext extends DcContext {
             }
             performMvboxIdle();
           }
+          Log.i(TAG, "!!!!!!!!!!!! MVBOX-Thread stopped");
         }, "mvboxThread");
         mvboxThread.setPriority(Thread.NORM_PRIORITY);
         mvboxThread.start();
@@ -351,13 +355,14 @@ public class ApplicationDcContext extends DcContext {
 
         sentboxThread = new Thread(() -> {
           Log.i(TAG, "###################### SENTBOX-Thread started. ######################");
-          while (true) {
+          while (run) {
             sentboxWakeLock.acquire();
             performSentboxJobs();
             performSentboxFetch();
             sentboxWakeLock.release();
             performSentboxIdle();
           }
+          Log.i(TAG, "!!!!!!!!!!!! SENTBOX-Thread stopped");
         }, "sentboxThread");
         sentboxThread.setPriority(Thread.NORM_PRIORITY-1);
         sentboxThread.start();
@@ -370,7 +375,7 @@ public class ApplicationDcContext extends DcContext {
       if (smtpThread == null || !smtpThread.isAlive()) {
         smtpThread = new Thread(() -> {
           Log.i(TAG, "###################### SMTP-Thread started. ######################");
-          while (true) {
+          while (run) {
             smtpWakeLock.acquire();
             performSmtpJobs();
             smtpWakeLock.release();
@@ -379,6 +384,7 @@ public class ApplicationDcContext extends DcContext {
             }
             performSmtpIdle();
           }
+          Log.i(TAG, "!!!!!!!!!!!! SMTP-Thread stopped");
         }, "smtpThread");
         smtpThread.setPriority(Thread.MAX_PRIORITY);
         smtpThread.start();
@@ -395,6 +401,27 @@ public class ApplicationDcContext extends DcContext {
       }
       Util.sleep(500);
     }
+  }
+
+  public void stopThreads() {
+    Log.i(TAG, "!!!!!!!!!!!! Stopping threads ...");
+    run = false;
+    synchronized (threadsCritical) {
+      if (imapThread!=null) { interruptImapIdle(); }
+      if (mvboxThread!=null) { interruptMvboxIdle(); }
+      if (sentboxThread!=null) { interruptSentboxIdle(); }
+      if (smtpThread!=null) { interruptSmtpIdle(); }
+      while (true) {
+        if ( (imapThread==null || !imapThread.isAlive())
+          && (mvboxThread==null || !mvboxThread.isAlive())
+          && (sentboxThread==null || !sentboxThread.isAlive())
+          && (smtpThread==null || !smtpThread.isAlive())) {
+          break;
+        }
+        Util.sleep(100);
+      }
+    }
+    Log.i(TAG, "!!!!!!!!!!!! threads stopped");
   }
 
 


### PR DESCRIPTION
this pr stops threads and call close() on switching account.

the imap-/mvbox-/sentbox-/smtp-threads needs to be terminated before dc_close() can be called successfully.

if this is not done, the threads are hanging around, and, even worse, if an account is opened _again_, there are now two threads working on the database which lead to duplicated messages.

note, that this issue is only related to duplicated messages if ever an account was selected, which, however, might be the same as the current.

fixes https://github.com/deltachat/deltachat-core-rust/issues/1404

EDIT: the last few commits move the account switching to an async task