### PR TITLE
Ephemeral messages ui

### DIFF
--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -39,4 +39,8 @@
           android:icon="?menu_map_icon"
           app:showAsAction="ifRoom" />
 
+    <item android:id="@+id/menu_ephemeral_messages"
+          android:title="@string/pref_ephemeral_messages"
+          android:visible="false" />
+
 </menu>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -127,7 +127,16 @@
       <item>@string/custom</item>
   </string-array>
 
-  <string-array name="mute_durations">
+    <string-array name="ephemeral_message_durations">
+        <item>@string/off</item>
+        <item>@string/after_30_seconds</item>
+        <item>@string/after_one_minute</item>
+        <item>@string/after_one_day</item>
+        <item>@string/after_one_week</item>
+        <item>@string/after_four_weeks</item>
+    </string-array>
+
+    <string-array name="mute_durations">
       <item>@string/mute_for_one_hour</item>
       <item>@string/mute_for_two_hours</item>
       <item>@string/mute_for_one_day</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -473,6 +473,7 @@
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>
+    <string name="pref_ephemeral_messages">Ephemeral Messages</string>
 
 
     <!-- automatically delete message -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -62,6 +62,12 @@
     <string name="this_month">This month</string>
     <string name="last_week">Last week</string>
     <string name="last_month">Last month</string>
+    <string name="n_seconds">%d seconds</string>
+    <string name="one_minute">One minute</string>
+    <string name="one_hour">One hour</string>
+    <string name="one_day">One day</string>
+    <string name="one_week">One week</string>
+    <string name="four_weeks">Four weeks</string>
     <!-- Translators: show beside messages that are "N minutes old". prefer a short string, prefer abbreviations if they're well-known -->
     <plurals name="n_minutes">
         <item quantity="one">%d min</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -481,7 +481,7 @@
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>
-    <string name="pref_ephemeral_messages">Ephemeral Messages</string>
+    <string name="pref_ephemeral_messages">Self-destructing messages</string>
 
 
     <!-- automatically delete message -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -62,12 +62,6 @@
     <string name="this_month">This month</string>
     <string name="last_week">Last week</string>
     <string name="last_month">Last month</string>
-    <string name="n_seconds">%d seconds</string>
-    <string name="one_minute">One minute</string>
-    <string name="one_hour">One hour</string>
-    <string name="one_day">One day</string>
-    <string name="one_week">One week</string>
-    <string name="four_weeks">Four weeks</string>
     <!-- Translators: show beside messages that are "N minutes old". prefer a short string, prefer abbreviations if they're well-known -->
     <plurals name="n_minutes">
         <item quantity="one">%d min</item>
@@ -198,6 +192,14 @@
     <string name="pin">Pin</string>
     <!-- Translators: this is the opposite of "Pin", removing the sticky-state from sth. -->
     <string name="unpin">Unpin</string>
+
+    <!-- epemeral messages -->
+    <string name="after_30_seconds">After 30 seconds</string>
+    <string name="after_one_minute">After one minute</string>
+    <string name="after_one_hour">After one hour</string>
+    <string name="after_one_day">After one day</string>
+    <string name="after_one_week">After one week</string>
+    <string name="after_four_weeks">After four weeks</string>
 
     <string name="mute_for_one_hour">Mute for 1 hour</string>
     <string name="mute_for_two_hours">Mute for 2 hours</string>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -54,7 +54,7 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="pref_location_streaming_enabled"
-            android:title="On-demand location streaming"/>
+            android:title="@string/pref_on_demand_location_streaming"/>
 
     </PreferenceCategory>
 

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -56,6 +56,11 @@
             android:key="pref_location_streaming_enabled"
             android:title="@string/pref_on_demand_location_streaming"/>
 
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_ephemeral_messages"
+            android:title="@string/pref_ephemeral_messages"/>
+
     </PreferenceCategory>
 
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -444,6 +444,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       menu.findItem(R.id.menu_show_map).setVisible(false);
     }
 
+    if (Prefs.isEphemeralMessagesEnabled(this)) {
+      menu.findItem(R.id.menu_ephemeral_messages).setVisible(true);
+    }
+
     if (isGroupConversation()) {
       if (isActiveGroup()) {
         inflater.inflate(R.menu.conversation_push_group_options, menu);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -518,6 +518,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       case R.id.menu_search_up:             handleMenuSearchNext(false);       return true;
       case R.id.menu_search_down:           handleMenuSearchNext(true);        return true;
       case android.R.id.home:               handleReturnToConversationList();  return true;
+      case R.id.menu_ephemeral_messages:    handleEphemeralMessages();         return true;
     }
 
     return false;
@@ -544,6 +545,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   //////// Event Handlers
+
+  private void handleEphemeralMessages() {
+      int preselected = dcContext.getChatEphemeralTimer(chatId);
+      EphemeralMessagesDialog.show(this, preselected, duration -> {
+        dcContext.setChatEphemeralTimer(chatId, (int) duration);
+      });
+  }
 
   private void handleShowMap() {
     Intent intent = new Intent(this, MapActivity.class);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -444,7 +444,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       menu.findItem(R.id.menu_show_map).setVisible(false);
     }
 
-    if (Prefs.isEphemeralMessagesEnabled(this)) {
+    if (Prefs.isEphemeralMessagesEnabled(this) || dcContext.getChatEphemeralTimer(chatId) != 0) {
       menu.findItem(R.id.menu_ephemeral_messages).setVisible(true);
     }
 

--- a/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
+++ b/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
@@ -1,0 +1,65 @@
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+
+import java.util.concurrent.TimeUnit;
+
+public class EphemeralMessagesDialog {
+
+    private final static String TAG = EphemeralMessagesDialog.class.getSimpleName();
+
+    public static void show(final Context context, int currentSelectedTime, final @NonNull EphemeralMessagesInterface listener) {
+        CharSequence[] choices = context.getResources().getStringArray(R.array.ephemeral_message_durations);
+        int preselected = getPreselection(currentSelectedTime);
+        final int[] selectedChoice = new int[]{preselected};
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(context)
+                .setTitle(R.string.pref_ephemeral_messages)
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
+                    final long burnAfter;
+                    switch (selectedChoice[0]) {
+                        case 1:  burnAfter = TimeUnit.SECONDS.toSeconds(30); break;
+                        case 2:  burnAfter = TimeUnit.HOURS.toSeconds(1); break;
+                        case 3:  burnAfter = TimeUnit.DAYS.toSeconds(1);  break;
+                        case 4:  burnAfter = TimeUnit.DAYS.toSeconds(7);  break;
+                        case 5:  burnAfter = TimeUnit.DAYS.toSeconds(28); break;
+                        default: burnAfter = 0; break;
+                    }
+                    listener.onTimeSelected(burnAfter);
+                })
+                .setSingleChoiceItems(choices, preselected, ((dialog, which) -> {
+                    selectedChoice[0] = which;
+                }));
+        builder.show();
+    }
+
+    public interface EphemeralMessagesInterface {
+        void onTimeSelected(long duration);
+    }
+
+    private static int getPreselection(int timespan) {
+        if (timespan ==  TimeUnit.DAYS.toSeconds(28)) {
+            return 5;
+        } else if (timespan == TimeUnit.DAYS.toSeconds(7)) {
+            return 4;
+        } else if (timespan == TimeUnit.DAYS.toSeconds(1)) {
+            return 3;
+        } else if (timespan == TimeUnit.HOURS.toSeconds(1)) {
+            return 2;
+        } else if (timespan == TimeUnit.SECONDS.toSeconds(30)) {
+            return 1;
+        } else {
+            if (timespan != 0) {
+                Log.e(TAG, "Invalid ephemeral messages timespan, falling back to OFF");
+            }
+            return 0;
+        }
+
+    }
+
+}

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -51,6 +51,7 @@ public class Prefs {
   private static final String PROMPTED_DOZE_MSG_ID_PREF        = "pref_prompted_doze_msg_id";
   private static final String IN_THREAD_NOTIFICATION_PREF      = "pref_key_inthread_notifications";
   public  static final String MESSAGE_BODY_TEXT_SIZE_PREF      = "pref_message_body_text_size";
+  public  static final String EPHEMERAL_MESSAGES_PREF          = "pref_ephemeral_messages";
 
   public  static final String NOTIFICATION_PRIVACY_PREF        = "pref_notification_privacy";
   public  static final String NOTIFICATION_PRIORITY_PREF       = "pref_notification_priority";
@@ -184,6 +185,10 @@ public class Prefs {
     catch(Exception e) {
       return false;
     }
+  }
+
+  public static boolean isEphemeralMessagesEnabled(Context context) {
+      return getBooleanPreference(context, EPHEMERAL_MESSAGES_PREF, false);
   }
 
   // ringtone


### PR DESCRIPTION
on top of #1457 
* simple UI to select ephemeral messages
* experimental feature switch in settings
* show ephemeral messages only if feature switch was enabled or ephemeral messages was already enabled (e.g. from another device)

Closes #1458 