### PR TITLE
Revert "initializeListAdapter() in ConversationListFragment.onNewIntent()"

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -163,7 +163,6 @@ public class ConversationListFragment extends Fragment
 
   public void onNewIntent() {
     initializeFabClickListener();
-    initializeListAdapter();
   }
 
   public ConversationListAdapter getListAdapter() {


### PR DESCRIPTION
Reverts deltachat/deltachat-android#1402

the call is expensive. it forces a reloading of the chatlist everytime, the user hits "back" from inside a chat and led to a half-second-delay and a flickering.

i think we have to solve the share-update a bit smarter.