### PR TITLE
Background image no longer distorted.

### DIFF
--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent" android:layout_width="match_parent">
+
+    <ImageView
+        android:id="@+id/conversation_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:ignore="ContentDescription"
+        android:scaleType="centerCrop" />
+
     <org.thoughtcrime.securesms.components.InputAwareLayout
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
-            xmlns:tools="http://schemas.android.com/tools"
             android:id="@+id/layout_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent">

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -175,6 +175,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   InputAwareLayout            container;
   private   View                        composePanel;
   protected Stub<ReminderView>          reminderView;
+  private   ImageView                   backgroundView;
 
   private   AttachmentTypeSelector attachmentTypeSelector;
   private   AttachmentManager      attachmentManager;
@@ -798,6 +799,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     quickAttachmentDrawer = ViewUtil.findById(this, R.id.quick_attachment_drawer);
     quickAttachmentToggle = ViewUtil.findById(this, R.id.quick_attachment_toggle);
     inputPanel            = ViewUtil.findById(this, R.id.bottom_panel);
+    backgroundView        = ViewUtil.findById(this, R.id.conversation_background);
 
     ImageButton quickCameraToggle = ViewUtil.findById(this, R.id.quick_camera_toggle);
 
@@ -842,13 +844,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     String backgroundImagePath = Prefs.getBackgroundImagePath(this);
     if(!backgroundImagePath.isEmpty()) {
       Drawable image = Drawable.createFromPath(backgroundImagePath);
-      getWindow().setBackgroundDrawable(image);
+      backgroundView.setImageDrawable(image);
     }
     else if(dynamicTheme.isDarkTheme(this)) {
-      getWindow().setBackgroundDrawableResource(R.drawable.background_hd_dark);
+      backgroundView.setImageResource(R.drawable.background_hd_dark);
     }
     else {
-      getWindow().setBackgroundDrawableResource(R.drawable.background_hd);
+      backgroundView.setImageResource(R.drawable.background_hd);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
@@ -136,13 +136,15 @@ public class ChatBackgroundActivity extends PassphraseRequiredActionBarActivity 
             Display display = ServiceUtil.getWindowManager(context).getDefaultDisplay();
             Point size = new Point();
             display.getSize(size);
+            // resize so that the larger side fits the screen accurately
+            int largerSide = (size.x > size.y ? size.x : size.y);
             Bitmap scaledBitmap = GlideApp.with(context)
                     .asBitmap()
                     .load(imageUri)
-                    .centerCrop()
+                    .fitCenter()
                     .skipMemoryCache(true)
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .submit(size.x, size.y)
+                    .submit(largerSide, largerSide)
                     .get();
             FileOutputStream outStream = new FileOutputStream(destinationPath);
             scaledBitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream);


### PR DESCRIPTION
I mirrored the activity of the ImageView on the Background setting view (as it was working there properly) in the conversation activity.

Then I modified the transformation during Background setting to create an image that is scaled down to the larger sides of the screen (so the scaling is indifferent at this stage to portrait/landscape).

When active the users will need to set his background image once so that the old image (that was cropped too much) is removed and a new one is set.
It could be a good idea to inform the user in the system messages about that change.
fixes #466 