### PR TITLE
fix calling dc_add_address_book()

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -65,8 +65,15 @@ public class ContactAccessor {
     List<String> mailList = new ArrayList<>();
     Set<String> contactPhotoIdentifiers = new HashSet<>();
     while (systemContactsCursor != null && systemContactsCursor.moveToNext()) {
+
       String name = systemContactsCursor.getString(CONTACT_CURSOR_NAME);
+      name = name.replace("\r", ""); // remove characters later used as field separator
+      name = name.replace("\n", "");
+
       String mail = systemContactsCursor.getString(CONTACT_CURSOR_MAIL);
+      mail = mail.replace("\r", ""); // remove characters later used as field separator
+      mail = mail.replace("\n", "");
+
       String contactId = systemContactsCursor.getString(CONTACT_CURSOR_CONTACT_ID);
       if (contactId != null) {
         String identifier = name + mail;


### PR DESCRIPTION
this pr makes sure, dc_add_address_book() does not get names or mail addresses with lineends.

if, for whatever reason, this happend in the past, name and mails could get ot of order, fixes #1334 