### PR TITLE
use wording 'Reliability service' for the permantent notification

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -468,9 +468,10 @@
     <string name="pref_background_default_color">Default color</string>
     <string name="pref_background_custom_image">Custom image</string>
     <string name="pref_background_custom_color">Custom color</string>
-    <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
-    <string name="pref_reliable_service">Reliable service</string>
-    <string name="pref_reliable_service_explain">Requires a permanent notification</string>
+    <!-- disabling the "Reliability service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
+    <string name="reliability_service">Reliability service</string>
+    <string name="reliability_service_explain">Requires a permanent notification</string>
+    <string name="reliability_service_enabled">Reliability service enabled</string>
 
 
     <!-- automatically delete message -->

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -61,7 +61,7 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="pref_reliable_service"
-            android:title="@string/pref_reliable_service"
-            android:summary="@string/pref_reliable_service_explain"/>
+            android:title="@string/reliability_service"
+            android:summary="@string/reliability_service_explain"/>
 
 </PreferenceScreen>

--- a/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
+++ b/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
@@ -102,7 +102,7 @@ public class KeepAliveService extends Service {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
 
         builder.setContentTitle(getString(R.string.app_name));
-        builder.setContentText(getString(R.string.notify_background_connection_enabled));
+        builder.setContentText(getString(R.string.reliability_service_enabled));
 
         if( Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN ) {
             builder.setPriority(NotificationCompat.PRIORITY_MIN);

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -138,7 +138,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     boolean notificationsEnabled = Prefs.isNotificationsEnabled(context);
     String ret = context.getString(notificationsEnabled ? R.string.on : R.string.off);
     if (notificationsEnabled && !Prefs.reliableService(context)) {
-      ret += ", " + context.getString(R.string.pref_reliable_service) + " " + context.getString(R.string.off);
+      ret += ", " + context.getString(R.string.reliability_service) + " " + context.getString(R.string.off);
     }
     return ret;
   }


### PR DESCRIPTION
this pr is about the name used for the permanent-notification switch and about unifying the wording, so that the user gets and idea that the switch belongs to the permanent-notification.

the idea is:

- have a more positive wording, sth. the user _wants_ to have

- the old "Background connection enabled" is very abstract - and also misleading as it may be understood as if the IMAP-server is working, network connected or so

- the wording is chosen so that the user gets the idea that disabling the notification has some drawbacks 

- the name of the switch using should be similar to the line displayed in the notification

screenshots:

<img width=310 src=https://user-images.githubusercontent.com/9800740/80592721-30c49e80-8a20-11ea-9ecc-8ae115122569.png> <img width=310 src=https://user-images.githubusercontent.com/9800740/80592725-315d3500-8a20-11ea-9d21-283c90a83b0b.png>

i think, we should also change the icon of the permantent notification, so that there are no two delta-chat icons, maybe we should just use something very common for that, eg. the arrows typically used to indicate "transfer". we cannot have _no_ icon.