### PR TITLE
Fix #1328 Missing notifications: initializeIncomingMessageNotifier() in ApplicationDcContext, not ApplicationContext

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -71,7 +71,6 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
     initializeRandomNumberFix();
     initializeLogging();
     initializeJobManager();
-    initializeIncomingMessageNotifier();
     ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
     MessageNotifierCompat.init(this);
 
@@ -138,23 +137,6 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
 
   private void initializeLogging() {
     SignalProtocolLoggerProvider.setProvider(new AndroidSignalProtocolLogger());
-  }
-
-  @SuppressLint("StaticFieldLeak")
-  private void initializeIncomingMessageNotifier() {
-
-    DcEventCenter dcEventCenter = dcContext.eventCenter;
-    dcEventCenter.addObserver(DcContext.DC_EVENT_INCOMING_MSG, new DcEventCenter.DcEventDelegate() {
-      @Override
-      public void handleEvent(int eventId, Object data1, Object data2) {
-        MessageNotifierCompat.updateNotification(((Long) data1).intValue(), ((Long) data2).intValue());
-      }
-
-      @Override
-      public boolean runOnMain() {
-        return false;
-      }
-    });
   }
 
   private void initializeJobManager() {

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -21,6 +21,9 @@ import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.FetchWorker;
+import org.thoughtcrime.securesms.connect.ForegroundDetector;
+import org.thoughtcrime.securesms.connect.KeepAliveService;
+import org.thoughtcrime.securesms.connect.NetworkStateReceiver;
 import org.thoughtcrime.securesms.crypto.PRNGFixes;
 import org.thoughtcrime.securesms.geolocation.DcLocationManager;
 import org.thoughtcrime.securesms.jobmanager.JobManager;
@@ -57,6 +60,13 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
 
     System.loadLibrary("native-utils");
     dcContext = new ApplicationDcContext(this);
+
+    new ForegroundDetector(ApplicationContext.getInstance(this));
+
+    BroadcastReceiver networkStateReceiver = new NetworkStateReceiver();
+    registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
+
+    KeepAliveService.maybeStartSelf(this);
 
     initializeRandomNumberFix();
     initializeLogging();

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -531,7 +531,7 @@ public class ApplicationDcContext extends DcContext {
         break;
 
       case DC_EVENT_INCOMING_MSG:
-        MessageNotifierCompat.updateNotification(((Long) data1).intValue(), ((Long) data2).intValue());
+        MessageNotifierCompat.updateNotification((int) data1, (int) data2); // updateNotification() makes sure to run in the correct thread
         if (eventCenter != null) {
           eventCenter.sendToObservers(event, data1, data2); // Other parts of the code are also interested in this event
         }

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -1,10 +1,8 @@
 package org.thoughtcrime.securesms.connect;
 
 import android.app.Activity;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -25,12 +23,10 @@ import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcLot;
 import com.b44t.messenger.DcMsg;
 
-import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.recipients.Recipient;
-import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.io.File;
@@ -76,13 +72,7 @@ public class ApplicationDcContext extends DcContext {
       Log.e(TAG, "Cannot create wakeLocks");
     }
 
-    new ForegroundDetector(ApplicationContext.getInstance(context));
     startThreads(0);
-
-    BroadcastReceiver networkStateReceiver = new NetworkStateReceiver();
-    context.registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
-
-    KeepAliveService.maybeStartSelf(context);
   }
 
   public void setStockTranslations() {

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -74,7 +74,6 @@ public class ApplicationDcContext extends DcContext {
       Log.e(TAG, "Cannot create wakeLocks");
     }
 
-    initializeIncomingMessageNotifier();
     startThreads(0);
   }
 
@@ -531,6 +530,14 @@ public class ApplicationDcContext extends DcContext {
         handleError(event, true, dataToString(data2));
         break;
 
+      case DC_EVENT_INCOMING_MSG:
+        MessageNotifierCompat.updateNotification(((Long) data1).intValue(), ((Long) data2).intValue());
+        if (eventCenter != null) {
+          eventCenter.sendToObservers(event, data1, data2); // Other parts of the code are also interested in this event
+        }
+        break;
+
+
       default: {
         final Object data1obj = data1IsString(event) ? dataToString(data1) : data1;
         final Object data2obj = data2IsString(event) ? dataToString(data2) : data2;
@@ -541,22 +548,6 @@ public class ApplicationDcContext extends DcContext {
       break;
     }
     return 0;
-  }
-
-  @SuppressLint("StaticFieldLeak")
-  private void initializeIncomingMessageNotifier() {
-
-    eventCenter.addObserver(DcContext.DC_EVENT_INCOMING_MSG, new DcEventCenter.DcEventDelegate() {
-      @Override
-      public void handleEvent(int eventId, Object data1, Object data2) {
-        MessageNotifierCompat.updateNotification(((Long) data1).intValue(), ((Long) data2).intValue());
-      }
-
-      @Override
-      public boolean runOnMain() {
-        return false;
-      }
-    });
   }
 
 }

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.connect;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -26,6 +27,7 @@ import com.b44t.messenger.DcMsg;
 import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
+import org.thoughtcrime.securesms.notifications.MessageNotifierCompat;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -72,6 +74,7 @@ public class ApplicationDcContext extends DcContext {
       Log.e(TAG, "Cannot create wakeLocks");
     }
 
+    initializeIncomingMessageNotifier();
     startThreads(0);
   }
 
@@ -538,6 +541,22 @@ public class ApplicationDcContext extends DcContext {
       break;
     }
     return 0;
+  }
+
+  @SuppressLint("StaticFieldLeak")
+  private void initializeIncomingMessageNotifier() {
+
+    eventCenter.addObserver(DcContext.DC_EVENT_INCOMING_MSG, new DcEventCenter.DcEventDelegate() {
+      @Override
+      public void handleEvent(int eventId, Object data1, Object data2) {
+        MessageNotifierCompat.updateNotification(((Long) data1).intValue(), ((Long) data2).intValue());
+      }
+
+      @Override
+      public boolean runOnMain() {
+        return false;
+      }
+    });
   }
 
 }


### PR DESCRIPTION
The IncomingMessageNotifier was not initialized again after switching accounts.

This now also contains Björn's PR in the hope of having no merge conflicts.

~Code style might need improvements.~
Update: DC_EVENT_INCOMING_MSG is now handled directly in handleEvent().
sendToObservers() made sure not to execute it on a background thread but updateNotification() does this, too, so everything is fine. (and no, I won't use fallthrough for this :wink:)