### PR TITLE
show ephemeral state in title

### DIFF
--- a/res/drawable/ic_timer_gray_18dp.xml
+++ b/res/drawable/ic_timer_gray_18dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="18dp" android:tint="#AAAAAA"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="18dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M15,1L9,1v2h6L15,1zM11,14h2L13,8h-2v6zM19.03,7.39l1.42,-1.42c-0.43,-0.51 -0.9,-0.99 -1.41,-1.41l-1.42,1.42C16.07,4.74 14.12,4 12,4c-4.97,0 -9,4.03 -9,9s4.02,9 9,9 9,-4.03 9,-9c0,-2.12 -0.74,-4.07 -1.97,-5.61zM12,20c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/res/layout/conversation_title_view.xml
+++ b/res/layout/conversation_title_view.xml
@@ -49,17 +49,35 @@
         android:layout_toEndOf="@id/contact_photo_image"
         android:layout_toRightOf="@id/contact_photo_image">
 
-        <org.thoughtcrime.securesms.components.emoji.EmojiTextView
-            android:id="@+id/title"
-            style="@style/TextSecure.TitleTextStyle"
+        <LinearLayout android:orientation="horizontal"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:drawablePadding="5dp"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:textSize="20dp"
-            android:transitionName="recipient_name"
-            tools:text="Jules Bonnot" />
+            android:layout_height="wrap_content">
+
+            <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+                android:id="@+id/title"
+                style="@style/TextSecure.TitleTextStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:drawablePadding="5dp"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textSize="20dp"
+                android:transitionName="recipient_name"
+                android:layout_weight="1"
+                tools:text="Jules Bonnot" />
+
+            <ImageView
+                android:id="@+id/ephemeral_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:paddingLeft="4dp"
+                android:paddingRight="4dp"
+                android:contentDescription="@string/ephemeral_messages"
+                app:srcCompat="@drawable/ic_timer_gray_18dp"
+                android:visibility="gone" />
+
+        </LinearLayout>
 
         <TextView
             android:id="@+id/subtitle"

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -248,6 +248,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     });
 
     dcContext.eventCenter.addObserver(DcContext.DC_EVENT_CHAT_MODIFIED, this);
+    dcContext.eventCenter.addObserver(DcContext.DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED, this);
     dcContext.eventCenter.addObserver(DcContext.DC_EVENT_CONTACTS_CHANGED, this);
 
     if (isForwarding(this)) {
@@ -1461,7 +1462,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public void handleEvent(int eventId, Object data1, Object data2) {
-    if (eventId == DcContext.DC_EVENT_CHAT_MODIFIED || eventId == DcContext.DC_EVENT_CONTACTS_CHANGED) {
+    if (eventId == DcContext.DC_EVENT_CHAT_MODIFIED
+     || eventId == DcContext.DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED
+     || eventId == DcContext.DC_EVENT_CONTACTS_CHANGED) {
       dcChat = dcContext.getChat(chatId);
       titleView.setTitle(glideRequests, dcChat);
       initializeSecurity(isSecureText, isDefaultSms);

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -53,32 +53,27 @@ public class ConversationTitleView extends RelativeLayout {
     ViewUtil.setTextViewGravityStart(this.subtitle, getContext());
   }
 
-  public void setTitle(@NonNull GlideRequests glideRequests, @Nullable DcChat dcChat) {
+  public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat) {
     setTitle(glideRequests, dcChat, true);
   }
 
-  public void setTitle(@NonNull GlideRequests glideRequests, @Nullable DcChat dcChat, boolean showSubtitle) {
-
+  public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat, boolean showSubtitle) {
     int imgLeft = 0;
     int imgRight = 0;
 
-    if (dcChat == null) {
-      setComposeTitle();
-    } else {
-      setRecipientTitle(dcChat, showSubtitle);
-      if (Prefs.isChatMuted(dcChat)) {
-        imgLeft = R.drawable.ic_volume_off_white_18dp;
-      }
-      if (dcChat.isVerified()) {
-        imgRight = R.drawable.ic_verified;
-      }
-      this.avatar.setAvatar(glideRequests, DcHelper.getContext(getContext()).getRecipient(dcChat), false);
+    setRecipientTitle(dcChat, showSubtitle);
+    if (Prefs.isChatMuted(dcChat)) {
+      imgLeft = R.drawable.ic_volume_off_white_18dp;
     }
+    if (dcChat.isVerified()) {
+      imgRight = R.drawable.ic_verified;
+    }
+    this.avatar.setAvatar(glideRequests, DcHelper.getContext(getContext()).getRecipient(dcChat), false);
 
     title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
   }
 
-  public void setTitle(@NonNull GlideRequests glideRequests, @Nullable DcContact contact) {
+  public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcContact contact) {
     // the verified state is _not_ shown in the title. this will be confusing as in the one-to-one-ChatViews, the verified
     // icon is also not shown as these chats are always opportunistic chats
     avatar.setAvatar(glideRequests, DcHelper.getContext(getContext()).getRecipient(contact), false);
@@ -97,10 +92,6 @@ public class ConversationTitleView extends RelativeLayout {
     this.avatar.setOnClickListener(listener);
   }
 
-  public void setOnAvatarClickListener(@Nullable OnClickListener listener) {
-    this.avatar.setOnClickListener(listener);
-  }
-
   @Override
   public void setOnLongClickListener(@Nullable OnLongClickListener listener) {
     this.content.setOnLongClickListener(listener);
@@ -109,12 +100,6 @@ public class ConversationTitleView extends RelativeLayout {
 
   public void setOnBackClickedListener(@Nullable OnClickListener listener) {
     this.back.setOnClickListener(listener);
-  }
-
-  private void setComposeTitle() {
-    this.title.setText(null);
-    this.subtitle.setText(null);
-    this.subtitle.setVisibility(View.GONE);
   }
 
   private void setRecipientTitle(DcChat dcChat, boolean showSubtitle) {

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -58,19 +58,50 @@ public class ConversationTitleView extends RelativeLayout {
   }
 
   public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat, boolean showSubtitle) {
+    final int chatId = dcChat.getId();
+    final Context context = getContext();
+    final DcContext dcContext = DcHelper.getContext(context);
+
+    // set title and subtitle texts
+    if( chatId == DcChat.DC_CHAT_ID_DEADDROP ) {
+      title.setText(R.string.menu_deaddrop);
+      subtitle.setText(R.string.menu_deaddrop_subtitle);
+    } else {
+      title.setText(dcChat.getName());
+      String subtitleStr = "ErrSubtitle";
+
+      int[] chatContacts = dcContext.getChatContacts(chatId);
+      if( dcChat.isGroup() ) {
+        subtitleStr = context.getResources().getQuantityString(R.plurals.n_members, chatContacts.length, chatContacts.length);
+      } else if( chatContacts.length>=1 ) {
+        if( dcChat.isSelfTalk() ) {
+          subtitleStr = context.getString(R.string.chat_self_talk_subtitle);
+        }
+        else if( dcChat.isDeviceTalk() ) {
+          subtitleStr = context.getString(R.string.device_talk_subtitle);
+        }
+        else {
+          subtitleStr = dcContext.getContact(chatContacts[0]).getAddr();
+        }
+      }
+
+      subtitle.setText(subtitleStr);
+    }
+
+    // set icons etc.
     int imgLeft = 0;
     int imgRight = 0;
 
-    setRecipientTitle(dcChat, showSubtitle);
     if (Prefs.isChatMuted(dcChat)) {
       imgLeft = R.drawable.ic_volume_off_white_18dp;
     }
     if (dcChat.isVerified()) {
       imgRight = R.drawable.ic_verified;
     }
-    this.avatar.setAvatar(glideRequests, DcHelper.getContext(getContext()).getRecipient(dcChat), false);
 
     title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
+    subtitle.setVisibility(showSubtitle? View.VISIBLE : View.GONE);
+    avatar.setAvatar(glideRequests, DcHelper.getContext(getContext()).getRecipient(dcChat), false);
   }
 
   public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcContact contact) {
@@ -100,37 +131,5 @@ public class ConversationTitleView extends RelativeLayout {
 
   public void setOnBackClickedListener(@Nullable OnClickListener listener) {
     this.back.setOnClickListener(listener);
-  }
-
-  private void setRecipientTitle(DcChat dcChat, boolean showSubtitle) {
-    int chatId = dcChat.getId();
-    if( chatId == DcChat.DC_CHAT_ID_DEADDROP ) {
-      this.title.setText(R.string.menu_deaddrop);
-      this.subtitle.setText(R.string.menu_deaddrop_subtitle);
-    } else {
-      this.title.setText(dcChat.getName());
-      String subtitle = "ErrSubtitle";
-
-      Context context = getContext();
-      DcContext dcContext = DcHelper.getContext(context);
-      int[] chatContacts = dcContext.getChatContacts(chatId);
-      if( dcChat.isGroup() ) {
-        subtitle = context.getResources().getQuantityString(R.plurals.n_members, chatContacts.length, chatContacts.length);
-      } else if( chatContacts.length>=1 ) {
-        if( dcChat.isSelfTalk() ) {
-          subtitle = context.getString(R.string.chat_self_talk_subtitle);
-        }
-        else if( dcChat.isDeviceTalk() ) {
-          subtitle = context.getString(R.string.device_talk_subtitle);
-        }
-        else {
-          subtitle = dcContext.getContact(chatContacts[0]).getAddr();
-        }
-      }
-
-      this.subtitle.setText(subtitle);
-    }
-
-    this.subtitle.setVisibility(showSubtitle? View.VISIBLE : View.GONE);
   }
 }

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -29,6 +29,7 @@ public class ConversationTitleView extends RelativeLayout {
   private AvatarImageView avatar;
   private TextView        title;
   private TextView        subtitle;
+  private ImageView       ephemeralIcon;
 
   public ConversationTitleView(Context context) {
     this(context, null);
@@ -43,11 +44,12 @@ public class ConversationTitleView extends RelativeLayout {
   public void onFinishInflate() {
     super.onFinishInflate();
 
-    this.back     = ViewUtil.findById(this, R.id.up_button);
-    this.content  = ViewUtil.findById(this, R.id.content);
-    this.title    = ViewUtil.findById(this, R.id.title);
-    this.subtitle = ViewUtil.findById(this, R.id.subtitle);
-    this.avatar   = ViewUtil.findById(this, R.id.contact_photo_image);
+    this.back          = ViewUtil.findById(this, R.id.up_button);
+    this.content       = ViewUtil.findById(this, R.id.content);
+    this.title         = ViewUtil.findById(this, R.id.title);
+    this.subtitle      = ViewUtil.findById(this, R.id.subtitle);
+    this.avatar        = ViewUtil.findById(this, R.id.contact_photo_image);
+    this.ephemeralIcon = ViewUtil.findById(this, R.id.ephemeral_icon);
 
     ViewUtil.setTextViewGravityStart(this.title, getContext());
     ViewUtil.setTextViewGravityStart(this.subtitle, getContext());
@@ -57,7 +59,7 @@ public class ConversationTitleView extends RelativeLayout {
     setTitle(glideRequests, dcChat, true);
   }
 
-  public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat, boolean showSubtitle) {
+  public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat, boolean showAddInfo) {
     final int chatId = dcChat.getId();
     final Context context = getContext();
     final DcContext dcContext = DcHelper.getContext(context);
@@ -99,9 +101,12 @@ public class ConversationTitleView extends RelativeLayout {
       imgRight = R.drawable.ic_verified;
     }
 
-    title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
-    subtitle.setVisibility(showSubtitle? View.VISIBLE : View.GONE);
     avatar.setAvatar(glideRequests, DcHelper.getContext(getContext()).getRecipient(dcChat), false);
+    title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
+    subtitle.setVisibility(showAddInfo? View.VISIBLE : View.GONE);
+
+    boolean isEphemeral = dcContext.getChatEphemeralTimer(chatId) != 0;
+    ephemeralIcon.setVisibility((showAddInfo && isEphemeral)? View.VISIBLE : View.GONE);
   }
 
   public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcContact contact) {


### PR DESCRIPTION
just a small hint, a first step :) the icon appears and reappears when ephemeral state is changed either locally or remotely.

i decided to tune the icon down to:

- not to be too annoying when ephemeral mode is enabled "always" with large timeouts, in this case, an always appearing "warning" seems to be too annoying
- the mode should not be too outstanding - as we cannot guarantee that things are delete on other devices at all
- there will be an additional icon beside each message as well, maybe even animated as on signal - that will also be very obvious

i also played around an icon in the chat (as for location), however, decided against that, for reasons mentioned above and also because the idea of the location being part of the chat window is that actually messages are emmited when this mode is enabled - this is not true for ephemeral mode.  also, the current icon is easier to implement on the other platforms in a similar way.

![Screen Shot 2020-07-10 at 21 07 38](https://user-images.githubusercontent.com/9800740/87189768-85727880-c2f1-11ea-9f81-f4031efac654.png)
