### PR TITLE
Voice message requires foreground

### DIFF
--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -116,28 +116,29 @@ public class AudioSlidePlayer {
   }
 
   public void play(final double progress) throws IOException {
-    // TODO: synchronized (MONITOR) {
-    if (this.mediaPlayer != null) {
-      return;
+    synchronized (MONITOR) {
+      if (this.mediaPlayer != null) {
+        return;
+      }
+
+      if (slide.getUri() == null) {
+        throw new IOException("Slide has no URI!");
+      }
+
+      LoadControl loadControl = new DefaultLoadControl.Builder().setBufferDurationsMs(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE).createDefaultLoadControl();
+      this.mediaPlayer = ExoPlayerFactory.newSimpleInstance(context, new DefaultRenderersFactory(context), new DefaultTrackSelector(), loadControl);
+
+      mediaPlayer.prepare(createMediaSource(slide.getUri()));
+      mediaPlayer.setPlayWhenReady(true);
+      mediaPlayer.setAudioAttributes(new AudioAttributes.Builder()
+          .setContentType(C.CONTENT_TYPE_MUSIC)
+          .setUsage(C.USAGE_MEDIA)
+          .build());
+
+      startKeepingScreenOn();
+
+      mediaPlayer.addListener(new MediaPlayerListener(progress));
     }
-
-    if (slide.getUri() == null) {
-      throw new IOException("Slide has no URI!");
-    }
-
-    LoadControl loadControl = new DefaultLoadControl.Builder().setBufferDurationsMs(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE).createDefaultLoadControl();
-    this.mediaPlayer        = ExoPlayerFactory.newSimpleInstance(context, new DefaultRenderersFactory(context), new DefaultTrackSelector(), loadControl);
-
-    mediaPlayer.prepare(createMediaSource(slide.getUri()));
-    mediaPlayer.setPlayWhenReady(true);
-    mediaPlayer.setAudioAttributes(new AudioAttributes.Builder()
-            .setContentType(C.CONTENT_TYPE_MUSIC)
-            .setUsage(C.USAGE_MEDIA)
-            .build());
-
-    startKeepingScreenOn();
-
-    mediaPlayer.addListener(new MediaPlayerListener(progress));
   }
 
   private class MediaPlayerListener implements Player.EventListener {

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -62,7 +62,7 @@ public class AudioSlidePlayer {
   private @NonNull  WeakReference<Listener> listener;
   private @Nullable SimpleExoPlayer         mediaPlayer;
   private @Nullable SimpleExoPlayer         durationCalculator;
-  private @NonNull  String                  name;
+  private @NonNull  String                  name = "-- Nothing yet --";
 
   public static AudioSlidePlayer createFor(@NonNull Context context,
                                            @NonNull AudioSlide slide,
@@ -239,8 +239,7 @@ public class AudioSlidePlayer {
     synchronized (MONITOR) {
       Log.d(TAG, "stopKeepingScreenOn " + name + " list: " + CURRENTLY_PLAYING);
       if (context instanceof Activity) { // should always be true
-        // check on string equality is valid as it should be the same instance.
-        if(CURRENTLY_PLAYING.get(CURRENTLY_PLAYING.size()-1) == name) {
+        if(CURRENTLY_PLAYING.get(CURRENTLY_PLAYING.size()-1).equals(name)) {
           Activity activity = ((Activity) context);
           activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         }
@@ -370,7 +369,7 @@ public class AudioSlidePlayer {
     }
 
     @Override
-    public void handleMessage(Message msg) {
+    public void handleMessage(@NonNull Message msg) {
       AudioSlidePlayer player = playerReference.get();
       if (player == null) return;
       synchronized (MONITOR) {

--- a/src/org/thoughtcrime/securesms/components/AudioView.java
+++ b/src/org/thoughtcrime/securesms/components/AudioView.java
@@ -12,11 +12,13 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.audio.AudioSlidePlayer;
 import org.thoughtcrime.securesms.mms.AudioSlide;
@@ -216,6 +218,10 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
     public void onClick(View v) {
       try {
         Log.w(TAG, "playbutton onClick");
+        if(getContext() instanceof ConversationActivity) {
+          ConversationActivity context = ((ConversationActivity)getContext());
+          context.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
         if (audioSlidePlayer != null) {
           togglePlayToPause();
           audioSlidePlayer.play(getProgress());
@@ -231,6 +237,10 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
     @Override
     public void onClick(View v) {
       Log.w(TAG, "pausebutton onClick");
+      if(getContext() instanceof ConversationActivity) {
+        ConversationActivity context = ((ConversationActivity)getContext());
+        context.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+      }
       if (audioSlidePlayer != null) {
         togglePauseToPlay();
         audioSlidePlayer.stop();

--- a/src/org/thoughtcrime/securesms/components/AudioView.java
+++ b/src/org/thoughtcrime/securesms/components/AudioView.java
@@ -12,13 +12,11 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
-import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.audio.AudioSlidePlayer;
 import org.thoughtcrime.securesms.mms.AudioSlide;

--- a/src/org/thoughtcrime/securesms/components/AudioView.java
+++ b/src/org/thoughtcrime/securesms/components/AudioView.java
@@ -218,10 +218,6 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
     public void onClick(View v) {
       try {
         Log.w(TAG, "playbutton onClick");
-        if(getContext() instanceof ConversationActivity) {
-          ConversationActivity context = ((ConversationActivity)getContext());
-          context.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        }
         if (audioSlidePlayer != null) {
           togglePlayToPause();
           audioSlidePlayer.play(getProgress());
@@ -237,10 +233,6 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
     @Override
     public void onClick(View v) {
       Log.w(TAG, "pausebutton onClick");
-      if(getContext() instanceof ConversationActivity) {
-        ConversationActivity context = ((ConversationActivity)getContext());
-        context.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-      }
       if (audioSlidePlayer != null) {
         togglePauseToPlay();
         audioSlidePlayer.stop();


### PR DESCRIPTION
This fixes #1022 by requesting the system to stay active during playback.

While at it I noticed that the AudioSlidePlayer has possibilities for race conditions and is generally badly structured. So, commits 3 and after are cleanup code.

To understand the synchronized(MONITOR) lines one has to know that synchronized on a static method and a non-static method does not synchronize on the same element.