### PR TITLE
jni: use dc_array_get_id instead of dc_array_get_raw

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -117,18 +117,12 @@ static jintArray dc_array2jintArray_n_unref(JNIEnv *env, dc_array_t* ca)
 
 	if (ca) {
 		if (icnt) {
-			const uint32_t* ca_data = dc_array_get_raw(ca);
-			if (sizeof(uint32_t)==sizeof(jint)) {
-				(*env)->SetIntArrayRegion(env, ret, 0, icnt, (jint*)ca_data);
+			jint* temp = calloc(icnt, sizeof(jint));
+			for (i = 0; i < icnt; i++) {
+				temp[i] = (jint)dc_array_get_id(ca, i);
 			}
-			else {
-				jint* temp = calloc(icnt, sizeof(jint));
-					for (i = 0; i < icnt; i++) {
-						temp[i] = (jint)ca_data[i];
-					}
-					(*env)->SetIntArrayRegion(env, ret, 0, icnt, temp);
-				free(temp);
-			}
+			(*env)->SetIntArrayRegion(env, ret, 0, icnt, temp);
+			free(temp);
 		}
 		dc_array_unref(ca);
 	}


### PR DESCRIPTION
dc_array_get_raw API prevents Rust code from storing IDs in other format
than an array of uint32_t.

iOS code and node bindings (see `dc_array_to_js_array`) already use `dc_array_get_id` loops, Android client is the only user of this API.