### PR TITLE
remove option 'accept invalid hostnames'

### DIFF
--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -370,6 +370,7 @@
             android:layout_width="0dp"
             android:layout_height="48dp"
             android:entries="@array/pref_dc_certck_entries"
+            android:entryValues="@array/pref_dc_certck_values"
             app:layout_constraintEnd_toEndOf="@id/guideline_root_end"
             app:layout_constraintStart_toStartOf="@id/guideline_root_start"
             app:layout_constraintTop_toBottomOf="@id/cert_check_label" />

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -230,8 +230,13 @@
     <string-array name="pref_dc_certck_entries">
         <item>@string/automatic</item>
         <item>@string/strict</item>
-        <item>@string/accept_invalid_hostnames</item>
         <item>@string/accept_invalid_certificates</item>
+    </string-array>
+
+    <string-array name="pref_dc_certck_values">
+        <item>0</item>
+        <item>1</item>
+        <item>3</item>
     </string-array>
 
   <!-- discrete MIME type (the part before the "/") -->


### PR DESCRIPTION
the option 'accept invalid hostnames' does not longer exist, see https://github.com/deltachat/deltachat-core-rust/pull/987