### PR TITLE
improve notification grouping

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -285,7 +285,8 @@
               android:enabled="true"
               android:exported="false">
         <intent-filter>
-            <action android:name="org.thoughtcrime.securesms.notifications.CLEAR"/>
+            <action android:name="org.thoughtcrime.securesms.notifications.MARK_NOTICED"/>
+            <action android:name="org.thoughtcrime.securesms.notifications.CANCEL"/>
         </intent-filter>
     </receiver>
 

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -64,6 +64,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   @SuppressWarnings("unused")
   private static final String TAG = ConversationListActivity.class.getSimpleName();
   private static final String OPENPGP4FPR = "openpgp4fpr";
+  public static final String CLEAR_NOTIFICATIONS = "clear_notifications";
 
   private final DynamicTheme    dynamicTheme    = new DynamicNoActionBarTheme();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -128,6 +129,10 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       getSupportActionBar().setDisplayHomeAsUpEnabled(false);
     }
     handleOpenpgp4fpr();
+
+    if (getIntent().getBooleanExtra(CLEAR_NOTIFICATIONS, false)) {
+      DcHelper.getContext(this).notificationCenter.removeAllNotifiations();
+    }
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -11,13 +11,14 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Util;
 
 public class MarkReadReceiver extends BroadcastReceiver {
-
-  public static final  String CLEAR_ACTION          = "org.thoughtcrime.securesms.notifications.CLEAR";
+  public static final  String MARK_NOTICED_ACTION   = "org.thoughtcrime.securesms.notifications.MARK_NOTICED";
+  public static final  String CANCEL_ACTION         = "org.thoughtcrime.securesms.notifications.CANCEL";
   public static final  String CHAT_ID_EXTRA         = "chat_id";
 
   @Override
   public void onReceive(final Context context, Intent intent) {
-    if (!CLEAR_ACTION.equals(intent.getAction())) {
+    boolean markNoticed = MARK_NOTICED_ACTION.equals(intent.getAction());
+    if (!markNoticed && !CANCEL_ACTION.equals(intent.getAction())) {
       return;
     }
 
@@ -30,7 +31,9 @@ public class MarkReadReceiver extends BroadcastReceiver {
 
     Util.runOnAnyBackgroundThread(() -> {
       dcContext.notificationCenter.removeNotifications(chatId);
-      dcContext.marknoticedChat(chatId);
+      if (markNoticed) {
+        dcContext.marknoticedChat(chatId);
+      }
     });
   }
 }

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -483,16 +483,18 @@ public class NotificationCenter {
             // esp. older android are not that great at grouping
             notificationManager.notify(ID_MSG_OFFSET + chatId, builder.build());
 
-            // group notifications together in a summary
-            if (Build.VERSION.SDK_INT >= 23) {
+            // group notifications together in a summary, this is possible since SDK 24 (Android 7)
+            // https://developer.android.com/training/notify-user/group.html
+            // in theory, this won't be needed due to setGroup(), however, in practise, it is needed up to at least Android 10.
+            if (Build.VERSION.SDK_INT >= 24) {
                 NotificationCompat.Builder summary = new NotificationCompat.Builder(context, notificationChannel)
                         .setGroup(GRP_MSG)
                         .setGroupSummary(true)
                         .setSmallIcon(R.drawable.icon_notification)
                         .setColor(context.getResources().getColor(R.color.delta_primary))
                         .setCategory(NotificationCompat.CATEGORY_MESSAGE)
-                        .setContentTitle("summary title")
-                        .setContentText("summary text")
+                        .setContentTitle("Delta Chat") // content title would only be used on SDK <24
+                        .setContentText("New messages") // content text would only be used on SDK <24
                         .setContentIntent(getOpenChatlistIntent());
                 notificationManager.notify(ID_MSG_SUMMARY, summary.build());
             }

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -333,7 +333,7 @@ public class NotificationCenter {
             NotificationPrivacyPreference privacy = Prefs.getNotificationPrivacy(context);
 
             DcMsg dcMsg = dcContext.getMsg(msgId);
-            String line = privacy.isDisplayMessage()? dcMsg.getSummarytext(100) : context.getString(R.string.notify_new_message);
+            String line = privacy.isDisplayMessage()? dcMsg.getSummarytext(2000) : context.getString(R.string.notify_new_message);
             if (dcChat.isGroup() && privacy.isDisplayContact()) {
                 line = dcContext.getContact(dcMsg.getFromId()).getFirstName() + ": " + line;
             }

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -133,7 +133,7 @@ public class NotificationCenter {
     private static final String CH_GRP_MSG = "chgrp_msg";
 
     // this is to group together notifications as such, maybe including a summary,
-    // ^see https://developer.android.com/training/notify-user/group.html
+    // see https://developer.android.com/training/notify-user/group.html
     private static final String GRP_MSG = "grp_msg";
 
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -219,7 +219,7 @@ public class NotificationCenter {
             NotificationChannelGroup chGrp = new NotificationChannelGroup(CH_GRP_MSG, context.getString(R.string.pref_chats));
             notificationManager.createNotificationChannelGroup(chGrp);
         }
-        return GRP_MSG;
+        return CH_GRP_MSG;
     }
 
     private String getNotificationChannel(NotificationManagerCompat notificationManager, DcChat dcChat) {

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -129,7 +129,12 @@ public class NotificationCenter {
     // Groups and Notification channel groups
     // --------------------------------------------------------------------------------------------
 
-    public static final String GRP_MSG = "chgrp_msg";
+    // this is just to further organize the appearance of channels in the settings UI
+    private static final String CH_GRP_MSG = "chgrp_msg";
+
+    // this is to group together notifications as such, maybe including a summary,
+    // ^see https://developer.android.com/training/notify-user/group.html
+    private static final String GRP_MSG = "grp_msg";
 
 
     // Notification IDs
@@ -202,8 +207,8 @@ public class NotificationCenter {
     }
 
     private String getNotificationChannelGroup(NotificationManagerCompat notificationManager) {
-        if (notificationChannelsSupported() && notificationManager.getNotificationChannelGroup(GRP_MSG) == null) {
-            NotificationChannelGroup chGrp = new NotificationChannelGroup(GRP_MSG, context.getString(R.string.pref_chats));
+        if (notificationChannelsSupported() && notificationManager.getNotificationChannelGroup(CH_GRP_MSG) == null) {
+            NotificationChannelGroup chGrp = new NotificationChannelGroup(CH_GRP_MSG, context.getString(R.string.pref_chats));
             notificationManager.createNotificationChannelGroup(chGrp);
         }
         return GRP_MSG;

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -28,6 +28,7 @@ import com.b44t.messenger.DcMsg;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import org.thoughtcrime.securesms.ConversationActivity;
+import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
@@ -97,7 +98,13 @@ public class NotificationCenter {
         }
         return argb;
     }
-    
+
+    private PendingIntent getOpenChatlistIntent() {
+        Intent intent = new Intent(context, ConversationListActivity.class);
+        intent.putExtra(ConversationListActivity.CLEAR_NOTIFICATIONS, true);
+        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
     private PendingIntent getOpenChatIntent(int chatId) {
         Intent intent = new Intent(context, ConversationActivity.class);
         intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
@@ -485,7 +492,8 @@ public class NotificationCenter {
                         .setColor(context.getResources().getColor(R.color.delta_primary))
                         .setCategory(NotificationCompat.CATEGORY_MESSAGE)
                         .setContentTitle("summary title")
-                        .setContentText("summary text");
+                        .setContentText("summary text")
+                        .setContentIntent(getOpenChatlistIntent());
                 notificationManager.notify(ID_MSG_SUMMARY, summary.build());
             }
         });


### PR DESCRIPTION
this pr creates a normally invisible summary-notification; this is needed to let android7+ let respect the group set by setGroup()

todo:

- ~~we have to dismiss the summary manually when we cancel notifications on our own by entering a chat~~ EDIT: done
- taping on the summary should open the chatlist

setting a correct title/text seems not to be needed as this is not displayed anyway.
using the summary on android<7 - i have not tested that, however, the system does not group much there anyway, so maybe things are already fine (enough).

in theory, we could _only_ show the summary on android<7 to have less notifications at all, however, of course, this would require setting the correct text/title and this can be part of another pr.

closes #1413 