### PR TITLE
Fix mailto links

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -194,6 +194,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private boolean    isSecurityInitialized    = false;
   private boolean    isShareDraftInitialized  = false;
 
+  private boolean successfulForwardingAttempt = false;
+
 
   private final DynamicTheme       dynamicTheme    = new DynamicTheme();
   private final DynamicLanguage    dynamicLanguage = new DynamicLanguage();
@@ -560,7 +562,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleReturnToConversationList() {
 
-    if (isRelayingMessageContent(this)) {
+    if (isRelayingMessageContent(this) || successfulForwardingAttempt) {
       if (isSharing(this)) {
         // we're allowing only 1 try to share, going back to the conversation list will
         // close the conversation list in activtyForResult() as well, so that the user
@@ -669,7 +671,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       }
       new AlertDialog.Builder(this)
               .setMessage(getString(R.string.ask_forward, name))
-              .setPositiveButton(R.string.ok, (dialogInterface, i) -> SendRelayedMessageUtil.immediatelyRelay(this, chatId))
+              .setPositiveButton(R.string.ok, (dialogInterface, i) -> {
+                SendRelayedMessageUtil.immediatelyRelay(this, chatId);
+                successfulForwardingAttempt = true;
+              })
               .setNegativeButton(R.string.cancel, (dialogInterface, i) -> finish())
               .show();
     }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -31,13 +31,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Vibrator;
 import android.provider.Browser;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.SearchView;
-import androidx.core.view.WindowCompat;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.Toolbar;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -58,6 +51,14 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.WindowCompat;
 
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
@@ -128,7 +129,6 @@ import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.isForwarding;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.isSharing;
-import static org.thoughtcrime.securesms.util.RelayUtil.resetRelayingMessageContent;
 
 /**
  * Activity for displaying a message thread, as well as
@@ -562,7 +562,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (isRelayingMessageContent(this)) {
       if (isSharing(this)) {
-        attachmentManager.cleanup();
+        // we're allowing only 1 try to share, going back to the conversation list will
+        // close the conversation list in activtyForResult() as well, so that the user
+        // comes back to the extenal app's share menu
+        setResult(RESULT_OK);
       }
       finish();
       return;

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -702,7 +702,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           isShareDraftInitialized = true;
         }
       });
-      //resetRelayingMessageContent(this);
     }
   }
 
@@ -735,8 +734,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       result.set(false);
     }
 
-    //ListenableFuture<Boolean> result = initializeDraftFromDatabase();
-    //updateToggleButtonState();
     return result;
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -694,15 +694,41 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           isShareDraftInitialized = true;
         }
       });
-      resetRelayingMessageContent(this);
+      //resetRelayingMessageContent(this);
     }
   }
 
   ///// Initializers
 
+  /**
+   * Drafts can be initialized by click on a mailto: link or from the database
+   * @return
+   */
   private ListenableFuture<Boolean> initializeDraft() {
-    ListenableFuture<Boolean> result = initializeDraftFromDatabase();
-    updateToggleButtonState();
+
+    final SettableFuture<Boolean> result = new SettableFuture<>();
+
+    final String    draftText      = getIntent().getStringExtra(TEXT_EXTRA);
+    final Uri       draftMedia     = getIntent().getData();
+    final MediaType draftMediaType = MediaType.from(getIntent().getType());
+
+    if (draftText != null) {
+      composeText.setText(draftText);
+      result.set(true);
+    }
+    if (draftMedia != null && draftMediaType != null) {
+      return setMedia(draftMedia, draftMediaType);
+    }
+
+    if (draftText == null && draftMedia == null && draftMediaType == null) {
+      return initializeDraftFromDatabase();
+    } else {
+      updateToggleButtonState();
+      result.set(false);
+    }
+
+    //ListenableFuture<Boolean> result = initializeDraftFromDatabase();
+    //updateToggleButtonState();
     return result;
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -202,8 +202,7 @@ public class ConversationListFragment extends Fragment
                       SendRelayedMessageUtil.immediatelyRelay(getActivity(), selectedChats.toArray(new Long[selectedChats.size()]));
                       actionMode.finish();
                       actionMode = null;
-                      // Start this activity again, this time with an intent without sharing:
-                      startActivity(new Intent(getActivity(), ConversationListActivity.class));
+                      getActivity().finish();
                     })
                     .show();
           }


### PR DESCRIPTION
fixes #1472 
I found some more issues on current master, partly introduced by #1341 

* when forwarding messages the Activity stack order was broken, multiple Activity List views could appear ( fixed by
20189fd )
* when forwarding is finished, the user always returns to the original chat a it was intended before #1341
* when sharing images, they couldn't kept as drafts (now fixed by 69b587c ) 
* 69b587c also now disallows to go the following path: share menu -> conversation list -> chat a -> back to conversation list -> back b, it caused troubles in the pre #1341 implementation while the fix in #1341 introduced the above mentioned draft bug. Instead the user can only jump into one chat or select mulitple chats from the chat list by long press on the list conversation items, going back will result in returning to the share menu

