### PR TITLE
Update strings used for ephemeral messages

### DIFF
--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -40,7 +40,7 @@
           app:showAsAction="ifRoom" />
 
     <item android:id="@+id/menu_ephemeral_messages"
-          android:title="@string/pref_ephemeral_messages"
+          android:title="@string/autodel_title_short"
           android:visible="false" />
 
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -476,7 +476,7 @@
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>
-    <string name="pref_ephemeral_messages">Self-destructing messages</string>
+    <string name="ephemeral_dialog_title">Delete read messages</string>
 
 
     <!-- automatically delete message -->

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -59,7 +59,7 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="pref_ephemeral_messages"
-            android:title="@string/pref_ephemeral_messages"/>
+            android:title="Chat auto-delete setting"/>
 
     </PreferenceCategory>
 

--- a/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
+++ b/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
@@ -18,7 +18,7 @@ public class EphemeralMessagesDialog {
         final int[] selectedChoice = new int[]{preselected};
 
         AlertDialog.Builder builder = new AlertDialog.Builder(context)
-                .setTitle(R.string.pref_ephemeral_messages)
+                .setTitle(R.string.ephemeral_dialog_title)
                 .setNegativeButton(R.string.cancel, null)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     final long burnAfter;


### PR DESCRIPTION
- For chat menu item, use already translated auto-delete string.
- For experimental setting, use untranslatable hard-coded string.
- Introduce a new translatable string for ephemeral dialog title