### PR TITLE
show permanent notification unconditionally and add a switch to override this

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -468,6 +468,10 @@
     <string name="pref_background_default_color">Default color</string>
     <string name="pref_background_custom_image">Custom image</string>
     <string name="pref_background_custom_color">Custom color</string>
+    <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
+    <string name="pref_reliable_service">Reliable service</string>
+    <string name="pref_reliable_service_explain">Requires a permanent notification</string>
+
 
     <!-- automatically delete message -->
     <string name="autodel_title">Auto-delete messages</string>

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -58,4 +58,10 @@
                 android:entries="@array/pref_notification_priority_entries"
                 android:entryValues="@array/pref_notification_priority_values"/>
 
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="pref_reliable_service"
+            android:title="@string/pref_reliable_service"
+            android:summary="@string/pref_reliable_service_explain"/>
+
 </PreferenceScreen>

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -40,6 +40,7 @@ import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.database.NoExternalStorageException;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Scrubber;
 import org.thoughtcrime.securesms.util.StorageUtil;
 
@@ -240,6 +241,8 @@ public class LogViewFragment extends Fragment {
         builder.append("ignoreBatteryOptimizations=").append(
             powerManager.isIgnoringBatteryOptimizations(context.getPackageName())).append("\n");
       }
+      builder.append("reliableService=").append(
+              Prefs.reliableService(context)).append("\n");
     } catch (Exception e) {
       builder.append("Unknown\n");
     }

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -30,6 +30,7 @@ import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.io.File;
@@ -81,7 +82,7 @@ public class ApplicationDcContext extends DcContext {
     BroadcastReceiver networkStateReceiver = new NetworkStateReceiver();
     context.registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
 
-    KeepAliveService.startSelf(context);
+    KeepAliveService.maybeStartSelf(context);
   }
 
   public void setStockTranslations() {

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -10,12 +10,14 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.Settings;
 import androidx.annotation.Nullable;
+import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import android.text.TextUtils;
 
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.connect.KeepAliveService;
 import org.thoughtcrime.securesms.notifications.MessageNotifierCompat;
 import org.thoughtcrime.securesms.util.Prefs;
 
@@ -64,6 +66,19 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     initializeListSummary((ListPreference) findPreference(Prefs.NOTIFICATION_PRIORITY_PREF));
 
     initializeRingtoneSummary(findPreference(Prefs.RINGTONE_PREF));
+
+
+    CheckBoxPreference reliableService =  this.findPreference("pref_reliable_service");
+    reliableService.setOnPreferenceChangeListener((preference, newValue) -> {
+      Context context = getContext();
+      boolean enabled = (Boolean) newValue;
+      if (enabled) {
+          KeepAliveService.startSelf(context);
+      } else {
+        context.stopService(new Intent(context, KeepAliveService.class));
+      }
+      return true;
+    });
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -135,10 +135,12 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
   }
 
   public static CharSequence getSummary(Context context) {
-    final int onCapsResId   = R.string.on;
-    final int offCapsResId  = R.string.off;
-
-    return context.getString(Prefs.isNotificationsEnabled(context) ? onCapsResId : offCapsResId);
+    boolean notificationsEnabled = Prefs.isNotificationsEnabled(context);
+    String ret = context.getString(notificationsEnabled ? R.string.on : R.string.off);
+    if (notificationsEnabled && !Prefs.reliableService(context)) {
+      ret += ", " + context.getString(R.string.pref_reliable_service) + " " + context.getString(R.string.off);
+    }
+    return ret;
   }
 
   private class NotificationPrivacyListener extends ListSummaryListener {

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -237,6 +237,15 @@ public class Prefs {
     return result==null? null : Uri.parse(result);
   }
 
+  public static boolean reliableService(Context context) {
+    try {
+      return getBooleanPreference(context, "pref_reliable_service", true);
+    }
+    catch(Exception e) {
+      return false;
+    }
+  }
+
   // vibrate
 
   public static boolean isNotificationVibrateEnabled(Context context) {


### PR DESCRIPTION
successor of https://github.com/deltachat/deltachat-android/pull/1302 - in fact, there were still some conditions in the code left.

now, the permantent-notification is really always shown, however, we also add a switch to override this. the wording of the switch, however, makes pretty clear that this is not encouraged:

<img src=https://user-images.githubusercontent.com/9800740/80492105-dbc35280-8963-11ea-8b8a-e8a69d84c405.png width=320>

