### PR TITLE
tweak device-msg that explains the permantent-notification

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -692,7 +692,7 @@
 
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
     <!-- this message is shown in the device chat, starting in version 1.6, it should explain the need for the permanent-notifiation and also use the same wording as used there (see "Background connection enabled") -->
-    <string name="device_talk_background_connection_android">You may already have noticed, that there is a new hint \"Background connection enabled\" shown by the system.\n\nThis hint is required to get reliable background notifications.  Without the hint, the operating system would probably kill the connection between Delta Chat and your server -\nif you think, this is weird - we totally agree - but so many manufacturers require exactly that 👉 https://dontkillmyapp.com\n\nHowever, we are happy that we could improve the receiving of messages in background with this change and could fulfil the requests of many users - thanks for reporting 🤗</string>
+    <string name="device_talk_background_connection_android">You may already have noticed, that there is a hint \"Background connection enabled\" shown by the system.\n\n👉 The hint normally prevents the operating system from killing the connection between Delta Chat and your server.\n\n👉 If the hint disappears without any action on your part, the connection has probably been killed anyway.\nIf you think, this is weird - we totally agree - but many manufacturers do exactly that. The site https://dontkillmyapp.com shows some workarounds.\n\nHowever, we are happy that we could improve the receiving of messages in background with this change and could fulfil the requests of many users - thanks for reporting 🤗</string>
 
 
 </resources>


### PR DESCRIPTION
this pr tweaks the device-message that explains the permantant-notification, esp. it point out that it also acts as an indicator that things may not work as expected and make the link to dontkillmyapp.com clearer.

if we can merge this is quickly, there are changes that it gets translated :)

![Screen Shot 2020-05-02 at 14 02 02](https://user-images.githubusercontent.com/9800740/80863555-8c3f9800-8c7d-11ea-9793-7847d21865d2.png)
