### PR TITLE
Rename "Auto-delete messages" into "Delete old messages"

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -146,7 +146,7 @@
   </string-array>
 
   <string-array name="autodel_device_durations">
-      <item>@string/off</item>
+      <item>@string/never</item>
       <item>@string/autodel_after_1_hour</item>
       <item>@string/autodel_after_1_day</item>
       <item>@string/autodel_after_1_week</item>
@@ -164,7 +164,7 @@
   </string-array>
 
   <string-array name="autodel_server_durations">
-      <item>@string/off</item>
+      <item>@string/never</item>
       <item>@string/autodel_at_once</item>
       <item>@string/autodel_after_1_hour</item>
       <item>@string/autodel_after_1_day</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -481,6 +481,7 @@
 
 
     <!-- automatically delete message -->
+    <string name="delete_old_messages">Delete old messages</string>
     <string name="autodel_title">Auto-delete messages</string>
     <string name="autodel_title_short">Auto-delete</string>
     <string name="autodel_device_title">Delete messages from device</string>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -34,7 +34,7 @@
         android:entryValues="@array/pref_compression_values"
         android:defaultValue="0" />
 
-    <PreferenceCategory android:title="@string/autodel_title">
+    <PreferenceCategory android:title="@string/delete_old_messages">
         <ListPreference
             android:key="autodel_device"
             android:title="@string/autodel_device_title"

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -127,7 +127,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     String readReceiptState = dcContext.getConfigInt("mdns_enabled")!=0? onRes : offRes;
     String autodelState = (dcContext.getConfigInt("delete_device_after")!=0 || dcContext.getConfigInt("delete_server_after")!=0)? onRes : offRes;
     return context.getString(R.string.pref_read_receipts) + " " + readReceiptState +
-            ", " + context.getString(R.string.autodel_title_short) + " " + autodelState;
+            ", " + context.getString(R.string.delete_old_messages) + " " + autodelState;
   }
 
   private class BlockedContactsClickListener implements Preference.OnPreferenceClickListener {

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -125,9 +125,13 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     final String onRes = context.getString(R.string.on);
     final String offRes = context.getString(R.string.off);
     String readReceiptState = dcContext.getConfigInt("mdns_enabled")!=0? onRes : offRes;
-    String autodelState = (dcContext.getConfigInt("delete_device_after")!=0 || dcContext.getConfigInt("delete_server_after")!=0)? onRes : offRes;
-    return context.getString(R.string.pref_read_receipts) + " " + readReceiptState +
-            ", " + context.getString(R.string.delete_old_messages) + " " + autodelState;
+    boolean deleteOld = (dcContext.getConfigInt("delete_device_after")!=0 || dcContext.getConfigInt("delete_server_after")!=0);
+
+    String summary = context.getString(R.string.pref_read_receipts) + " " + readReceiptState;
+    if (deleteOld) {
+      summary += ", " + context.getString(R.string.delete_old_messages) + " " + onRes;
+    }
+    return summary;
   }
 
   private class BlockedContactsClickListener implements Preference.OnPreferenceClickListener {


### PR DESCRIPTION
This change makes it clear which messages are deleted, so this setting
can't be confused with Ephemeral-Timer header, configured per chat.

![2_scale](https://user-images.githubusercontent.com/18373967/86961384-d0618400-c169-11ea-9e82-27c7bf7929b3.png)
![1_scale](https://user-images.githubusercontent.com/18373967/86961376-cd669380-c169-11ea-977a-4a6f6be539a2.png)
