### PR TITLE
fix opening avatar-preview

### DIFF
--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/media_preview__edit"
+        android:title="@string/menu_group_name_and_image"
+        android:icon="@drawable/ic_create_white_24dp"
+        app:showAsAction="always"/>
     <item android:id="@+id/media_preview__forward"
           android:title="@string/menu_forward"
           android:icon="@drawable/ic_forward_white_24dp"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -168,7 +168,6 @@
     <string name="menu_select_all">Select all</string>
     <string name="menu_expand">Expand</string>
     <string name="menu_edit_name">Edit name</string>
-    <string name="menu_edit_group_name_and_image">Edit group name and image</string>
     <string name="menu_edit_group_name">Edit group name</string>
     <string name="menu_edit_group_image">Edit group image</string>
     <string name="menu_settings">Settings</string>

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -213,7 +213,7 @@ public class CreateProfileActivity extends BaseActionBarActivity {
             protected void onPostExecute(byte[] result) {
               if (result != null) {
                 avatarBytes = result;
-                GlideApp.with(getApplicationContext())
+                GlideApp.with(CreateProfileActivity.this)
                         .load(avatarBytes)
                         .skipMemoryCache(true)
                         .diskCacheStrategy(DiskCacheStrategy.NONE)

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -126,7 +126,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
 
     String title;
     if(isEdit()) {
-      title = getString(R.string.menu_edit_group);
+      title = getString(R.string.menu_group_name_and_image);
     }
     else if(verified) {
       title = getString(R.string.menu_new_verified_group);

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -78,6 +78,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
   private final static String TAG = MediaPreviewActivity.class.getSimpleName();
 
+  public static final String ACTIVITY_TITLE_EXTRA = "activity_title";
+  public static final String EDIT_AVATAR_CHAT_ID  = "avatar_for_chat_id";
   public static final String ADDRESS_EXTRA        = "address";
   public static final String OUTGOING_EXTRA       = "outgoing";
   public static final String LEFT_IS_RECENT_EXTRA = "left_is_recent";
@@ -101,6 +103,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
   private int restartItem = -1;
 
+  private int editAvatarChatId = 0;
+
   @SuppressWarnings("ConstantConditions")
   @Override
   protected void onCreate(Bundle bundle, boolean ready) {
@@ -113,6 +117,12 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     setContentView(R.layout.media_preview_activity);
+
+    editAvatarChatId = getIntent().getIntExtra(EDIT_AVATAR_CHAT_ID, 0);
+    @Nullable String title = getIntent().getStringExtra(ACTIVITY_TITLE_EXTRA);
+    if (title!=null) {
+      getSupportActionBar().setTitle(title);
+    }
 
     initializeViews();
     initializeResources();
@@ -246,6 +256,17 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     return restartItem;
   }
 
+  private void editAvatar() {
+    Intent intent = new Intent(this, GroupCreateActivity.class);
+    intent.putExtra(GroupCreateActivity.EDIT_GROUP_CHAT_ID, editAvatarChatId);
+    if (dcContext.getChat(editAvatarChatId).isVerified()) {
+      intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, true);
+    }
+    startActivity(intent);
+    finish(); // avoid the need to update the enlarged-avatar
+  }
+
+
   private void showOverview() {
     if(conversationRecipient.getAddress().isDcChat()) {
       Intent intent = new Intent(this, ProfileActivity.class);
@@ -338,6 +359,10 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
       menu.findItem(R.id.media_preview__forward).setVisible(false);
     }
 
+    if (editAvatarChatId==0) {
+        menu.findItem(R.id.media_preview__edit).setVisible(false);
+    }
+
     return true;
   }
 
@@ -346,6 +371,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     super.onOptionsItemSelected(item);
 
     switch (item.getItemId()) {
+      case R.id.media_preview__edit:     editAvatar();   return true;
       case R.id.media_preview__overview: showOverview(); return true;
       case R.id.media_preview__forward:  forward();      return true;
       case R.id.save:                    saveToDisk();   return true;

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -98,7 +98,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
     titleView = (ConversationTitleView) supportActionBar.getCustomView();
     titleView.setOnBackClickedListener(view -> onBackPressed());
-    titleView.setOnAvatarClickListener(view -> onEnlargeAvatar());
+    titleView.setOnClickListener(view -> onEnlargeAvatar());
 
     updateToolbar();
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -118,7 +118,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       if (chatId != 0) {
         inflater.inflate(R.menu.profile_chat, menu);
         if (chatIsGroup) {
-          menu.findItem(R.id.edit_name).setTitle(R.string.menu_edit_group_name_and_image);
+          menu.findItem(R.id.edit_name).setTitle(R.string.menu_group_name_and_image);
         }
       }
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -405,6 +405,8 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
     Intent intent = new Intent(this, MediaPreviewActivity.class);
     intent.setDataAndType(profileImageUri, type);
+    intent.putExtra(MediaPreviewActivity.ACTIVITY_TITLE_EXTRA, getString(isContactProfile() ? R.string.pref_profile_photo : R.string.group_avatar));
+    intent.putExtra(MediaPreviewActivity.EDIT_AVATAR_CHAT_ID, chatIsGroup ? chatId : 0); // shows edit-button, might be 0 for a contact-profile
     startActivity(intent);
   }
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -401,12 +401,11 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       profileImagePath = dcContext.getContact(contactId).getProfileImage();
 
     profileImageUri = Uri.fromFile(new File(profileImagePath));
-    Context ctx = getBaseContext();
     String type = "image/" + profileImagePath.substring(profileImagePath.lastIndexOf(".") +1);
 
-    Intent intent = new Intent(ctx, MediaPreviewActivity.class);
-      intent.setDataAndType(profileImageUri, type);
-    ctx.startActivity(intent);
+    Intent intent = new Intent(this, MediaPreviewActivity.class);
+    intent.setDataAndType(profileImageUri, type);
+    startActivity(intent);
   }
 
   public void onEditName() {


### PR DESCRIPTION
fix opening avatar-preview, getBaseContext() is not needed and led to…crashes on some android versions as this context might not be an Activity

moreover, this pr streamlines some things:
- open enlarge-avatar-view on title-bar-tap (not only avatar-tap) - this is the way we also open the profile-view
- add an edit-button to the  enlarge-avatar-view
- use the wording already present, in use and translated.
- revert Glide change (see commit history for further explanations)

still unsolved is what happens when there is no avatar to enlarge - currently the empty view opens, with the option to edit. this can be improved (maybe show fallback, maybe show some hints, maybe do not enlarger at all), however, i think this should be part of a follow up.

fixes #1399 