### PR TITLE
fix showing selected chats

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -70,7 +70,7 @@ public class ConversationListItem extends RelativeLayout
 
   private DcLot              dcSummary;
   private Set<Long>          selectedThreads;
-  private int                chatId;
+  private long               chatId;
   private int                msgId;
   private GlideRequests      glideRequests;
   private TextView           subjectView;
@@ -130,7 +130,7 @@ public class ConversationListItem extends RelativeLayout
     this.dcSummary        = dcSummary;
     this.selectedThreads  = selectedThreads;
     Recipient recipient   = thread.getRecipient();
-    this.chatId           = (int) thread.getThreadId();
+    this.chatId           = thread.getThreadId();
     this.msgId            = msgId;
     this.glideRequests    = glideRequests;
     this.unreadCount      = thread.getUnreadCount();


### PR DESCRIPTION
this bug was introduced some days ago at adce890bef0d54cdacdcb6eddc46afc67a653fb2
by declaring chatId as "int" instead of "long", which is formally correct,
however, int many parts of the code, the chatId is "long" -
as for the set of selected chats:
checking that set for an "int" always returns false ...

i first wanted to change all the sets to use int instead of long,
however, this would require lots of lines to be change -
keeping in mind that this seems to be very sensitive,
and use "long" for the chatId in ConversationListItem.

doing a larger refactoring of Long to Int has the potential to introduce more bugs,
things are not that intuitive in this area -
i would also not have exected that i cannot query a set of longs using an integer,
when using primitives (i know, they are converted implicitly to objects :)

fixes #1377