### PR TITLE
Revert "Fix #999 swiping a notification away should not mark things as "noticed""

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -253,6 +253,7 @@ abstract class MessageNotifier {
                 firstItem.getText(""), firstItem.getSlideDeck());
         builder.setContentIntent(firstItem.getPendingIntent(context));
         builder.setGroup(NOTIFICATION_GROUP);
+        builder.setDeleteIntent(notificationState.getMarkAsReadIntent(context, chatId, notificationId));
 
         long timestamp = firstItem.getTimestamp();
         if (timestamp != 0) builder.setWhen(timestamp);
@@ -312,6 +313,7 @@ abstract class MessageNotifier {
         builder.setMessageCount(notificationState.getMessageCount(), notificationState.getChatCount());
         builder.setMostRecentSender(firstItem.getIndividualRecipient());
         builder.setGroup(NOTIFICATION_GROUP);
+        builder.setDeleteIntent(notificationState.getMarkAsReadIntent(context, 0, SUMMARY_NOTIFICATION_ID));
 
         long timestamp = firstItem.getTimestamp();
         if (timestamp != 0) builder.setWhen(timestamp);


### PR DESCRIPTION
Reverts deltachat/deltachat-android#1277
closes https://github.com/deltachat/deltachat-android/issues/1353
reopens https://github.com/deltachat/deltachat-android/issues/999 

i think the original behavior was better, the reappearing is pretty annoying and not intended, esp. as the messages reappear _at once_ when another chat is opened.

this is because of the re-adding of all notifications instead, which was needed for some needed hacks on the notification-channels. i will to a general cleanup.