### PR TITLE
start ConversationListActivity with startActivityForResult()

### DIFF
--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -42,6 +42,7 @@ import org.thoughtcrime.securesms.util.RelayUtil;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.setSharedText;
 
 /**
@@ -206,7 +207,9 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
     if (chatId != -1) {
       RelayUtil.setDirectSharing(composeIntent, chatId);
     }
-    startActivity(composeIntent);
+    startActivityForResult(composeIntent, REQUEST_RELAY);
+    // We use startActivityForResult() here so that the conversations list is correctly updated. (hide "Device messages", ...)a
+    // With startActivity() the list was not always updated before and after sharing and incorrectly showed or did not show the device talk.
     finish();
 
   }


### PR DESCRIPTION
so that the conversations list is correctly updated before and after
sharing. Now it always correctly shows or does not show the devicetalk.

Second try after
https://github.com/deltachat/deltachat-android/pull/1402.

@r10s I tried again :wink:. 

I got to the idea because with forwarding everything worked fine and with forwarding startActivityForResult() is used:

    private void handleForwardMessage(final Set<DcMsg> messageRecords) {
        Intent composeIntent = new Intent(getActivity(), ConversationListActivity.class);
        int[] msgIds = DcMsg.msgSetToIds(messageRecords);
        setForwardingMessageIds(composeIntent, msgIds);
        startActivityForResult(composeIntent, REQUEST_RELAY);
        getActivity().overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
    }

In my tests everything worked fine.