### PR TITLE
Fix mismatch between ephemeral options and strings

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -131,6 +131,7 @@
         <item>@string/off</item>
         <item>@string/after_30_seconds</item>
         <item>@string/after_1_minute</item>
+        <item>@string/autodel_after_1_hour</item>
         <item>@string/autodel_after_1_day</item>
         <item>@string/autodel_after_1_week</item>
         <item>@string/autodel_after_4_weeks</item>

--- a/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
+++ b/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
@@ -24,10 +24,11 @@ public class EphemeralMessagesDialog {
                     final long burnAfter;
                     switch (selectedChoice[0]) {
                         case 1:  burnAfter = TimeUnit.SECONDS.toSeconds(30); break;
-                        case 2:  burnAfter = TimeUnit.HOURS.toSeconds(1); break;
-                        case 3:  burnAfter = TimeUnit.DAYS.toSeconds(1);  break;
-                        case 4:  burnAfter = TimeUnit.DAYS.toSeconds(7);  break;
-                        case 5:  burnAfter = TimeUnit.DAYS.toSeconds(28); break;
+                        case 2:  burnAfter = TimeUnit.MINUTES.toSeconds(1); break;
+                        case 3:  burnAfter = TimeUnit.HOURS.toSeconds(1); break;
+                        case 4:  burnAfter = TimeUnit.DAYS.toSeconds(1);  break;
+                        case 5:  burnAfter = TimeUnit.DAYS.toSeconds(7);  break;
+                        case 6:  burnAfter = TimeUnit.DAYS.toSeconds(28); break;
                         default: burnAfter = 0; break;
                     }
                     listener.onTimeSelected(burnAfter);
@@ -43,13 +44,15 @@ public class EphemeralMessagesDialog {
     }
 
     private static int getPreselection(int timespan) {
-        if (timespan ==  TimeUnit.DAYS.toSeconds(28)) {
-            return 5;
+        if (timespan == TimeUnit.DAYS.toSeconds(28)) {
+            return 6;
         } else if (timespan == TimeUnit.DAYS.toSeconds(7)) {
-            return 4;
+            return 5;
         } else if (timespan == TimeUnit.DAYS.toSeconds(1)) {
-            return 3;
+            return 4;
         } else if (timespan == TimeUnit.HOURS.toSeconds(1)) {
+            return 3;
+        } else if (timespan == TimeUnit.MINUTES.toSeconds(1)) {
             return 2;
         } else if (timespan == TimeUnit.SECONDS.toSeconds(30)) {
             return 1;


### PR DESCRIPTION
Selecting 1 minute actually set timer to one hour and there was no
"one hour" option in the menu.