### PR TITLE
quick-fix background jumping

### DIFF
--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent" android:layout_width="match_parent">
-
-    <ImageView
-        android:id="@+id/conversation_background"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:ignore="ContentDescription"
-        android:scaleType="centerCrop" />
-
     <org.thoughtcrime.securesms.components.InputAwareLayout
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
             android:id="@+id/layout_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent">

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -176,7 +176,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   InputAwareLayout            container;
   private   View                        composePanel;
   protected Stub<ReminderView>          reminderView;
-  private   ImageView                   backgroundView;
 
   private   AttachmentTypeSelector attachmentTypeSelector;
   private   AttachmentManager      attachmentManager;
@@ -801,7 +800,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     quickAttachmentDrawer = ViewUtil.findById(this, R.id.quick_attachment_drawer);
     quickAttachmentToggle = ViewUtil.findById(this, R.id.quick_attachment_toggle);
     inputPanel            = ViewUtil.findById(this, R.id.bottom_panel);
-    backgroundView        = ViewUtil.findById(this, R.id.conversation_background);
 
     ImageButton quickCameraToggle = ViewUtil.findById(this, R.id.quick_camera_toggle);
 
@@ -846,13 +844,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     String backgroundImagePath = Prefs.getBackgroundImagePath(this);
     if(!backgroundImagePath.isEmpty()) {
       Drawable image = Drawable.createFromPath(backgroundImagePath);
-      backgroundView.setImageDrawable(image);
+      getWindow().setBackgroundDrawable(image);
     }
     else if(dynamicTheme.isDarkTheme(this)) {
-      backgroundView.setImageResource(R.drawable.background_hd_dark);
+      getWindow().setBackgroundDrawableResource(R.drawable.background_hd_dark);
     }
     else {
-      backgroundView.setImageResource(R.drawable.background_hd);
+      getWindow().setBackgroundDrawableResource(R.drawable.background_hd);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
@@ -136,15 +136,13 @@ public class ChatBackgroundActivity extends PassphraseRequiredActionBarActivity 
             Display display = ServiceUtil.getWindowManager(context).getDefaultDisplay();
             Point size = new Point();
             display.getSize(size);
-            // resize so that the larger side fits the screen accurately
-            int largerSide = (size.x > size.y ? size.x : size.y);
             Bitmap scaledBitmap = GlideApp.with(context)
                     .asBitmap()
                     .load(imageUri)
-                    .fitCenter()
+                    .centerCrop()
                     .skipMemoryCache(true)
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .submit(largerSide, largerSide)
+                    .submit(size.x, size.y)
                     .get();
             FileOutputStream outStream = new FileOutputStream(destinationPath);
             scaledBitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream);


### PR DESCRIPTION
this pr reverts #1372 and fixes the new bug #1417 -by that, #466 gets reopened.

i think, the jumping background image on opening/closing is worse than having a calm background image with maybe bad aspect ratio.

in other words, this pr makes things as good or as bad as in the current releases.

of course, in a subsequent pr, both things will be fixed, however, that is not that simple as it appears first.