### PR TITLE
add an update debouncer

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -110,6 +110,7 @@ public class ConversationFragment extends Fragment
     private View                        floatingLocationButton;
     private TextView                    noMessageTextView;
     private ApplicationDcContext        dcContext;
+    private Debouncer                   updateDebouncer = new Debouncer(500);
 
     public boolean isPaused;
     private Debouncer markseenDebouncer;
@@ -835,6 +836,6 @@ public class ConversationFragment extends Fragment
             setLastSeen(-1);
         }*/
 
-        reloadList();
+        updateDebouncer.publish(() -> reloadList());
     }
 }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -62,6 +62,7 @@ import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcChatlistLoader;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.util.Debouncer;
 import org.thoughtcrime.securesms.util.RelayUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.guava.Optional;
@@ -94,6 +95,7 @@ public class ConversationListFragment extends Fragment
   private Locale                      locale;
   private String                      queryFilter  = "";
   private boolean                     archive;
+  private Debouncer                   updateDebouncer = new Debouncer(500);
 
   @Override
   public void onCreate(Bundle icicle) {
@@ -533,7 +535,7 @@ public class ConversationListFragment extends Fragment
 
   @Override
   public void handleEvent(int eventId, Object data1, Object data2) {
-    getLoaderManager().restartLoader(0,null,this);
+    updateDebouncer.publish(() -> getLoaderManager().restartLoader(0,null,this));
   }
 }
 


### PR DESCRIPTION
just an experiment, to not redraw on each and every DC_EVENT_MSGS_CHANGED event.

however, even on a relatively slow testing phone, the chatlist stays usable even when updates were not debounced.

as the debouncer also adds some delay, it seems not to be worth the effort.