### PR TITLE
Allow enlarge of avatar

### DIFF
--- a/res/layout/profile_activity.xml
+++ b/res/layout/profile_activity.xml
@@ -44,4 +44,13 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
+    <org.thoughtcrime.securesms.components.AvatarImageView
+        android:id="@+id/profile_large"
+        android:visibility="invisible"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/pager"
+        android:layout_gravity="center"
+        android:adjustViewBounds="true"/>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/res/layout/profile_activity.xml
+++ b/res/layout/profile_activity.xml
@@ -51,6 +51,7 @@
         android:layout_height="wrap_content"
         android:layout_above="@id/pager"
         android:layout_gravity="center"
+        android:padding="8dp"
         android:adjustViewBounds="true"/>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/res/layout/profile_activity.xml
+++ b/res/layout/profile_activity.xml
@@ -44,14 +44,4 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
-    <org.thoughtcrime.securesms.components.AvatarImageView
-        android:id="@+id/profile_large"
-        android:visibility="invisible"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@id/pager"
-        android:layout_gravity="center"
-        android:padding="8dp"
-        android:adjustViewBounds="true"/>
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/res/menu/profile_chat.xml
+++ b/res/menu/profile_chat.xml
@@ -2,10 +2,6 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item android:title="@string/menu_edit_group_image"
-          android:id="@+id/edit_group_image"
-          app:showAsAction="never"/>
-
     <item android:title="@string/menu_mute"
           android:id="@+id/menu_mute_notifications"
           app:showAsAction="never"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -168,6 +168,7 @@
     <string name="menu_select_all">Select all</string>
     <string name="menu_expand">Expand</string>
     <string name="menu_edit_name">Edit name</string>
+    <string name="menu_edit_group_name_and_image">Edit group name and image</string>
     <string name="menu_edit_group_name">Edit group name</string>
     <string name="menu_edit_group_image">Edit group image</string>
     <string name="menu_settings">Settings</string>

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -195,10 +195,10 @@ public class CreateProfileActivity extends BaseActionBarActivity {
                   Uri imageUri = Crop.getOutput(data);
                   Bitmap bitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), imageUri);
                   ByteArrayOutputStream stream = new ByteArrayOutputStream();
-                  bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+                  bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream);
                   return stream.toByteArray();
                 } catch (Exception any) {
-                  Log.e(TAG, "could not send raw PNG to core. Using scaled JPG.", any);
+                  Log.e(TAG, "could not send raw JPG to core. Using scaled JPG.", any);
                 }
                 BitmapUtil.ScaleResult result =
                     BitmapUtil.createScaledBytes(CreateProfileActivity.this, Crop.getOutput(data), new ProfileMediaConstraints());

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -335,6 +335,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     if (!isMediaInDb()) {
       menu.findItem(R.id.media_preview__overview).setVisible(false);
       menu.findItem(R.id.delete).setVisible(false);
+      menu.findItem(R.id.media_preview__forward).setVisible(false);
     }
 
     return true;

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -395,7 +395,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   public void onEnlargeAvatar() {
     String profileImagePath;
     Uri profileImageUri;
-    if(chatIsGroup)
+    if(chatId!=0)
       profileImagePath = dcContext.getChat(chatId).getProfileImage();
     else
       profileImagePath = dcContext.getContact(contactId).getProfileImage();

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -18,15 +18,18 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.EditText;
+import android.widget.ImageView;
 
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEventCenter;
 
+import org.thoughtcrime.securesms.components.AvatarImageView;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
@@ -403,6 +406,13 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
         intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, true);
       }
       startActivity(intent);
+    } else {
+      AvatarImageView profileLarge = findViewById(R.id.profile_large);
+      DcContact contact = dcContext.getContact(contactId);
+      Recipient recipient = dcContext.getRecipient(contact);
+      profileLarge.setAvatar(GlideApp.with(this), recipient, false);
+      profileLarge.setVisibility(ImageView.VISIBLE);
+      profileLarge.setOnClickListener(v -> profileLarge.setVisibility(ImageView.INVISIBLE));
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -1,11 +1,13 @@
 package org.thoughtcrime.securesms;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Settings;
+
 import com.google.android.material.tabs.TabLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -18,24 +20,22 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.EditText;
-import android.widget.ImageView;
 
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEventCenter;
 
-import org.thoughtcrime.securesms.components.AvatarImageView;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
-import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
+import java.io.File;
 import java.util.ArrayList;
 
 public class ProfileActivity extends PassphraseRequiredActionBarActivity
@@ -393,15 +393,20 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   }
 
   public void onEnlargeAvatar() {
-    AvatarImageView profileLarge = findViewById(R.id.profile_large);
-    Recipient recipient;
+    String profileImagePath;
+    Uri profileImageUri;
     if(chatIsGroup)
-        recipient = dcContext.getRecipient(dcContext.getChat(chatId));
+      profileImagePath = dcContext.getChat(chatId).getProfileImage();
     else
-        recipient = dcContext.getRecipient(dcContext.getContact(contactId));
-    profileLarge.setAvatar(GlideApp.with(this), recipient, false);
-    profileLarge.setVisibility(ImageView.VISIBLE);
-    profileLarge.setOnClickListener(v -> profileLarge.setVisibility(ImageView.INVISIBLE));
+      profileImagePath = dcContext.getContact(contactId).getProfileImage();
+
+    profileImageUri = Uri.fromFile(new File(profileImagePath));
+    Context ctx = getBaseContext();
+    String type = "image/" + profileImagePath.substring(profileImagePath.lastIndexOf(".") +1);
+
+    Intent intent = new Intent(ctx, MediaPreviewActivity.class);
+      intent.setDataAndType(profileImageUri, type);
+    ctx.startActivity(intent);
   }
 
   public void onEditName() {

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -98,7 +98,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
     titleView = (ConversationTitleView) supportActionBar.getCustomView();
     titleView.setOnBackClickedListener(view -> onBackPressed());
-    titleView.setOnAvatarClickListener(view -> onShowAndEditImage());
+    titleView.setOnAvatarClickListener(view -> onEnlargeAvatar());
 
     updateToolbar();
 
@@ -118,10 +118,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       if (chatId != 0) {
         inflater.inflate(R.menu.profile_chat, menu);
         if (chatIsGroup) {
-          menu.findItem(R.id.edit_name).setTitle(R.string.menu_edit_group_name);
-        }
-        else {
-          menu.findItem(R.id.edit_group_image).setVisible(false);
+          menu.findItem(R.id.edit_name).setTitle(R.string.menu_edit_group_name_and_image);
         }
       }
 
@@ -339,9 +336,6 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       case R.id.edit_name:
         onEditName();
         break;
-      case R.id.edit_group_image:
-        onShowAndEditImage();
-        break;
       case R.id.show_encr_info:
         onEncrInfo();
         break;
@@ -398,7 +392,19 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
             .show();
   }
 
-  public void onShowAndEditImage() {
+  public void onEnlargeAvatar() {
+    AvatarImageView profileLarge = findViewById(R.id.profile_large);
+    Recipient recipient;
+    if(chatIsGroup)
+        recipient = dcContext.getRecipient(dcContext.getChat(chatId));
+    else
+        recipient = dcContext.getRecipient(dcContext.getContact(contactId));
+    profileLarge.setAvatar(GlideApp.with(this), recipient, false);
+    profileLarge.setVisibility(ImageView.VISIBLE);
+    profileLarge.setOnClickListener(v -> profileLarge.setVisibility(ImageView.INVISIBLE));
+  }
+
+  public void onEditName() {
     if (chatIsGroup) {
       Intent intent = new Intent(this, GroupCreateActivity.class);
       intent.putExtra(GroupCreateActivity.EDIT_GROUP_CHAT_ID, chatId);
@@ -406,19 +412,6 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
         intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, true);
       }
       startActivity(intent);
-    } else {
-      AvatarImageView profileLarge = findViewById(R.id.profile_large);
-      DcContact contact = dcContext.getContact(contactId);
-      Recipient recipient = dcContext.getRecipient(contact);
-      profileLarge.setAvatar(GlideApp.with(this), recipient, false);
-      profileLarge.setVisibility(ImageView.VISIBLE);
-      profileLarge.setOnClickListener(v -> profileLarge.setVisibility(ImageView.INVISIBLE));
-    }
-  }
-
-  public void onEditName() {
-    if (chatIsGroup) {
-      onShowAndEditImage();
     }
     else {
       DcContact dcContact = dcContext.getContact(contactId);


### PR DESCRIPTION
fixes #1228

Tap on the avatar in a profile to see a large version of it. Tap the large one to make it small again.

Should be discussed if the size of the overlay is proper.

I also noticed that I cannot modify a contacts avatar (as we can with their name). We might want to allow to at least intentionally delete / suppress it.