### PR TITLE
more careful account switching

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -21,6 +21,9 @@ import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.FetchWorker;
+import org.thoughtcrime.securesms.connect.ForegroundDetector;
+import org.thoughtcrime.securesms.connect.KeepAliveService;
+import org.thoughtcrime.securesms.connect.NetworkStateReceiver;
 import org.thoughtcrime.securesms.crypto.PRNGFixes;
 import org.thoughtcrime.securesms.geolocation.DcLocationManager;
 import org.thoughtcrime.securesms.jobmanager.JobManager;
@@ -57,6 +60,13 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
 
     System.loadLibrary("native-utils");
     dcContext = new ApplicationDcContext(this);
+
+    new ForegroundDetector(ApplicationContext.getInstance(this));
+
+    BroadcastReceiver networkStateReceiver = new NetworkStateReceiver();
+    registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
+
+    KeepAliveService.maybeStartSelf(this);
 
     initializeRandomNumberFix();
     initializeLogging();

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -1,10 +1,8 @@
 package org.thoughtcrime.securesms.connect;
 
 import android.app.Activity;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -25,12 +23,10 @@ import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcLot;
 import com.b44t.messenger.DcMsg;
 
-import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.recipients.Recipient;
-import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.io.File;
@@ -76,13 +72,7 @@ public class ApplicationDcContext extends DcContext {
       Log.e(TAG, "Cannot create wakeLocks");
     }
 
-    new ForegroundDetector(ApplicationContext.getInstance(context));
     startThreads(0);
-
-    BroadcastReceiver networkStateReceiver = new NetworkStateReceiver();
-    context.registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
-
-    KeepAliveService.maybeStartSelf(context);
   }
 
   public void setStockTranslations() {


### PR DESCRIPTION
do not recreate/restart ForegroundDetector, NetworkStateReceiver, KeepAliveService on switching account.

these objects belong to the app, not to the account.

closes #1327, not sure of #1328 is related