### PR TITLE
Use the mute functions of the core

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1184,6 +1184,16 @@ JNIEXPORT jintArray Java_com_b44t_messenger_DcContext_getChatContacts(JNIEnv *en
 	return dc_array2jintArray_n_unref(env, ca);
 }
 
+JNIEXPORT jboolean Java_com_b44t_messenger_DcContext_setChatMuteDuration(JNIEnv *env, jobject obj, jint chat_id, jlong duration)
+{
+    return dc_set_chat_mute_duration(get_dc_context(env, obj), chat_id, duration);
+}
+
+JNIEXPORT jboolean Java_com_b44t_messenger_DcChat_isMuted(JNIEnv *env, jobject obj)
+{
+    return dc_chat_is_muted(get_dc_chat(env, obj));
+}
+
 
 /*******************************************************************************
  * DcMsg
@@ -1669,4 +1679,3 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcContext_dataToString(JNIEnv *env, jc
 	const char* cstring = (const char*)data;
 	return JSTRING_NEW(cstring);
 }
-

--- a/src/com/b44t/messenger/DcChat.java
+++ b/src/com/b44t/messenger/DcChat.java
@@ -35,6 +35,7 @@ public class DcChat {
     public native boolean canSend           ();
     public native boolean isVerified        ();
     public native boolean isSendingLocations();
+    public native boolean isMuted           ();
 
     // working with raw c-data
     private long        chatCPtr;    // CAVE: the name is referenced in the JNI

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -161,6 +161,7 @@ public class DcContext {
     public native int[]        getChatMedia         (int chat_id, int type1, int type2, int type3);
     public native int          getNextMedia         (int msg_id, int dir, int type1, int type2, int type3);
     public native int[]        getChatContacts      (int chat_id);
+    public native boolean      setChatMuteDuration  (int chat_id, long duration);
     public native void         deleteChat           (int chat_id);
     public @NonNull DcMsg      getMsg               (int msg_id) { return new DcMsg(getMsgCPtr(msg_id)); }
     public native String       getMsgInfo           (int id);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -433,7 +433,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     inflater.inflate(R.menu.conversation, menu);
 
-    if(Prefs.isChatMuted(this, chatId)) {
+    if(Prefs.isChatMuted(dcChat)) {
       menu.findItem(R.id.menu_mute_notifications).setTitle(R.string.menu_unmute);
     }
 
@@ -561,14 +561,14 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleMuteNotifications() {
-    if(!Prefs.isChatMuted(this, chatId)) {
-      MuteDialog.show(this, until -> {
-        Prefs.setChatMutedUntil(this, chatId, until);
+    if(!Prefs.isChatMuted(dcChat)) {
+      MuteDialog.show(this, duration -> {
+        Prefs.setChatMuteDuration(dcContext, chatId, duration);
         titleView.setTitle(glideRequests, dcChat);
       });
     } else {
       // unmute
-      Prefs.setChatMutedUntil(this, chatId, 0);
+      Prefs.setChatMuteDuration(dcContext, chatId, 0);
       titleView.setTitle(glideRequests, dcChat);
     }
   }

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -70,7 +70,7 @@ public class ConversationListItem extends RelativeLayout
 
   private DcLot              dcSummary;
   private Set<Long>          selectedThreads;
-  private long               chatId;
+  private int                chatId;
   private int                msgId;
   private GlideRequests      glideRequests;
   private TextView           subjectView;
@@ -130,7 +130,7 @@ public class ConversationListItem extends RelativeLayout
     this.dcSummary        = dcSummary;
     this.selectedThreads  = selectedThreads;
     Recipient recipient   = thread.getRecipient();
-    this.chatId           = thread.getThreadId();
+    this.chatId           = (int) thread.getThreadId();
     this.msgId            = msgId;
     this.glideRequests    = glideRequests;
     this.unreadCount      = thread.getUnreadCount();
@@ -173,7 +173,7 @@ public class ConversationListItem extends RelativeLayout
     }
 
     fromView.setCompoundDrawablesWithIntrinsicBounds(
-        Prefs.isChatMuted(getContext(), (int) chatId)? R.drawable.ic_volume_off_grey600_18dp : 0,
+        Prefs.isChatMuted(dcContext.getChat(chatId))? R.drawable.ic_volume_off_grey600_18dp : 0,
         0,
         thread.isVerified()? R.drawable.ic_verified : 0,
         0);

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -173,7 +173,7 @@ public class ConversationListItem extends RelativeLayout
     }
 
     fromView.setCompoundDrawablesWithIntrinsicBounds(
-        Prefs.isChatMuted(dcContext.getChat(chatId))? R.drawable.ic_volume_off_grey600_18dp : 0,
+        thread.isMuted()? R.drawable.ic_volume_off_grey600_18dp : 0,
         0,
         thread.isVerified()? R.drawable.ic_verified : 0,
         0);

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -66,7 +66,7 @@ public class ConversationTitleView extends RelativeLayout {
       setComposeTitle();
     } else {
       setRecipientTitle(dcChat, showSubtitle);
-      if (Prefs.isChatMuted(getContext(), dcChat.getId())) {
+      if (Prefs.isChatMuted(dcChat)) {
         imgLeft = R.drawable.ic_volume_off_white_18dp;
       }
       if (dcChat.isVerified()) {

--- a/src/org/thoughtcrime/securesms/MuteDialog.java
+++ b/src/org/thoughtcrime/securesms/MuteDialog.java
@@ -15,20 +15,20 @@ public class MuteDialog {
     builder.setItems(R.array.mute_durations, (dialog, which) -> {
       final long muteUntil;
 
+      // See https://c.delta.chat/classdc__context__t.html#a6460395925d49d2053bc95224bf5ce37.
       switch (which) {
-        case 0:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);    break;
-        case 1:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2);    break;
-        case 2:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);     break;
-        case 3:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(7);     break;
-        case 4:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(36500); break;
-        default: muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);    break;
+        case 0:  muteUntil = 0;    break; // unmute
+        case 1:  muteUntil = TimeUnit.HOURS.toSeconds(2);    break;
+        case 2:  muteUntil = TimeUnit.DAYS.toSeconds(1);     break;
+        case 3:  muteUntil = TimeUnit.DAYS.toSeconds(7);     break;
+        case 4:  muteUntil = -1; break; // mute forever
+        default: muteUntil = 0; break;
       }
 
       listener.onMuted(muteUntil);
     });
 
     builder.show();
-
   }
 
   public interface MuteSelectionListener {

--- a/src/org/thoughtcrime/securesms/MuteDialog.java
+++ b/src/org/thoughtcrime/securesms/MuteDialog.java
@@ -17,10 +17,10 @@ public class MuteDialog {
 
       // See https://c.delta.chat/classdc__context__t.html#a6460395925d49d2053bc95224bf5ce37.
       switch (which) {
-        case 0:  muteUntil = 0;    break; // unmute
-        case 1:  muteUntil = TimeUnit.HOURS.toSeconds(2);    break;
-        case 2:  muteUntil = TimeUnit.DAYS.toSeconds(1);     break;
-        case 3:  muteUntil = TimeUnit.DAYS.toSeconds(7);     break;
+        case 0:  muteUntil = TimeUnit.HOURS.toSeconds(1); break;
+        case 1:  muteUntil = TimeUnit.HOURS.toSeconds(2); break;
+        case 2:  muteUntil = TimeUnit.DAYS.toSeconds(1);  break;
+        case 3:  muteUntil = TimeUnit.DAYS.toSeconds(7);  break;
         case 4:  muteUntil = -1; break; // mute forever
         default: muteUntil = 0; break;
       }
@@ -32,7 +32,7 @@ public class MuteDialog {
   }
 
   public interface MuteSelectionListener {
-    void onMuted(long until);
+    void onMuted(long duration);
   }
 
 }

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -355,7 +355,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       setMuted(0);
     }
     else {
-      MuteDialog.show(this, until -> setMuted(until));
+      MuteDialog.show(this, duration -> setMuted(duration));
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -140,7 +140,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
     item = menu.findItem(R.id.menu_mute_notifications);
     if(item!=null) {
-      item.setTitle(Prefs.isChatMuted(this, chatId)? R.string.menu_unmute : R.string.menu_mute);
+      item.setTitle(Prefs.isChatMuted(dcContext.getChat(chatId))? R.string.menu_unmute : R.string.menu_mute);
     }
 
     super.onPrepareOptionsMenu(menu);
@@ -351,7 +351,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   }
 
   public void onNotifyOnOff() {
-    if (Prefs.isChatMuted(this, chatId)) {
+    if (Prefs.isChatMuted(dcContext.getChat(chatId))) {
       setMuted(0);
     }
     else {
@@ -359,14 +359,9 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  private void setMuted(final long until) {
-    if(chatId!=0) {
-      Prefs.setChatMutedUntil(this, chatId, until);
-
-      // normally, sendToObservers() is only used to forward events from the core to the ui.
-      // we do an exception here, as "mute" is not handled by the core,
-      // but various elements listen to similar changes with the DC_EVENT_CHAT_MODIFIED event.
-      dcContext.eventCenter.sendToObservers(DcContext.DC_EVENT_CHAT_MODIFIED, new Integer(chatId), 0);
+  private void setMuted(final long duration) {
+    if (chatId != 0) {
+      Prefs.setChatMuteDuration(dcContext, chatId, duration);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/components/FromTextView.java
+++ b/src/org/thoughtcrime/securesms/components/FromTextView.java
@@ -15,6 +15,7 @@ import android.util.AttributeSet;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
+import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.ResUtil;
 import org.thoughtcrime.securesms.util.Prefs;
@@ -74,7 +75,7 @@ public class FromTextView extends EmojiTextView {
 
     int chatId = recipient.getAddress().isDcChat()? recipient.getAddress().getDcChatId() : 0;
 
-    if (Prefs.isChatMuted(getContext(), chatId)) {
+    if (Prefs.isChatMuted(DcHelper.getContext(getContext()).getChat(chatId))) {
       setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_volume_off_grey600_18dp, 0, 0, 0);
     }
     else {

--- a/src/org/thoughtcrime/securesms/components/FromTextView.java
+++ b/src/org/thoughtcrime/securesms/components/FromTextView.java
@@ -72,15 +72,6 @@ public class FromTextView extends EmojiTextView {
     }
 
     setText(builder);
-
-    int chatId = recipient.getAddress().isDcChat()? recipient.getAddress().getDcChatId() : 0;
-
-    if (Prefs.isChatMuted(DcHelper.getContext(getContext()).getChat(chatId))) {
-      setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_volume_off_grey600_18dp, 0, 0, 0);
-    }
-    else {
-      setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
-    }
   }
 
 

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -279,7 +279,7 @@ public class ApplicationDcContext extends DcContext {
 
     return new ThreadRecord(context, body, recipient, date,
         unreadCount, chatId,
-        chat.getVisibility(), verified, chat.isSendingLocations(), summary);
+        chat.getVisibility(), verified, chat.isSendingLocations(), chat.isMuted(), summary);
   }
 
 

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -48,6 +48,7 @@ public class ThreadRecord {
   private           final int     visibility;
   private           final boolean verified;
   private           final boolean isSendingLocations;
+  private           final boolean isMuted;
   private @Nullable final DcLot   dcSummary;
 
   public ThreadRecord(@NonNull Context context, @NonNull String body,
@@ -56,6 +57,7 @@ public class ThreadRecord {
                       int visibility,
                       boolean verified,
                       boolean isSendingLocations,
+                      boolean isMuted,
                       @Nullable DcLot dcSummary)
   {
     this.context              = context.getApplicationContext();
@@ -67,6 +69,7 @@ public class ThreadRecord {
     this.visibility       = visibility;
     this.verified         = verified;
     this.isSendingLocations = isSendingLocations;
+    this.isMuted          = isMuted;
     this.dcSummary        = dcSummary;
   }
 
@@ -120,5 +123,9 @@ public class ThreadRecord {
 
   public boolean isSendingLocations() {
     return  isSendingLocations;
+  }
+
+  public boolean isMuted() {
+    return  isMuted;
   }
 }

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -90,7 +90,7 @@ abstract class MessageNotifier {
         boolean isVisible = visibleChatId == chatId;
 
         if (!Prefs.isNotificationsEnabled(appContext) ||
-                Prefs.isChatMuted(appContext, chatId))
+                Prefs.isChatMuted(dcContext.getChat(chatId)))
         {
             return;
         }
@@ -352,7 +352,7 @@ abstract class MessageNotifier {
             return;
         }
 
-        if(Prefs.isChatMuted(appContext, chatId)) {
+        if(Prefs.isChatMuted(, chatId)) {
             Log.d(TAG, "chat muted");
             return;
         }
@@ -363,7 +363,7 @@ abstract class MessageNotifier {
     }
 
     void addMessageToNotificationState(ApplicationDcContext dcContext, int chatId, int msgId) {
-        if (Prefs.isChatMuted(appContext, chatId)) {
+        if (Prefs.isChatMuted(dcContext.getChat(chatId))) {
             return;
         }
 

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifierPreApi23.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifierPreApi23.java
@@ -3,6 +3,8 @@ package org.thoughtcrime.securesms.notifications;
 import android.content.Context;
 import androidx.core.app.NotificationManagerCompat;
 
+import com.b44t.messenger.DcChat;
+
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcHelper;
 
@@ -40,19 +42,19 @@ class MessageNotifierPreApi23 extends MessageNotifier {
     }
 
     @Override
-    void sendNotifications(int chatId, int messageId, boolean signal) {
+    void sendNotifications(DcChat chat, int messageId, boolean signal) {
         ApplicationDcContext dcContext = DcHelper.getContext(appContext);
         if (signal = isSignalAllowed(signal)) {
             lastAudibleNotification = System.currentTimeMillis();
         }
 
-        if (dcContext.getChat(chatId).isDeviceTalk()) {
+        if (chat.isDeviceTalk()) {
             // currently, we just never notify on device chat.
             // esp. on first start, this is annoying.
             return;
         }
 
-        addMessageToNotificationState(dcContext, chatId, messageId);
+        addMessageToNotificationState(dcContext, chat, messageId);
         synchronized (lock) {
             if (notificationState.hasMultipleChats()) {
                 sendMultipleChatNotification(appContext, notificationState, signal);

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
+import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContext;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
@@ -278,16 +279,12 @@ public class Prefs {
 
   // mute
 
-  public static void setChatMutedUntil(Context context, int chatId, long until) {
-    setLongPreference(context, CHAT_MUTED_UNTIL+chatId, until);
+  public static void setChatMuteDuration(DcContext context, int chatId, long duration) {
+    context.setChatMuteDuration(chatId, duration);
   }
 
-  public static long getChatMutedUntil(Context context, int chatId) {
-    return getLongPreference(context, CHAT_MUTED_UNTIL+chatId, 0);
-  }
-
-  public static boolean isChatMuted(Context context, int chatId) {
-    return System.currentTimeMillis() <= getChatMutedUntil(context, chatId);
+  public static boolean isChatMuted(DcChat chat) {
+    return chat.isMuted();
   }
 
   // map


### PR DESCRIPTION
Fix #1338.

Muting and unmuting now takes about 0.1s while it was instantly before, but I guess it's not worth improving this. And maybe it is improved by https://github.com/deltachat/deltachat-core-rust/pull/1492.

Du you think that I should inline the Prefs.*mute*() functions?