### PR TITLE
Switching to "Default" Language behaves as it should be

### DIFF
--- a/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
@@ -70,14 +70,18 @@ public class DynamicLanguage {
   // Beware that Locale.getDefault() returns the locale the App was STARTED in, not the locale of the system.
   // It just happens to be the same for the majority of use cases.
   private static Locale getDefaultLocale() {
-    Locale locale;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      locale = Resources.getSystem().getConfiguration().getLocales().get(0);
-    } else {
-      //noinspection deprecation
-      locale = Resources.getSystem().getConfiguration().locale;
+    Locale locale = null;
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        locale = Resources.getSystem().getConfiguration().getLocales().get(0);
+      } else {
+        //noinspection deprecation
+        locale = Resources.getSystem().getConfiguration().locale;
+      }
+    } catch(Exception e) {
+      e.printStackTrace();
     }
-    return locale;
+    return locale != null ? locale : Locale.getDefault();
   }
 
   public static Locale getSelectedLocale(Context context) {

--- a/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
@@ -10,11 +10,16 @@ import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import androidx.annotation.RequiresApi;
+import androidx.core.os.ConfigurationCompat;
+
 import android.text.TextUtils;
+import android.util.Log;
 
 import java.util.Locale;
 
 public class DynamicLanguage {
+
+  private static final String TAG = DynamicLanguage.class.getSimpleName();
 
   private static final String DEFAULT = "zz";
 
@@ -72,14 +77,9 @@ public class DynamicLanguage {
   private static Locale getDefaultLocale() {
     Locale locale = null;
     try {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        locale = Resources.getSystem().getConfiguration().getLocales().get(0);
-      } else {
-        //noinspection deprecation
-        locale = Resources.getSystem().getConfiguration().locale;
-      }
+      locale = ConfigurationCompat.getLocales(Resources.getSystem().getConfiguration()).get(0);
     } catch(Exception e) {
-      e.printStackTrace();
+      Log.e(TAG, "could not determine the system locale.", e);
     }
     return locale != null ? locale : Locale.getDefault();
   }

--- a/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
@@ -5,6 +5,8 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import androidx.annotation.RequiresApi;
@@ -65,11 +67,24 @@ public class DynamicLanguage {
     return activity.getResources().getConfiguration().locale;
   }
 
+  // Beware that Locale.getDefault() returns the locale the App was STARTED in, not the locale of the system.
+  // It just happens to be the same for the majority of use cases.
+  private static Locale getDefaultLocale() {
+    Locale locale;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      locale = Resources.getSystem().getConfiguration().getLocales().get(0);
+    } else {
+      //noinspection deprecation
+      locale = Resources.getSystem().getConfiguration().locale;
+    }
+    return locale;
+  }
+
   public static Locale getSelectedLocale(Context context) {
     String language[] = TextUtils.split(Prefs.getLanguage(context), "_");
 
     if (language[0].equals(DEFAULT)) {
-      return Locale.getDefault();
+      return getDefaultLocale();
     } else if (language.length == 2) {
       return new Locale(language[0], language[1]);
     } else {


### PR DESCRIPTION
Fixes #1209

To reproduce the bug this fixes the App needs to START with a Language that is not the System default. In doubt restart your phone after selecting a non-default language.

Code wise this change modifies the way the system default language is read. Currently `Locale.getDefault()` is used but this returns the locale the app was started in (and I suspect that it is the same it terminated the last time).
The new code is from here https://stackoverflow.com/a/28498119/881272 