### PR TITLE
Implementing hashCode in DcMsg.

### DIFF
--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -1,5 +1,7 @@
 package com.b44t.messenger;
 
+import android.util.Log;
+
 public class DcContact {
 
     public final static int DC_CONTACT_ID_SELF               = 1;
@@ -32,6 +34,11 @@ public class DcContact {
 
         DcContact that = (DcContact) other;
         return this.getId()==that.getId();
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getId();
     }
 
     @Override

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -1,5 +1,9 @@
 package com.b44t.messenger;
 
+import android.util.Log;
+
+import org.thoughtcrime.securesms.ConversationItem;
+
 import androidx.annotation.NonNull;
 
 import java.io.File;
@@ -30,6 +34,8 @@ public class DcMsg {
     public final static int DC_MSG_ID_MARKER1 = 1;
     public final static int DC_MSG_ID_DAYMARKER = 9;
 
+    private static final String TAG = ConversationItem.class.getSimpleName();
+
     public DcMsg(DcContext context, int viewtype) {
         msgCPtr = context.createMsgCPtr(viewtype);
     }
@@ -43,6 +49,13 @@ public class DcMsg {
         super.finalize();
         unrefMsgCPtr();
         msgCPtr = 0;
+    }
+
+    @Override
+    public int hashCode() {
+        if(this.getId() ==0)
+            Log.e(TAG, "encountered a DcMsg with id 0.");
+        return this.getId();
     }
 
     @Override

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -2,8 +2,6 @@ package com.b44t.messenger;
 
 import android.util.Log;
 
-import org.thoughtcrime.securesms.ConversationItem;
-
 import androidx.annotation.NonNull;
 
 import java.io.File;
@@ -34,7 +32,7 @@ public class DcMsg {
     public final static int DC_MSG_ID_MARKER1 = 1;
     public final static int DC_MSG_ID_DAYMARKER = 9;
 
-    private static final String TAG = ConversationItem.class.getSimpleName();
+    private static final String TAG = DcMsg.class.getSimpleName();
 
     public DcMsg(DcContext context, int viewtype) {
         msgCPtr = context.createMsgCPtr(viewtype);
@@ -53,8 +51,9 @@ public class DcMsg {
 
     @Override
     public int hashCode() {
-        if(this.getId() ==0)
+        if (this.getId() == 0) {
             Log.e(TAG, "encountered a DcMsg with id 0.");
+        }
         return this.getId();
     }
 


### PR DESCRIPTION
fixes #1071 
The issue there is that batchSelected in ConversationItem is a HashSet. Then we use the 'contains' function of it to see if the item that should currently be displayed is within the selected set.

HashSet.contains does not check the equals function, but just memorizes the hash code.

As hashCode must have the same behavior as equals I added the check for id=0.

If we can create an assertion that id is never 0 we should strip the check in equals and hashCode.

This change could change the behavior of all sorts of places where HashSet/HashMap of DcMsg is used, not just the one we are in right now. I did a quick check and everything looked fine but I think this change should be put to longer beta testing in a nightly before being rolled out.

There is a secondary finding that takes some thought:
Because this change fixes the issue it follows that the issue is caused from two DcMsg objects being compared to each other. So, when we scroll far enough and back again new DcMsg objects are being created that were present before. This could (hypothetically) cause a memory leak somewhere as we bind the DcMsg object to something (e.g. the batchSelected list) and they then don't get garbage collected because of this.
It could also cause different DcMsg objects pointing to different states of the same message (read state, etc.)
So, when we encounter issues that might be caused by such behavior, keep that in mind.

We could also fix the issue 1071 by modifying DcContext to hold a cache of DcMsg objects with weak references. Then we can return the same message every time.
Or we change the batch selection to contain message ids instead.