### PR TITLE
more accurate check of account-database-names

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -64,7 +64,7 @@ public class AccountManager {
 
     private @Nullable Account maybeGetAccount(File file) {
         try {
-            if (!file.isDirectory() && file.getName().endsWith(".db")) {
+            if (!file.isDirectory() && file.getName().startsWith("messenger") && file.getName().endsWith(".db")) {
                 DcContext testContext = new DcContext(null, file.getAbsolutePath());
                 if (testContext.isOk()) {
                     Account ret = new Account();


### PR DESCRIPTION
account-database-names have the format messenger*.db -
only checking for the extension will offer eg.
mapbox cachefiles in the account switcher (mbgl-offline.db)

fixes #1440 