### PR TITLE
Relay to multiple contacts, rework message relaying

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -362,6 +362,7 @@
     <!-- Translators: Title shown above a chat/contact list; the user selects the recipient of the messages he wants to forward to -->
     <string name="forward_to">Forward to…</string>
     <string name="share_multiple_attachments">Do you want to send %1$d files to the selected chat?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
+    <string name="share_multiple_attachments_multiple_chats">Do you want to send %1$d file(s) to %2$d chats?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
     <string name="share_abort">Sharing aborted due to missing permissions.</string>
 
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -219,6 +219,7 @@
         <item quantity="other">Delete %d messages here and on the server?</item>
     </plurals>
     <string name="ask_forward">Forward messages to %1$s?</string>
+    <string name="ask_forward_multiple">Forward messages to %1$d chats?</string>
     <string name="ask_export_attachment">Export attachment? Exporting attachments will allow any other apps on your device to access them.\n\nContinue?</string>
     <string name="ask_block_contact">Block this contact? You will no longer receive messages from this contact.</string>
     <string name="ask_unblock_contact">Unblock this contact? You will once again be able to receive messages from this contact.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -362,9 +362,9 @@
     <!-- share and forward messages -->
     <!-- Translators: Title shown above a chat/contact list; the user selects the recipient of the messages he wants to forward to -->
     <string name="forward_to">Forward to…</string>
-    <string name="share_multiple_attachments">Do you want to send %1$d files to the selected chat?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
-    <string name="share_multiple_attachments_multiple_chats">Do you want to send %1$d file(s) to %2$d chats?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
-    <string name="share_text_multiple_chats">Do you want to send this text to %1$d chats?\n\n\"%2$s\"</string>
+    <string name="share_multiple_attachments">Send %1$d files to the selected chat?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
+    <string name="share_multiple_attachments_multiple_chats">Send %1$d file(s) to %2$d chats?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
+    <string name="share_text_multiple_chats">Send this text to %1$d chats?\n\n\"%2$s\"</string>
     <string name="share_abort">Sharing aborted due to missing permissions.</string>
 
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -363,6 +363,7 @@
     <string name="forward_to">Forward to…</string>
     <string name="share_multiple_attachments">Do you want to send %1$d files to the selected chat?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
     <string name="share_multiple_attachments_multiple_chats">Do you want to send %1$d file(s) to %2$d chats?\n\nThe files are sent unmodified in their original size, eg. images and videos are not recoded.</string>
+    <string name="share_text_multiple_chats">Do you want to send this text to %1$d chats?\n\n\"%2$s\"</string>
     <string name="share_abort">Sharing aborted due to missing permissions.</string>
 
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -661,7 +661,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private void handleSharing() {
     ArrayList<Uri> uriList =  RelayUtil.getSharedUris(this);
     RelayUtil.resetRelayingMessageContent(this);
-    if (uriList == null) return;
     if (uriList.size() > 1) {
       String message = String.format(getString(R.string.share_multiple_attachments), uriList.size());
       new AlertDialog.Builder(this)

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -669,16 +669,17 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
               .setPositiveButton(R.string.menu_send, (dialog, which) -> SendMessageUtil.immediatelyRelay(this, chatId))
               .show();
     } else {
-        if (uriList.size() == 1) {
-          DcMsg message = SendMessageUtil.createMessage(this, uriList.get(0), getSharedText(this));
-          dcContext.setDraft(chatId, message);
+      if (uriList.isEmpty()) {
+        dcContext.setDraft(chatId, SendMessageUtil.createMessage(this, null, getSharedText(this)));
+      } else {
+        dcContext.setDraft(chatId, SendMessageUtil.createMessage(this, uriList.get(0), getSharedText(this)));
+      }
+      initializeDraft().addListener(new AssertedSuccessListener<Boolean>() {
+        @Override
+        public void onSuccess(Boolean result) {
+          isShareDraftInitialized = true;
         }
-        initializeDraft().addListener(new AssertedSuccessListener<Boolean>() {
-          @Override
-          public void onSuccess(Boolean result) {
-            isShareDraftInitialized = true;
-          }
-        });
+      });
     }
     RelayUtil.resetRelayingMessageContent(this);
   }
@@ -686,27 +687,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   ///// Initializers
 
   private ListenableFuture<Boolean> initializeDraft() {
-    final SettableFuture<Boolean> result = new SettableFuture<>();
-
-    final String    draftText      = getIntent().getStringExtra(TEXT_EXTRA);
-    final Uri       draftMedia     = getIntent().getData();
-    final MediaType draftMediaType = MediaType.from(getIntent().getType());
-
-    if (draftText != null) {
-      composeText.setText(draftText);
-      result.set(true);
-    }
-    if (draftMedia != null && draftMediaType != null) {
-      return setMedia(draftMedia, draftMediaType);
-    }
-
-    if (draftText == null && draftMedia == null && draftMediaType == null) {
-      return initializeDraftFromDatabase();
-    } else {
-      updateToggleButtonState();
-      result.set(false);
-    }
-
+    ListenableFuture<Boolean> result = initializeDraftFromDatabase();
+    updateToggleButtonState();
     return result;
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -660,15 +660,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleSharing() {
     ArrayList<Uri> uriList =  RelayUtil.getSharedUris(this);
-    RelayUtil.resetRelayingMessageContent(this);
     if (uriList.size() > 1) {
       String message = String.format(getString(R.string.share_multiple_attachments), uriList.size());
       new AlertDialog.Builder(this)
               .setMessage(message)
               .setCancelable(false)
-              .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {
-                finish();
-              }))
+              .setNegativeButton(android.R.string.cancel, ((dialog, which) -> finish()))
               .setPositiveButton(R.string.menu_send, (dialog, which) -> SendMessageUtil.immediatelyRelay(this, chatId))
               .show();
     } else {
@@ -683,6 +680,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           }
         });
     }
+    RelayUtil.resetRelayingMessageContent(this);
   }
 
   ///// Initializers

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1108,7 +1108,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     return future;
   }
 
-  private static class RelayingTask extends AsyncTask<Void, Void, Void> {
+  static class RelayingTask extends AsyncTask<Void, Void, Void> {
 
     WeakReference<Activity> activityRef;
     int chatId;
@@ -1143,8 +1143,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     private void handleSharing(Activity activity) {
       DcContext dcContext = DcHelper.getContext(activity);
       ArrayList<Uri> uris = getSharedUris(activity);
+      Log.e(TAG, "HandleSharing, size: " + uris.size());
       try {
         for(Uri uri : uris) {
+          Log.e(TAG, "HandleSharing "+uri);
           DcMsg message = createMessage(activityRef.get(), uri);
           dcContext.sendMsg(chatId, message);
           cleanup(activity, uri);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -129,6 +129,7 @@ import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.isForwarding;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.isSharing;
+import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
 
 /**
  * Activity for displaying a message thread, as well as
@@ -680,8 +681,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           isShareDraftInitialized = true;
         }
       });
+      resetRelayingMessageContent(this);
     }
-    RelayUtil.resetRelayingMessageContent(this);
   }
 
   ///// Initializers

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -18,7 +18,6 @@ package org.thoughtcrime.securesms;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
@@ -103,7 +102,7 @@ import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.RelayUtil;
-import org.thoughtcrime.securesms.util.SendMessageUtil;
+import org.thoughtcrime.securesms.util.SendRelayedMessageUtil;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -117,7 +116,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -642,7 +640,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private void handleForwarding() {
     DcChat dcChat = dcContext.getChat(chatId);
     if (dcChat.isSelfTalk()) {
-      SendMessageUtil.immediatelyRelay(this, chatId);
+      SendRelayedMessageUtil.immediatelyRelay(this, chatId);
     } else {
       String name = dcChat.getName();
       if (!dcChat.isGroup()) {
@@ -653,7 +651,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       }
       new AlertDialog.Builder(this)
               .setMessage(getString(R.string.ask_forward, name))
-              .setPositiveButton(R.string.ok, (dialogInterface, i) -> SendMessageUtil.immediatelyRelay(this, chatId))
+              .setPositiveButton(R.string.ok, (dialogInterface, i) -> SendRelayedMessageUtil.immediatelyRelay(this, chatId))
               .setNegativeButton(R.string.cancel, (dialogInterface, i) -> finish())
               .show();
     }
@@ -667,13 +665,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
               .setMessage(message)
               .setCancelable(false)
               .setNegativeButton(android.R.string.cancel, ((dialog, which) -> finish()))
-              .setPositiveButton(R.string.menu_send, (dialog, which) -> SendMessageUtil.immediatelyRelay(this, chatId))
+              .setPositiveButton(R.string.menu_send, (dialog, which) -> SendRelayedMessageUtil.immediatelyRelay(this, chatId))
               .show();
     } else {
       if (uriList.isEmpty()) {
-        dcContext.setDraft(chatId, SendMessageUtil.createMessage(this, null, getSharedText(this)));
+        dcContext.setDraft(chatId, SendRelayedMessageUtil.createMessage(this, null, getSharedText(this)));
       } else {
-        dcContext.setDraft(chatId, SendMessageUtil.createMessage(this, uriList.get(0), getSharedText(this)));
+        dcContext.setDraft(chatId, SendRelayedMessageUtil.createMessage(this, uriList.get(0), getSharedText(this)));
       }
       initializeDraft().addListener(new AssertedSuccessListener<Boolean>() {
         @Override

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -198,7 +198,6 @@ public class ConversationListFragment extends Fragment
                     .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {}))
                     .setPositiveButton(R.string.menu_send, (dialog, which) -> {
                       SendMessageUtil.immediatelyRelay(getActivity(), selectedChats.toArray(new Long[selectedChats.size()]));
-                      resetRelayingMessageContent(getActivity());
                       actionMode.finish();
                       actionMode = null;
                       // Start this activity again, this time with an intent without sharing:

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -193,10 +193,7 @@ public class ConversationListFragment extends Fragment
                     .setPositiveButton(R.string.menu_send, (dialog, which) -> {
                       Log.e(TAG, "sending uris: " + getSharedUris(getActivity()).size() + " text: "+getSharedText(getActivity()));
                       final Set<Long> selectedChats = getListAdapter().getBatchSelections();
-                      for (long chatId : selectedChats) {
-                        Log.e(TAG, "...to "+chatId);
-                        SendMessageUtil.immediatelyRelay(getActivity(), (int) chatId);
-                      }
+                      SendMessageUtil.immediatelyRelay(getActivity(), selectedChats);
                       resetRelayingMessageContent(getActivity());
                       actionMode.finish();
                       actionMode = null;

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -66,7 +66,7 @@ import org.thoughtcrime.securesms.connect.DcChatlistLoader;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.util.RelayUtil;
-import org.thoughtcrime.securesms.util.SendMessageUtil;
+import org.thoughtcrime.securesms.util.SendRelayedMessageUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.guava.Optional;
 import org.thoughtcrime.securesms.util.task.SnackbarAsyncTask;
@@ -83,7 +83,6 @@ import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
 import static org.thoughtcrime.securesms.util.RelayUtil.isForwarding;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
-import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
 
 
 public class ConversationListFragment extends Fragment
@@ -200,7 +199,7 @@ public class ConversationListFragment extends Fragment
                     .setCancelable(false)
                     .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {}))
                     .setPositiveButton(R.string.menu_send, (dialog, which) -> {
-                      SendMessageUtil.immediatelyRelay(getActivity(), selectedChats.toArray(new Long[selectedChats.size()]));
+                      SendRelayedMessageUtil.immediatelyRelay(getActivity(), selectedChats.toArray(new Long[selectedChats.size()]));
                       actionMode.finish();
                       actionMode = null;
                       // Start this activity again, this time with an intent without sharing:

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -39,7 +39,6 @@ import androidx.appcompat.view.ActionMode;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -78,7 +77,6 @@ import java.util.Set;
 
 import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
-import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
@@ -181,7 +179,13 @@ public class ConversationListFragment extends Fragment
     if (isRelayingMessageContent(getActivity())) {
       if (isActionMode) {
         fab.setOnClickListener(v -> {
-          String message = String.format("Do you want to share?");
+          final Set<Long> selectedChats = getListAdapter().getBatchSelections();
+          String message = String.format(
+                  Locale.getDefault(),
+                  getString(R.string.share_multiple_attachments_multiple_chats),
+                  getSharedUris(getActivity()).size(),
+                  selectedChats.size()
+          );
           Context context = getContext();
           if (context != null) {
             new AlertDialog.Builder(context)
@@ -189,8 +193,7 @@ public class ConversationListFragment extends Fragment
                     .setCancelable(false)
                     .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {}))
                     .setPositiveButton(R.string.menu_send, (dialog, which) -> {
-                      final Set<Long> selectedChats = getListAdapter().getBatchSelections();
-                      SendMessageUtil.immediatelyRelay(getActivity(), selectedChats);
+                      SendMessageUtil.immediatelyRelay(getActivity(), selectedChats.toArray(new Long[selectedChats.size()]));
                       resetRelayingMessageContent(getActivity());
                       actionMode.finish();
                       actionMode = null;

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -185,7 +185,7 @@ public class ConversationListFragment extends Fragment
           final Set<Long> selectedChats = getListAdapter().getBatchSelections();
           ArrayList<Uri> uris = getSharedUris(getActivity());
           String message;
-          if (uris.size() > 1) {
+          if (uris.size() > 0) {
             message = String.format(Locale.getDefault(), getString(R.string.share_multiple_attachments_multiple_chats), uris.size(), selectedChats.size());
           } else {
             message = String.format(Locale.getDefault(), getString(R.string.share_text_multiple_chats), selectedChats.size(), getSharedText(getActivity()));

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -180,7 +180,6 @@ public class ConversationListFragment extends Fragment
     Intent intent = new Intent(getActivity(), NewConversationActivity.class);
     if (isRelayingMessageContent(getActivity())) {
       if (isActionMode) {
-        Log.e(TAG, "init fab actionmode");
         fab.setOnClickListener(v -> {
           String message = String.format("Do you want to share?");
           Context context = getContext();
@@ -190,7 +189,6 @@ public class ConversationListFragment extends Fragment
                     .setCancelable(false)
                     .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {}))
                     .setPositiveButton(R.string.menu_send, (dialog, which) -> {
-                      Log.e(TAG, "sending uris: " + getSharedUris(getActivity()).size() + " text: "+getSharedText(getActivity()));
                       final Set<Long> selectedChats = getListAdapter().getBatchSelections();
                       SendMessageUtil.immediatelyRelay(getActivity(), selectedChats);
                       resetRelayingMessageContent(getActivity());
@@ -203,11 +201,9 @@ public class ConversationListFragment extends Fragment
         });
       } else {
         acquireRelayMessageContent(getActivity(), intent);
-        Log.e(TAG, "init fab nonactionmode");
         fab.setOnClickListener(v -> getActivity().startActivityForResult(intent, REQUEST_RELAY));
       }
     } else {
-      Log.e(TAG, "init fab nonrelaying");
       fab.setOnClickListener(v -> startActivity(intent));
     }
   }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -188,8 +188,7 @@ public class ConversationListFragment extends Fragment
             new AlertDialog.Builder(context)
                     .setMessage(message)
                     .setCancelable(false)
-                    .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {
-                    }))
+                    .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {}))
                     .setPositiveButton(R.string.menu_send, (dialog, which) -> {
                       Log.e(TAG, "sending uris: " + getSharedUris(getActivity()).size() + " text: "+getSharedText(getActivity()));
                       final Set<Long> selectedChats = getListAdapter().getBatchSelections();

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -81,6 +81,7 @@ import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
+import static org.thoughtcrime.securesms.util.RelayUtil.isForwarding;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
 
@@ -185,7 +186,9 @@ public class ConversationListFragment extends Fragment
           final Set<Long> selectedChats = getListAdapter().getBatchSelections();
           ArrayList<Uri> uris = getSharedUris(getActivity());
           String message;
-          if (uris.size() > 0) {
+          if (isForwarding(getActivity())) {
+            message = String.format(Locale.getDefault(), getString(R.string.ask_forward_multiple), selectedChats.size());
+          } else if (uris.size() > 0) {
             message = String.format(Locale.getDefault(), getString(R.string.share_multiple_attachments_multiple_chats), uris.size(), selectedChats.size());
           } else {
             message = String.format(Locale.getDefault(), getString(R.string.share_text_multiple_chats), selectedChats.size(), getSharedText(getActivity()));

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -194,7 +194,8 @@ public class ConversationListFragment extends Fragment
                       resetRelayingMessageContent(getActivity());
                       actionMode.finish();
                       actionMode = null;
-                      startActivity(new Intent(getActivity(), (ConversationListActivity.class)));
+                      // Start this activity again, this time with an intent without sharing:
+                      startActivity(new Intent(getActivity(), ConversationListActivity.class));
                     })
                     .show();
           }
@@ -498,6 +499,7 @@ public class ConversationListFragment extends Fragment
   }
 
   private void updateActionModeItems(Menu menu) {
+    // We do not show action mode icons when relaying (= sharing or forwarding).
     if (!isRelayingMessageContent(getActivity())) {
       MenuItem pinItem = menu.findItem(R.id.menu_pin_selected);
       if (areSomeSelectedChatsUnpinned()) {

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -77,6 +77,8 @@ import java.util.Set;
 
 import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
+import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
+import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 
 
@@ -175,7 +177,6 @@ public class ConversationListFragment extends Fragment
   private void initializeFabClickListener(boolean isActionMode) {
     Intent intent = new Intent(getActivity(), NewConversationActivity.class);
     if (isRelayingMessageContent(getActivity())) {
-      acquireRelayMessageContent(getActivity(), intent);
       if (isActionMode) {
         Log.e(TAG, "init fab actionmode");
         fab.setOnClickListener(v -> {
@@ -188,7 +189,7 @@ public class ConversationListFragment extends Fragment
                     .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {
                     }))
                     .setPositiveButton(R.string.menu_send, (dialog, which) -> {
-                      Log.e(TAG, "sending");
+                      Log.e(TAG, "sending uris: " + getSharedUris(getActivity()).size() + " text: "+getSharedText(getActivity()));
                       final Set<Long> selectedChats = getListAdapter().getBatchSelections();
                       for (long chatId : selectedChats) {
                         Log.e(TAG, "...to "+chatId);
@@ -199,6 +200,7 @@ public class ConversationListFragment extends Fragment
           }
         });
       } else {
+        acquireRelayMessageContent(getActivity(), intent);
         Log.e(TAG, "init fab nonactionmode");
         fab.setOnClickListener(v -> getActivity().startActivityForResult(intent, REQUEST_RELAY));
       }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -71,12 +72,14 @@ import org.thoughtcrime.securesms.util.guava.Optional;
 import org.thoughtcrime.securesms.util.task.SnackbarAsyncTask;
 import org.thoughtcrime.securesms.util.views.ProgressDialog;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
 import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
+import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
@@ -180,12 +183,13 @@ public class ConversationListFragment extends Fragment
       if (isActionMode) {
         fab.setOnClickListener(v -> {
           final Set<Long> selectedChats = getListAdapter().getBatchSelections();
-          String message = String.format(
-                  Locale.getDefault(),
-                  getString(R.string.share_multiple_attachments_multiple_chats),
-                  getSharedUris(getActivity()).size(),
-                  selectedChats.size()
-          );
+          ArrayList<Uri> uris = getSharedUris(getActivity());
+          String message;
+          if (uris.size() > 1) {
+            message = String.format(Locale.getDefault(), getString(R.string.share_multiple_attachments_multiple_chats), uris.size(), selectedChats.size());
+          } else {
+            message = String.format(Locale.getDefault(), getString(R.string.share_text_multiple_chats), selectedChats.size(), getSharedText(getActivity()));
+          }
           Context context = getContext();
           if (context != null) {
             new AlertDialog.Builder(context)

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -66,6 +66,7 @@ import org.thoughtcrime.securesms.connect.DcChatlistLoader;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.util.RelayUtil;
+import org.thoughtcrime.securesms.util.SendMessageUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.guava.Optional;
 import org.thoughtcrime.securesms.util.task.SnackbarAsyncTask;
@@ -80,6 +81,7 @@ import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageConte
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
+import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
 
 
 public class ConversationListFragment extends Fragment
@@ -193,8 +195,12 @@ public class ConversationListFragment extends Fragment
                       final Set<Long> selectedChats = getListAdapter().getBatchSelections();
                       for (long chatId : selectedChats) {
                         Log.e(TAG, "...to "+chatId);
-                        new ConversationActivity.RelayingTask(getActivity(), (int) chatId).execute();
+                        SendMessageUtil.immediatelyRelay(getActivity(), (int) chatId);
                       }
+                      resetRelayingMessageContent(getActivity());
+                      actionMode.finish();
+                      actionMode = null;
+                      startActivity(new Intent(getActivity(), (ConversationListActivity.class)));
                     })
                     .show();
           }

--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@ -62,11 +62,14 @@ public class RelayUtil {
     }
 
     public static @NonNull ArrayList<Uri> getSharedUris(Activity activity) {
-        try {
-            return activity.getIntent().getParcelableArrayListExtra(SHARED_URIS);
-        } catch (NullPointerException npe) {
-            return new ArrayList<>();
+        if (activity != null) {
+            Intent i = activity.getIntent();
+            if (i != null) {
+                ArrayList<Uri> uris = i.getParcelableArrayListExtra(SHARED_URIS);
+                if (uris != null) return uris;
+            }
         }
+        return new ArrayList<>();
     }
 
     public static String getSharedText(Activity activity) {

--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@ -61,11 +61,11 @@ public class RelayUtil {
         }
     }
 
-    public static ArrayList<Uri> getSharedUris(Activity activity) {
+    public static @NonNull ArrayList<Uri> getSharedUris(Activity activity) {
         try {
             return activity.getIntent().getParcelableArrayListExtra(SHARED_URIS);
         } catch (NullPointerException npe) {
-            return null;
+            return new ArrayList<>();
         }
     }
 
@@ -106,7 +106,7 @@ public class RelayUtil {
             if (isDirectSharing(currentActivity)) {
                 newActivityIntent.putExtra(DIRECT_SHARING_CHAT_ID, getDirectSharingChatId(currentActivity));
             }
-            if (getSharedUris(currentActivity) != null) {
+            if (!getSharedUris(currentActivity).isEmpty()) {
                 newActivityIntent.putParcelableArrayListExtra(SHARED_URIS, getSharedUris(currentActivity));
             }
             if (getSharedText(currentActivity) != null) {

--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@ -76,6 +76,15 @@ public class RelayUtil {
         }
     }
 
+    public static void resetSharedText(Activity activity) {
+        try {
+            activity.getIntent().removeExtra(TEXT_EXTRA);
+        } catch (NullPointerException npe) {
+            npe.printStackTrace();
+        }
+    }
+
+
     public static void resetRelayingMessageContent(Activity activity) {
         try {
             activity.getIntent().removeExtra(FORWARDED_MESSAGE_IDS);

--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.util;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
+
 import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
@@ -131,6 +132,5 @@ public class RelayUtil {
     public static void setDirectSharing(Intent composeIntent, int chatId) {
         composeIntent.putExtra(DIRECT_SHARING_CHAT_ID, chatId);
     }
-
 
 }

--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@ -53,7 +53,7 @@ public class RelayUtil {
         }
     }
 
-    public static int[] getForwardedMessageIDs(Activity activity) {
+    static int[] getForwardedMessageIDs(Activity activity) {
         try {
             return activity.getIntent().getIntArrayExtra(FORWARDED_MESSAGE_IDS);
         } catch (NullPointerException npe) {
@@ -74,14 +74,6 @@ public class RelayUtil {
             return activity.getIntent().getStringExtra(TEXT_EXTRA);
         } catch (NullPointerException npe) {
             return null;
-        }
-    }
-
-    public static void resetSharedText(Activity activity) {
-        try {
-            activity.getIntent().removeExtra(TEXT_EXTRA);
-        } catch (NullPointerException npe) {
-            npe.printStackTrace();
         }
     }
 

--- a/src/org/thoughtcrime/securesms/util/SendMessageUtil.java
+++ b/src/org/thoughtcrime/securesms/util/SendMessageUtil.java
@@ -1,0 +1,122 @@
+package org.thoughtcrime.securesms.util;
+
+import android.app.Activity;
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.b44t.messenger.DcContext;
+import com.b44t.messenger.DcMsg;
+
+import org.thoughtcrime.securesms.ConversationActivity;
+import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.mms.PartAuthority;
+import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
+
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+
+import static android.app.Activity.RESULT_OK;
+import static org.thoughtcrime.securesms.util.RelayUtil.getForwardedMessageIDs;
+import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
+import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
+import static org.thoughtcrime.securesms.util.RelayUtil.isForwarding;
+import static org.thoughtcrime.securesms.util.RelayUtil.isSharing;
+
+public class SendMessageUtil {
+  private static final String TAG = SendMessageUtil.class.getSimpleName();
+
+  public static void immediatelyRelay(Activity activity, int chatId) {
+    activity.setResult(RESULT_OK);
+    if (isForwarding(activity)) {
+      handleForwarding(activity, chatId);
+    } else if (isSharing(activity)) {
+      handleSharing(activity, chatId);
+    }
+  }
+
+  private static void handleForwarding(Activity activity, int chatId) {
+    DcContext dcContext = DcHelper.getContext(activity);
+    dcContext.forwardMsgs(getForwardedMessageIDs(activity), chatId);
+  }
+
+  private static void handleSharing(Activity activity, int chatId) {
+    DcContext dcContext = DcHelper.getContext(activity);
+    ArrayList<Uri> uris = getSharedUris(activity);
+
+    Log.e(TAG, "HandleSharing, size: " + uris.size()+" text: "+ getSharedText(activity));
+    DcMsg textMessage = createMessage(activity, null, getSharedText(activity));
+    dcContext.sendMsg(chatId, textMessage);
+    for(Uri uri : uris) {
+      Log.e(TAG, "HandleSharing "+uri + " text: "+ getSharedText(activity));
+      DcMsg message = createMessage(activity, uri, null);
+      dcContext.sendMsg(chatId, message);
+      cleanup(activity, uri);
+    }
+  }
+
+  private static void cleanup(Context context, final @Nullable Uri uri) {
+    if (uri != null && PersistentBlobProvider.isAuthority(context, uri)) {
+      Log.w(TAG, "cleaning up " + uri);
+      PersistentBlobProvider.getInstance(context).delete(context, uri);
+    }
+  }
+
+  public static DcMsg createMessage(Context context, Uri uri, String text) throws NullPointerException {
+    DcContext dcContext = DcHelper.getContext(context);
+    DcMsg message;
+    String mimeType = MediaUtil.getMimeType(context, uri);
+    if (uri == null) {
+      message = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+    } else if (MediaUtil.isImageType(mimeType)) {
+      message = new DcMsg(dcContext, DcMsg.DC_MSG_IMAGE);
+    }
+    else if (MediaUtil.isAudioType(mimeType)) {
+      message = new DcMsg(dcContext,DcMsg.DC_MSG_AUDIO);
+    }
+    else if (MediaUtil.isVideoType(mimeType)) {
+      message = new DcMsg(dcContext, DcMsg.DC_MSG_VIDEO);
+    }
+    else {
+      message = new DcMsg(dcContext, DcMsg.DC_MSG_FILE);
+    }
+
+    if (uri != null) {
+      message.setFile(getRealPathFromUri(context, uri), mimeType);
+    }
+    message.setText(text);
+    return message;
+  }
+
+  private static String getRealPathFromUri(Context context, Uri uri) throws NullPointerException {
+    ApplicationDcContext dcContext = DcHelper.getContext(context);
+    try {
+      String filename = uri.getPathSegments().get(2); // Get real file name from Uri
+      String ext = "";
+      int i = filename.lastIndexOf(".");
+      if(i>=0) {
+        ext = filename.substring(i);
+        filename = filename.substring(0, i);
+      }
+      String path = dcContext.getBlobdirFile(filename, ext);
+
+      // copy content to this file
+      if(path != null) {
+        InputStream inputStream = PartAuthority.getAttachmentStream(context, uri);
+        OutputStream outputStream = new FileOutputStream(path);
+        Util.copy(inputStream, outputStream);
+      }
+
+      return path;
+    }
+    catch(Exception e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/util/SendMessageUtil.java
+++ b/src/org/thoughtcrime/securesms/util/SendMessageUtil.java
@@ -25,6 +25,7 @@ import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
 import static org.thoughtcrime.securesms.util.RelayUtil.isForwarding;
 import static org.thoughtcrime.securesms.util.RelayUtil.isSharing;
+import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
 
 public class SendMessageUtil {
   private static final String TAG = SendMessageUtil.class.getSimpleName();
@@ -37,14 +38,17 @@ public class SendMessageUtil {
     activity.setResult(RESULT_OK);
     if (isForwarding(activity)) {
       int[] forwardedMessageIDs = getForwardedMessageIDs(activity);
+      resetRelayingMessageContent(activity);
       Util.runOnAnyBackgroundThread(() -> {
         for (long chatId : chatIds) {
           handleForwarding(activity, (int) chatId, forwardedMessageIDs);
         }
+
       });
     } else if (isSharing(activity)) {
       ArrayList<Uri> sharedUris = getSharedUris(activity);
       String sharedText = getSharedText(activity);
+      resetRelayingMessageContent(activity);
       Util.runOnAnyBackgroundThread(() -> {
         for (long chatId : chatIds) {
           handleSharing(activity, (int) chatId, sharedUris, sharedText);

--- a/src/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -17,7 +17,6 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Collection;
 
 import static android.app.Activity.RESULT_OK;
 import static org.thoughtcrime.securesms.util.RelayUtil.getForwardedMessageIDs;
@@ -27,8 +26,8 @@ import static org.thoughtcrime.securesms.util.RelayUtil.isForwarding;
 import static org.thoughtcrime.securesms.util.RelayUtil.isSharing;
 import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
 
-public class SendMessageUtil {
-  private static final String TAG = SendMessageUtil.class.getSimpleName();
+public class SendRelayedMessageUtil {
+  private static final String TAG = SendRelayedMessageUtil.class.getSimpleName();
 
   public static void immediatelyRelay(Activity activity, int chatId) {
     immediatelyRelay(activity, new Long[]{(long) chatId});


### PR DESCRIPTION
Fix #1340.

Also, I did extensive testing of message relaying:
- I. share and II. forward
- a. text
  b. text and one image
  c. 2 images
  d. 1 file (unknown type)
  e. 2 files (unknown type)
- to:
  1. 1 chat (just tap on it)
  2. If applicable: go back and forth a bit to test drafts
  3. 2 chats (multi-relaying)

and some of the bugs I found and fixed were probably already there before, although I did not test this.

After fixing things, I went through this list again and everything worked.

Seems like at some places in the UI the chatId is saved as a long, which seems not to make much sense because the core saves them as int. Anyway, I had to cast them.

