### PR TITLE
Fix #1305 An object (image), "shared" to Delta Chat once, appears again forever in Chat editors until app is closed

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -548,9 +548,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (isRelayingMessageContent(this)) {
       if (isSharing(this)) {
-        dcContext.setDraft(dcChat.getId(), null);
         attachmentManager.cleanup();
-        composeText.setText("");
       }
       finish();
       return;
@@ -662,6 +660,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleSharing() {
     ArrayList<Uri> uriList =  RelayUtil.getSharedUris(this);
+    RelayUtil.resetRelayingMessageContent(this); // This avoids that the shared text appears again if another chat is opened
     if (uriList == null) return;
     if (uriList.size() > 1) {
       String message = String.format(getString(R.string.share_multiple_attachments), uriList.size());

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -660,7 +660,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleSharing() {
     ArrayList<Uri> uriList =  RelayUtil.getSharedUris(this);
-    RelayUtil.resetRelayingMessageContent(this); // This avoids that the shared text appears again if another chat is opened
+    RelayUtil.resetRelayingMessageContent(this);
     if (uriList == null) return;
     if (uriList.size() > 1) {
       String message = String.format(getString(R.string.share_multiple_attachments), uriList.size());


### PR DESCRIPTION
Fix #1305 An object (image), "shared" to Delta Chat once, appears again forever in Chat editors until app is closed

The problem was that the intent still had the share flag and data. When opening a new chat, DC thought that we had just shared something.

A draft is now initialized (and stays) so that the user can return to sending later.

Also fixes #1317 (just tested it, don't think it's worth debugging why it fixes this)