### PR TITLE
Revert "fix recent emoji updates"

### DIFF
--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiKeyboardProvider.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiKeyboardProvider.java
@@ -48,7 +48,6 @@ public class EmojiKeyboardProvider implements MediaKeyboardProvider,
       @Override
       public void onEmojiSelected(String emoji) {
         recentModel.onCodePointSelected(emoji);
-        emojiPagerAdapter.notifyDataSetChanged();
 
         if (emojiEventListener != null) {
           emojiEventListener.onEmojiSelected(emoji);
@@ -157,11 +156,6 @@ public class EmojiKeyboardProvider implements MediaKeyboardProvider,
     @Override
     public boolean isViewFromObject(View view, Object object) {
       return view == object;
-    }
-
-    @Override
-    public int getItemPosition(@NonNull Object object) {
-      return POSITION_NONE;
     }
   }
 


### PR DESCRIPTION
Fixes #1438 - tapping the same emoji position twice results in the same emoji now, also on the recent tab.

This reverts commit 6aec743e4dfb907b9cc667a0969ffceb98e24fe4 (including its POSITION_NONE behavior, that may led to performance issues as this always says "this item is no longer valid, please recreate) and synchronizes the corresponding code to the signal upstream.

wrt the original issue, that some emojis are not added instantly (https://github.com/deltachat/deltachat-android/pull/1410#pullrequestreview-430162678) - this seems to be a minor issue compared to #1438 - esp. as the list is always updates onces the keyboard is reopened (the same issue is upstream, btw).