### PR TITLE
initializeListAdapter() in ConversationListFragment.onNewIntent()

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -165,6 +165,7 @@ public class ConversationListFragment extends Fragment
 
   public void onNewIntent() {
     initializeFabClickListener();
+    initializeListAdapter();
   }
 
   public ConversationListAdapter getListAdapter() {


### PR DESCRIPTION
The problem was that the list was not always updated before and after
sharing. Now it always correctly shows or does not show the devicetalk.

@r10s 