### PR TITLE
You won't believe how this makes the compilation 4x faster!

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,3 @@
 APP_PLATFORM := android-16
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_STL := c++_static
-

--- a/ndk-make-fast.sh
+++ b/ndk-make-fast.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# If you want to, you can run this script with instead of ndk-make.sh your architecture as an argument
+# to speed up compilation by factor 4 (will not work on macOS and might not work for other reasons):
+#
+#     ./ndk-make.sh arm64-v8a
+#
+# Possible values are armeabi-v7a, arm64-v8a, x86 and x86_64.
+# You should be able to find out your architecture by running:
+#
+#     adb shell uname -m
+#
+# or:
+#
+#     adb shell cat /proc/cpuinfo
+#
+# The values in the following lines mean the same:
+#
+# armeabi-v7a, armv7 and arm
+# arm64-v8a, aarch64 and arm64
+# x86 and i686
+# (there are no synonyms for x86_64)
+
+
+set -e
+echo "starting time: `date`"
+
+# Check if the argument is a correct architecture:
+if test $1 && echo "armeabi-v7a arm64-v8a x86 x86_64" | grep -vwq $1; then
+    echo "Architecture '$1' not known, possible values are armeabi-v7a, arm64-v8a, x86 and x86_64."
+    exit
+fi
+
+cd jni
+rm -f armeabi-v7a/*
+rm -f arm64-v8a/*
+rm -f x86/*
+rm -f x86_64/*
+mkdir -p armeabi-v7a
+mkdir -p arm64-v8a
+mkdir -p x86
+mkdir -p x86_64
+
+cd deltachat-core-rust
+
+# fix build on MacOS Catalina
+unset CPATH
+
+if test -z $1 || test $1 = armeabi-v7a; then
+    echo "-- cross compiling to armv7-linux-androideabi (arm) --"
+    export CFLAGS=-D__ANDROID_API__=16
+    TARGET_CC=armv7a-linux-androideabi16-clang \
+    cargo +`cat rust-toolchain` build --release --target armv7-linux-androideabi -p deltachat_ffi
+    cp target/armv7-linux-androideabi/release/libdeltachat.a ../armeabi-v7a
+fi
+
+if test -z $1 || test $1 = arm64-v8a; then
+    echo "-- cross compiling to aarch64-linux-android (arm64) --"
+    export CFLAGS=-D__ANDROID_API__=21
+    TARGET_CC=aarch64-linux-android21-clang \
+    cargo +`cat rust-toolchain` build --release --target aarch64-linux-android -p deltachat_ffi
+    cp target/aarch64-linux-android/release/libdeltachat.a ../arm64-v8a
+fi
+
+if test -z $1 || test $1 = x86; then
+    echo "-- cross compiling to i686-linux-android (x86) --"
+    export CFLAGS=-D__ANDROID_API__=16
+    TARGET_CC=i686-linux-android16-clang \
+    cargo +`cat rust-toolchain` build --release --target i686-linux-android -p deltachat_ffi
+    cp target/i686-linux-android/release/libdeltachat.a ../x86
+fi
+
+if test -z $1 || test $1 = x86_64; then
+    echo "-- cross compiling to x86_64-linux-android (x86_64) --"
+    export CFLAGS=-D__ANDROID_API__=21
+    TARGET_CC=x86_64-linux-android21-clang \
+    cargo +`cat rust-toolchain` build --release --target x86_64-linux-android -p deltachat_ffi
+    cp target/x86_64-linux-android/release/libdeltachat.a ../x86_64
+fi
+
+echo -- ndk-build --
+
+cd ..
+# Set the right arch in Application.mk:
+oldDotMk="$(cat Application.mk)"
+
+if test $1; then
+    sed -i "s/APP_ABI.*/APP_ABI := $1/g" Application.mk
+else
+    # We are compiling for all architectures:
+    sed -i "s/APP_ABI.*/APP_ABI := armeabi-v7a arm64-v8a x86 x86_64/g" Application.mk
+fi
+
+cd ..
+ndk-build
+
+cd jni
+# Restore old Application.mk:
+echo "$oldDotMk" > Application.mk
+
+echo "ending time: `date`"

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
+set -e
+echo "starting time: `date`"
+
+cd jni/deltachat-core-rust
 
 # to setup the toolchains (from https://medium.com/visly/rust-on-android-19f34a2fb43 )
 # run the following in `jni/deltachat-core-rust`:
-#
-#    rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android --toolchain `cat rust-toolchain`
+# $ rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android --toolchain `cat rust-toolchain`
 # 
 # Currently ndk20b is minimum required version
 # (newer versions will likely work, however, are not tested and not used in offial releases,
@@ -21,40 +24,34 @@
 # [target.x86_64-linux-android]
 # linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/x86_64-linux-android21-clang"
 # ```
-#
-#
-# If you want to, you can run the script with your architecture as an argument
-# to speed up compilation by factor 4:
-#
-#     ./ndk-make.sh arm64-v8a
-#
-# Possible values are armeabi-v7a, arm64-v8a, x86 and x86_64.
-# You should be able to find out your architecture by running:
-#
-#     adb shell uname -m
-#
-# or:
-#
-#     adb shell cat /proc/cpuinfo
-#
-# The values in the following lines mean the same:
-#
-# armeabi-v7a, armv7 and arm
-# arm64-v8a, aarch64 and arm64
-# x86 and i686
-# (there are no synonyms for x86_64)
+# then, the following should work:
+# (If you want to speed up compilation, have look at the comment in ndk-make-fast.sh.)
 
+# fix build on MacOS Catalina
+unset CPATH
 
-set -e
-echo "starting time: `date`"
+echo "-- cross compiling to armv7-linux-androideabi (arm) --"
+export CFLAGS=-D__ANDROID_API__=16
+TARGET_CC=armv7a-linux-androideabi16-clang \
+cargo +`cat rust-toolchain` build --release --target armv7-linux-androideabi -p deltachat_ffi
 
-# Check if the argument is a correct architecture:
-if test $1 && echo "armeabi-v7a arm64-v8a x86 x86_64" | grep -vwq $1; then
-    echo "Architecture '$1' not known, possible values are armeabi-v7a, arm64-v8a, x86 and x86_64."
-    exit
-fi
+echo "-- cross compiling to aarch64-linux-android (arm64) --"
+export CFLAGS=-D__ANDROID_API__=21
+TARGET_CC=aarch64-linux-android21-clang \
+cargo +`cat rust-toolchain` build --release --target aarch64-linux-android -p deltachat_ffi
 
-cd jni
+echo "-- cross compiling to i686-linux-android (x86) --"
+export CFLAGS=-D__ANDROID_API__=16
+TARGET_CC=i686-linux-android16-clang \
+cargo +`cat rust-toolchain` build --release --target i686-linux-android -p deltachat_ffi
+
+echo "-- cross compiling to x86_64-linux-android (x86_64) --"
+export CFLAGS=-D__ANDROID_API__=21
+TARGET_CC=x86_64-linux-android21-clang \
+cargo +`cat rust-toolchain` build --release --target x86_64-linux-android -p deltachat_ffi
+
+echo -- copy generated .a files --
+cd ..
 rm -f armeabi-v7a/*
 rm -f arm64-v8a/*
 rm -f x86/*
@@ -63,62 +60,12 @@ mkdir -p armeabi-v7a
 mkdir -p arm64-v8a
 mkdir -p x86
 mkdir -p x86_64
-
-cd deltachat-core-rust
-
-# fix build on MacOS Catalina
-unset CPATH
-
-if test -z $1 || test $1 = armeabi-v7a; then
-    echo "-- cross compiling to armv7-linux-androideabi (arm) --"
-    export CFLAGS=-D__ANDROID_API__=16
-    TARGET_CC=armv7a-linux-androideabi16-clang \
-    cargo +`cat rust-toolchain` build --release --target armv7-linux-androideabi -p deltachat_ffi
-    cp target/armv7-linux-androideabi/release/libdeltachat.a ../armeabi-v7a
-fi
-
-if test -z $1 || test $1 = arm64-v8a; then
-    echo "-- cross compiling to aarch64-linux-android (arm64) --"
-    export CFLAGS=-D__ANDROID_API__=21
-    TARGET_CC=aarch64-linux-android21-clang \
-    cargo +`cat rust-toolchain` build --release --target aarch64-linux-android -p deltachat_ffi
-    cp target/aarch64-linux-android/release/libdeltachat.a ../arm64-v8a
-fi
-
-if test -z $1 || test $1 = x86; then
-    echo "-- cross compiling to i686-linux-android (x86) --"
-    export CFLAGS=-D__ANDROID_API__=16
-    TARGET_CC=i686-linux-android16-clang \
-    cargo +`cat rust-toolchain` build --release --target i686-linux-android -p deltachat_ffi
-    cp target/i686-linux-android/release/libdeltachat.a ../x86
-fi
-
-if test -z $1 || test $1 = x86_64; then
-    echo "-- cross compiling to x86_64-linux-android (x86_64) --"
-    export CFLAGS=-D__ANDROID_API__=21
-    TARGET_CC=x86_64-linux-android21-clang \
-    cargo +`cat rust-toolchain` build --release --target x86_64-linux-android -p deltachat_ffi
-    cp target/x86_64-linux-android/release/libdeltachat.a ../x86_64
-fi
+cp deltachat-core-rust/target/armv7-linux-androideabi/release/libdeltachat.a armeabi-v7a
+cp deltachat-core-rust/target/aarch64-linux-android/release/libdeltachat.a arm64-v8a
+cp deltachat-core-rust/target/i686-linux-android/release/libdeltachat.a x86
+cp deltachat-core-rust/target/x86_64-linux-android/release/libdeltachat.a x86_64
 
 echo -- ndk-build --
-
-cd ..
-# Set the right arch in Application.mk:
-oldDotMk="$(cat Application.mk)"
-
-if test $1; then
-    sed -i "s/APP_ABI.*/APP_ABI := $1/g" Application.mk
-else
-    # We are compiling for all architectures:
-    sed -i "s/APP_ABI.*/APP_ABI := armeabi-v7a arm64-v8a x86 x86_64/g" Application.mk
-fi
-
 cd ..
 ndk-build
-
-cd jni
-# Restore old Application.mk:
-echo "$oldDotMk" > Application.mk
-
 echo "ending time: `date`"

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
-set -e
-echo "starting time: `date`"
-
-cd jni/deltachat-core-rust
 
 # to setup the toolchains (from https://medium.com/visly/rust-on-android-19f34a2fb43 )
 # run the following in `jni/deltachat-core-rust`:
-# $ rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android --toolchain `cat rust-toolchain`
+#
+#    rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android --toolchain `cat rust-toolchain`
 # 
 # Currently ndk20b is minimum required version
 # (newer versions will likely work, however, are not tested and not used in offial releases,
@@ -24,33 +21,40 @@ cd jni/deltachat-core-rust
 # [target.x86_64-linux-android]
 # linker = "PATH_TO_NDK/toolchains/llvm/prebuilt/HOST/bin/x86_64-linux-android21-clang"
 # ```
-# then, the following should work:
+#
+#
+# If you want to, you can run the script with your architecture as an argument
+# to speed up compilation by factor 4:
+#
+#     ./ndk-make.sh arm64-v8a
+#
+# Possible values are armeabi-v7a, arm64-v8a, x86 and x86_64.
+# You should be able to find out your architecture by running:
+#
+#     adb shell uname -m
+#
+# or:
+#
+#     adb shell cat /proc/cpuinfo
+#
+# The values in the following lines mean the same:
+#
+# armeabi-v7a, armv7 and arm
+# arm64-v8a, aarch64 and arm64
+# x86 and i686
+# (there are no synonyms for x86_64)
 
-# fix build on MacOS Catalina
-unset CPATH
 
-echo "-- cross compiling to armv7-linux-androideabi (arm) --"
-export CFLAGS=-D__ANDROID_API__=16
-TARGET_CC=armv7a-linux-androideabi16-clang \
-cargo +`cat rust-toolchain` build --release --target armv7-linux-androideabi -p deltachat_ffi
+set -e
+echo "starting time: `date`"
 
-echo "-- cross compiling to aarch64-linux-android (arm64) --"
-export CFLAGS=-D__ANDROID_API__=21
-TARGET_CC=aarch64-linux-android21-clang \
-cargo +`cat rust-toolchain` build --release --target aarch64-linux-android -p deltachat_ffi
+# Check if the argument is a correct architecture:
+if test $1 && echo "armeabi-v7a arm64-v8a x86 x86_64" | grep -vwq $1; then
+    echo "Architecture '$1' not known, possible values are armeabi-v7a, arm64-v8a, x86 and x86_64."
+    exit
+fi
 
-echo "-- cross compiling to i686-linux-android (x86) --"
-export CFLAGS=-D__ANDROID_API__=16
-TARGET_CC=i686-linux-android16-clang \
-cargo +`cat rust-toolchain` build --release --target i686-linux-android -p deltachat_ffi
-
-echo "-- cross compiling to x86_64-linux-android (x86_64) --"
-export CFLAGS=-D__ANDROID_API__=21
-TARGET_CC=x86_64-linux-android21-clang \
-cargo +`cat rust-toolchain` build --release --target x86_64-linux-android -p deltachat_ffi
-
-echo -- copy generated .a files --
-cd ..
+cd jni
 rm -f armeabi-v7a/*
 rm -f arm64-v8a/*
 rm -f x86/*
@@ -59,12 +63,62 @@ mkdir -p armeabi-v7a
 mkdir -p arm64-v8a
 mkdir -p x86
 mkdir -p x86_64
-cp deltachat-core-rust/target/armv7-linux-androideabi/release/libdeltachat.a armeabi-v7a
-cp deltachat-core-rust/target/aarch64-linux-android/release/libdeltachat.a arm64-v8a
-cp deltachat-core-rust/target/i686-linux-android/release/libdeltachat.a x86
-cp deltachat-core-rust/target/x86_64-linux-android/release/libdeltachat.a x86_64
+
+cd deltachat-core-rust
+
+# fix build on MacOS Catalina
+unset CPATH
+
+if test -z $1 || test $1 = armeabi-v7a; then
+    echo "-- cross compiling to armv7-linux-androideabi (arm) --"
+    export CFLAGS=-D__ANDROID_API__=16
+    TARGET_CC=armv7a-linux-androideabi16-clang \
+    cargo +`cat rust-toolchain` build --release --target armv7-linux-androideabi -p deltachat_ffi
+    cp target/armv7-linux-androideabi/release/libdeltachat.a ../armeabi-v7a
+fi
+
+if test -z $1 || test $1 = arm64-v8a; then
+    echo "-- cross compiling to aarch64-linux-android (arm64) --"
+    export CFLAGS=-D__ANDROID_API__=21
+    TARGET_CC=aarch64-linux-android21-clang \
+    cargo +`cat rust-toolchain` build --release --target aarch64-linux-android -p deltachat_ffi
+    cp target/aarch64-linux-android/release/libdeltachat.a ../arm64-v8a
+fi
+
+if test -z $1 || test $1 = x86; then
+    echo "-- cross compiling to i686-linux-android (x86) --"
+    export CFLAGS=-D__ANDROID_API__=16
+    TARGET_CC=i686-linux-android16-clang \
+    cargo +`cat rust-toolchain` build --release --target i686-linux-android -p deltachat_ffi
+    cp target/i686-linux-android/release/libdeltachat.a ../x86
+fi
+
+if test -z $1 || test $1 = x86_64; then
+    echo "-- cross compiling to x86_64-linux-android (x86_64) --"
+    export CFLAGS=-D__ANDROID_API__=21
+    TARGET_CC=x86_64-linux-android21-clang \
+    cargo +`cat rust-toolchain` build --release --target x86_64-linux-android -p deltachat_ffi
+    cp target/x86_64-linux-android/release/libdeltachat.a ../x86_64
+fi
 
 echo -- ndk-build --
+
+cd ..
+# Set the right arch in Application.mk:
+oldDotMk="$(cat Application.mk)"
+
+if test $1; then
+    sed -i "s/APP_ABI.*/APP_ABI := $1/g" Application.mk
+else
+    # We are compiling for all architectures:
+    sed -i "s/APP_ABI.*/APP_ABI := armeabi-v7a arm64-v8a x86 x86_64/g" Application.mk
+fi
+
 cd ..
 ndk-build
+
+cd jni
+# Restore old Application.mk:
+echo "$oldDotMk" > Application.mk
+
 echo "ending time: `date`"


### PR DESCRIPTION
Sorry for the click-bait title, but it fitted too well :wink: :tada: 

Anyway, I added the possibility to ndk-make.sh to compile only for one
arch.

In my tests, if I also set the optimisation level to 0 (default is 3),
the compilation time went down from 3:30 to 1:20. Not sure if this is
worth it because I remember a comment stating that this makes generating
keys take forever. Maybe I should do some measurements and experiment
with levels 1 and 2 but that's for another PR.

What do you think?

Also - NO MORE WAITING 20MIN FOR COMPILATION TO FINISH!!!!!!!!!!!!!!!! :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: :tada: 