### PR TITLE
fix marking incoming message as being seen

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -111,6 +111,7 @@ public class ConversationFragment extends Fragment
     private TextView                    noMessageTextView;
     private ApplicationDcContext        dcContext;
 
+    public boolean isPaused;
     private Debouncer markseenDebouncer;
 
     @Override
@@ -209,6 +210,11 @@ public class ConversationFragment extends Fragment
         if (list.getAdapter() != null) {
             list.getAdapter().notifyDataSetChanged();
         }
+
+        if (isPaused) {
+            isPaused = false;
+            markseenDebouncer.publish(() -> manageMessageSeenState());
+        }
     }
 
 
@@ -216,6 +222,7 @@ public class ConversationFragment extends Fragment
     public void onPause() {
         super.onPause();
         setLastSeen(System.currentTimeMillis());
+        isPaused = true;
     }
 
     @Override
@@ -502,6 +509,10 @@ public class ConversationFragment extends Fragment
         }
         else{
             noMessageTextView.setVisibility(View.GONE);
+        }
+
+        if (!isPaused) {
+            markseenDebouncer.publish(() -> manageMessageSeenState());
         }
     }
 


### PR DESCRIPTION
closes #1380 

before, messages were only maked as seen after the chat was entered
or after some scrolling takes place.

if a user was inside a chat, reading the last incoming message,
that did not sent out markseen (unless, some scrolling was done,
which, honestly, is often the case)

this commit starts the markseen-bouncer also when the chatlist is reloaded
(true eg. on incoming messages) - but this is not done when the
list is paused (eg. screen is off or some other fragment/dialog above)