### PR TITLE
prep 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Delta Chat Android Changelog
 
 ## v1.8.0
-2020-05-10
+2020-05-11
 
 * by default, the permantent notification is no longer shown;
   the background fetch realibility depends on the system and the
   permantent notification can be enabled at "Settings / Notifications" as needed
-* bug fixes
+* fix a bug that stops receiving messages under some circumstances
+* more bug fixes
 * update translations
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Delta Chat Android Changelog
 
+## v1.8.0
+2020-05-10
+
+* by default, the permantent notification is no longer shown;
+  the background fetch realibility depends on the system and the
+  permantent notification can be enabled at "Settings / Notifications" as needed
+* bug fixes
+* update translations
+
+
 ## v1.6.2
 2020-05-02
 
@@ -19,6 +29,8 @@
 * new experimental feature that allows switching the account in use
 * improve interaction with traditional mail clients
 * improved onboarding when the provider returns a link
+* to improve background fetch, show a permantent notification by default
+* the permantent notification can be disabled at "Settins / Notifications"
 * bug fixes
 * add Indonesian and Persian translations, update other translations
 

--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,8 @@ android {
     }
 
     defaultConfig {
-        versionCode 580
-        versionName "1.7.0"
+        versionCode 581
+        versionName "1.8.0"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -693,6 +693,7 @@
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
     <!-- this message is shown in the device chat, starting in version 1.6, it should explain the need for the permanent-notifiation and also use the same wording as used there (see "Background connection enabled") -->
     <string name="device_talk_background_connection_android">You may already have noticed, that there is a hint \"Background connection enabled\" shown by the system.\n\n👉 The hint normally prevents the operating system from killing the connection between Delta Chat and your server.\n\n👉 If the hint disappears without any action on your part, the connection has probably been killed anyway.\nIf you think this is weird, we totally agree - but many manufacturers do exactly that. The site https://dontkillmyapp.com shows some workarounds.\n\nHowever, we are happy that we could improve the receiving of messages in background with this change and could fulfil the requests of many users - thanks for reporting 🤗</string>
+    <string name="device_talk_background_connection2_android">You can now enable and disabled the \"Background connection\" as needed at \"Settings / Notifications\".</string>
 
 
 </resources>

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -7,6 +7,13 @@
                             android:title="@string/pref_notifications"
                             android:defaultValue="true" />
 
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:dependency="pref_key_enable_notifications"
+            android:defaultValue="false"
+            android:key="pref_reliable_service"
+            android:title="@string/pref_reliable_service"
+            android:summary="@string/pref_reliable_service_explain"/>
+
         <Preference
                 android:dependency="pref_key_enable_notifications"
                 android:key="pref_key_ringtone"
@@ -57,11 +64,5 @@
                 android:defaultValue="1"
                 android:entries="@array/pref_notification_priority_entries"
                 android:entryValues="@array/pref_notification_priority_values"/>
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_reliable_service"
-            android:title="@string/pref_reliable_service"
-            android:summary="@string/pref_reliable_service_explain"/>
 
 </PreferenceScreen>

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -59,7 +59,7 @@
                 android:entryValues="@array/pref_notification_priority_values"/>
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="pref_reliable_service"
             android:title="@string/pref_reliable_service"
             android:summary="@string/pref_reliable_service_explain"/>

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -84,14 +84,13 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   protected void onCreate(Bundle icicle, boolean ready) {
     ApplicationDcContext dcContext = DcHelper.getContext(this);
 
-    // show the permanent-notification hint above the welcome-messages (that is also visible in the preview)
-    // for existing installation, of course, that will be the last as the welcome-messages are added long time ago.
-    DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
-    msg.setText(getString(R.string.device_talk_background_connection_android));
-    dcContext.addDeviceMsg("update1.6.0-h", msg);
-
     // add welcome message
     dcContext.updateDeviceChats();
+    if (dcContext.wasDeviceMsgEverAdded("update1.6.0-h")) {
+      DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+      msg.setText(getString(R.string.device_talk_background_connection2_android));
+      dcContext.addDeviceMsg("update1.8.0-a", msg);
+    }
 
     setContentView(R.layout.conversation_list_activity);
 

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -241,6 +241,8 @@ public class LogViewFragment extends Fragment {
         builder.append("ignoreBatteryOptimizations=").append(
             powerManager.isIgnoringBatteryOptimizations(context.getPackageName())).append("\n");
       }
+      builder.append("notifications=").append(
+              Prefs.isNotificationsEnabled(context)).append("\n");
       builder.append("reliableService=").append(
               Prefs.reliableService(context)).append("\n");
     } catch (Exception e) {

--- a/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
+++ b/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
@@ -25,7 +25,7 @@ public class KeepAliveService extends Service {
         // note, that unfortunately, the check for isIgnoringBatteryOptimizations() is not sufficient,
         // this checks only stock-android settings, several os have additional "optimizers" that ignore this setting.
         // therefore, the most reliable way to not get killed is a permanent-foreground-notification.
-        if(Prefs.reliableService(context))  {
+        if (Prefs.isNotificationsEnabled(context) && Prefs.reliableService(context))  {
             startSelf(context);
         }
     }

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -71,9 +71,21 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     CheckBoxPreference reliableService =  this.findPreference("pref_reliable_service");
     reliableService.setOnPreferenceChangeListener((preference, newValue) -> {
       Context context = getContext();
-      boolean enabled = (Boolean) newValue;
-      if (enabled) {
+      boolean enabled = (Boolean) newValue; // Prefs.reliableService() still has the old value
+      if (enabled && Prefs.isNotificationsEnabled(context)) {
           KeepAliveService.startSelf(context);
+      } else {
+        context.stopService(new Intent(context, KeepAliveService.class));
+      }
+      return true;
+    });
+
+    CheckBoxPreference notificationsEnabled = this.findPreference("pref_key_enable_notifications");
+    notificationsEnabled.setOnPreferenceChangeListener((preference, newValue) -> {
+      Context context = getContext();
+      boolean enabled = (Boolean) newValue; // Prefs.isNotificationsEnabled() still has the old value
+      if (enabled && Prefs.reliableService(context)) {
+        KeepAliveService.startSelf(context);
       } else {
         context.stopService(new Intent(context, KeepAliveService.class));
       }
@@ -137,9 +149,6 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
   public static CharSequence getSummary(Context context) {
     boolean notificationsEnabled = Prefs.isNotificationsEnabled(context);
     String ret = context.getString(notificationsEnabled ? R.string.on : R.string.off);
-    if (notificationsEnabled && !Prefs.reliableService(context)) {
-      ret += ", " + context.getString(R.string.pref_reliable_service) + " " + context.getString(R.string.off);
-    }
     return ret;
   }
 

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -236,7 +236,7 @@ public class Prefs {
 
   public static boolean reliableService(Context context) {
     try {
-      return getBooleanPreference(context, "pref_reliable_service", true);
+      return getBooleanPreference(context, "pref_reliable_service", false);
     }
     catch(Exception e) {
       return false;


### PR DESCRIPTION
this pr changes the default of the permantent-notification to "off" for the reasons explained in the first commit.

the other commit streamline the ui a bit around this new default.