### PR TITLE
bump exoplayer version to 2.9.6 becaus of some fixes that apply to us

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0'
     implementation 'androidx.work:work-runtime:2.3.4'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.9.1' // plays video and audio
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.1'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.9.6' // plays video and audio
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.6'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.journeyapps:zxing-android-embedded:3.4.0' // QR Code scanner
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.2' // used as JSON library


### PR DESCRIPTION
Changes exoplayer Version from 2.9.1 to 2.9.6. Most current is 2.11.4, but I didn't invest time to figure out if we need any of the new features.
exoplayer Release notes contain also this line:
2.9.3 Fix regression where some audio formats were incorrectly marked as being
  unplayable due to under-reporting of platform decoder capabilities

There are also some other fixes that might be beneficial to us, even if we didn't encounter them yet.

