### PR TITLE
Generally show device message notifications, open password settings if the user clicks on a "wrong pw" message

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -722,6 +722,15 @@ public class ConversationFragment extends Fragment
             else if(DozeReminder.isDozeReminderMsg(getContext(), messageRecord)) {
                 DozeReminder.dozeReminderTapped(getContext());
             }
+            else {
+                String self_mail = dcContext.getConfig("configured_mail_user");
+                if (self_mail != null && !self_mail.isEmpty()
+                        && messageRecord.getText().contains(self_mail)
+                        && getListAdapter().getChat().isDeviceTalk()) {
+                    // This is a device message informing the user that the password is wrong
+                    startActivity(new Intent(getActivity(), RegistrationActivity.class));
+                }
+            }
         }
 
         @Override

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -308,12 +308,6 @@ public class NotificationCenter {
                 return;
             }
 
-            if (dcChat.isDeviceTalk()) {
-                // currently, we just never notify on device chat.
-                // esp. on first start, this is annoying.
-                return;
-            }
-
             NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
 
             // get notification text as a single line


### PR DESCRIPTION
for https://github.com/deltachat/deltachat-core-rust/pull/1613 (we might also have to do this for Desktop and IOS)