### PR TITLE
improve layout of emoji popups

### DIFF
--- a/res/drawable/emoji_variation_selector_background_light.xml
+++ b/res/drawable/emoji_variation_selector_background_light.xml
@@ -4,6 +4,7 @@
     android:shape="rectangle">
 
     <corners android:radius="5dp" />
+    <stroke android:width="1dp" android:color="@color/grey_400"/>
     <solid android:color="@color/core_white" />
 
 </shape>


### PR DESCRIPTION
in light mode, input field and emoji popups are both white,
therefore opening the emoji popup (used eg. for diversified emojis)
in the first line looks weird, you do not really know
if the display is part of the emoji picker or of the input field.
fixing that by adding a small border around the popup.

in dark mode, things are already fine.