### PR TITLE
background image scaling good without jumping (2)

### DIFF
--- a/res/layout/activity_select_chat_background.xml
+++ b/res/layout/activity_select_chat_background.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ImageView
+    <org.thoughtcrime.securesms.components.ScaleStableImageView
         android:id="@+id/preview"
         android:scaleType="centerCrop"
         android:layout_width="match_parent"

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent" android:layout_width="match_parent">
+
+    <ImageView
+        android:id="@+id/conversation_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:ignore="ContentDescription"
+        android:scaleType="centerCrop" />
+
     <org.thoughtcrime.securesms.components.InputAwareLayout
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
-            xmlns:tools="http://schemas.android.com/tools"
             android:id="@+id/layout_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent">

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:ignore="ContentDescription"
-        android:scaleType="centerCrop" />
+        android:scaleType="matrix" />
 
     <org.thoughtcrime.securesms.components.InputAwareLayout
             android:id="@+id/layout_container"

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -3,12 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent" android:layout_width="match_parent">
 
-    <ImageView
+    <org.thoughtcrime.securesms.components.ScaleStableImageView
         android:id="@+id/conversation_background"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:ignore="ContentDescription"
-        android:scaleType="matrix" />
+        android:scaleType="centerCrop" />
 
     <org.thoughtcrime.securesms.components.InputAwareLayout
             android:id="@+id/layout_container"

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -175,6 +175,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   InputAwareLayout            container;
   private   View                        composePanel;
   protected Stub<ReminderView>          reminderView;
+  private   ImageView                   backgroundView;
 
   private   AttachmentTypeSelector attachmentTypeSelector;
   private   AttachmentManager      attachmentManager;
@@ -823,6 +824,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     quickAttachmentDrawer = ViewUtil.findById(this, R.id.quick_attachment_drawer);
     quickAttachmentToggle = ViewUtil.findById(this, R.id.quick_attachment_toggle);
     inputPanel            = ViewUtil.findById(this, R.id.bottom_panel);
+    backgroundView        = ViewUtil.findById(this, R.id.conversation_background);
 
     ImageButton quickCameraToggle = ViewUtil.findById(this, R.id.quick_camera_toggle);
 
@@ -871,13 +873,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     String backgroundImagePath = Prefs.getBackgroundImagePath(this);
     if(!backgroundImagePath.isEmpty()) {
       Drawable image = Drawable.createFromPath(backgroundImagePath);
-      getWindow().setBackgroundDrawable(image);
+      backgroundView.setImageDrawable(image);
     }
     else if(dynamicTheme.isDarkTheme(this)) {
-      getWindow().setBackgroundDrawableResource(R.drawable.background_hd_dark);
+      backgroundView.setImageResource(R.drawable.background_hd_dark);
     }
     else {
-      getWindow().setBackgroundDrawableResource(R.drawable.background_hd);
+      backgroundView.setImageResource(R.drawable.background_hd);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -76,6 +76,7 @@ import org.thoughtcrime.securesms.components.HidingLinearLayout;
 import org.thoughtcrime.securesms.components.InputAwareLayout;
 import org.thoughtcrime.securesms.components.InputPanel;
 import org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout.OnKeyboardShownListener;
+import org.thoughtcrime.securesms.components.ScaleStableImageView;
 import org.thoughtcrime.securesms.components.SendButton;
 import org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer;
 import org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer.AttachmentDrawerListener;
@@ -175,7 +176,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   InputAwareLayout            container;
   private   View                        composePanel;
   protected Stub<ReminderView>          reminderView;
-  private   ImageView                   backgroundView;
+  private   ScaleStableImageView        backgroundView;
 
   private   AttachmentTypeSelector attachmentTypeSelector;
   private   AttachmentManager      attachmentManager;
@@ -829,6 +830,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     ImageButton quickCameraToggle = ViewUtil.findById(this, R.id.quick_camera_toggle);
 
     container.addOnKeyboardShownListener(this);
+    container.addOnKeyboardHiddenListener(backgroundView);
+    container.addOnKeyboardShownListener(backgroundView);
     inputPanel.setListener(this);
     inputPanel.setMediaListener(this);
 
@@ -871,16 +874,17 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void initializeBackground() {
     String backgroundImagePath = Prefs.getBackgroundImagePath(this);
+    Drawable background;
     if(!backgroundImagePath.isEmpty()) {
-      Drawable image = Drawable.createFromPath(backgroundImagePath);
-      backgroundView.setImageDrawable(image);
+      background = Drawable.createFromPath(backgroundImagePath);
     }
-    else if(dynamicTheme.isDarkTheme(this)) {
-      backgroundView.setImageResource(R.drawable.background_hd_dark);
+    else if(DynamicTheme.isDarkTheme(this)) {
+      background = getResources().getDrawable(R.drawable.background_hd_dark);
     }
     else {
-      backgroundView.setImageResource(R.drawable.background_hd);
+      background = getResources().getDrawable(R.drawable.background_hd);
     }
+    backgroundView.setImageDrawable(background);
   }
 
   protected void initializeActionBar() {

--- a/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -55,6 +55,7 @@ public class ScaleStableImageView
     @Override
     public void setImageDrawable(@Nullable Drawable drawable) {
         defaultDrawable = drawable;
+        storedSizes.clear();
         overrideDrawable(defaultDrawable);
     }
 

--- a/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -32,8 +32,7 @@ import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
  */
 public class ScaleStableImageView
     extends AppCompatImageView
-    implements KeyboardAwareLinearLayout.OnKeyboardShownListener, KeyboardAwareLinearLayout.OnKeyboardHiddenListener
-{
+    implements KeyboardAwareLinearLayout.OnKeyboardShownListener, KeyboardAwareLinearLayout.OnKeyboardHiddenListener {
 
     private static final String TAG = ScaleStableImageView.class.getSimpleName();
 
@@ -60,7 +59,7 @@ public class ScaleStableImageView
     }
 
     private void overrideDrawable(Drawable newDrawable) {
-        if(currentDrawable == newDrawable) return;
+        if (currentDrawable == newDrawable) return;
         currentDrawable = newDrawable;
         super.setImageDrawable(newDrawable);
     }
@@ -73,11 +72,11 @@ public class ScaleStableImageView
 
     @Override
     protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
-        if(width == 0 || height == 0) return;
+        if (width == 0 || height == 0) return;
         final String newKey = width + "x" + height;
         int orientation = getResources().getConfiguration().orientation;
         boolean portrait;
-        if(orientation == ORIENTATION_PORTRAIT) {
+        if (orientation == ORIENTATION_PORTRAIT) {
             portrait = true;
         } else if (orientation == ORIENTATION_LANDSCAPE) {
             portrait = false;
@@ -103,14 +102,14 @@ public class ScaleStableImageView
             return;
         }
 
-        if(keyboardShown) {
+        if (keyboardShown) {
             // don't scale; Crop.
             Drawable large;
-            if(portrait)
-                large = storedSizes.get(portraitWidth+"x"+portraitHeight);
+            if (portrait)
+                large = storedSizes.get(portraitWidth + "x" + portraitHeight);
             else
-                large = storedSizes.get(landscapeWidth+"x"+landscapeHeight);
-            if(large == null) return; // no baseline. can't work.
+                large = storedSizes.get(landscapeWidth + "x" + landscapeHeight);
+            if (large == null) return; // no baseline. can't work.
             Bitmap original = ((BitmapDrawable) large).getBitmap();
             Bitmap cropped = Bitmap.createBitmap(original, 0, 0, width, height);
             Drawable croppedDrawable = new BitmapDrawable(getResources(), cropped);
@@ -141,10 +140,11 @@ public class ScaleStableImageView
     }
 
     private void measureViewSize(int width, int height, int oldWidth, int oldHeight, boolean portrait) {
-        if(portraitWidth != 0 && portraitHeight != 0 && landscapeWidth != 0 && landscapeHeight != 0) return;
+        if (portraitWidth != 0 && portraitHeight != 0 && landscapeWidth != 0 && landscapeHeight != 0)
+            return;
 
-        if(oldWidth == 0 && oldHeight == 0) { // screen just opened from inside the app
-            if(portrait) { // portrait
+        if (oldWidth == 0 && oldHeight == 0) { // screen just opened from inside the app
+            if (portrait) { // portrait
                 portraitHeight = height;
                 portraitWidth = width;
             } else { // landscape
@@ -152,89 +152,19 @@ public class ScaleStableImageView
                 landscapeWidth = width;
             }
         } else {
-            if(oldWidth == portraitWidth) { // was in portrait
-                if(!portrait) { // rotate to landscape
+            if (oldWidth == portraitWidth) { // was in portrait
+                if (!portrait) { // rotate to landscape
                     landscapeHeight = height;
                     landscapeWidth = width;
                 }
             } else if (oldHeight == landscapeHeight) {
-                if(portrait) {
+                if (portrait) {
                     portraitHeight = height;
                     portraitWidth = width;
                 }
             }
         }
     }
-
-    // opening in portrait
-    // Keyboard hidden
-    // 0x0 to 1080x1704
-
-    // opening in landscape
-    // Keyboard hidden
-    // 0x0 to 1776x1008
-
-    // opening keyboard in portrait
-    // Keyboard shown
-    // 1080x1704 to 1080x914
-    // closing keyboard in portrait
-    // Keyboard hidden
-    // 1080x914 to 1080x1704
-
-    // opening keyboard in landscape
-    // (nothing)
-    // closing keyboard in landscape
-    // (nothing)
-
-    // going from landscape to portrait
-    // Keyboard hidden
-    // 1776x1008 to 1080x1704
-
-    // going from portrait to landscape
-    // Keyboard hidden
-    // 1080x1704 to 1776x1008
-
-    // going with open keyboard from landscape to portrait
-    // Keyboard hidden
-    // 1776x1008 to 1080x1704
-    // Keyboard shown
-    // 1080x1704 to 1080x914
-
-    // going with open keyboard from portrait to landscape
-    // Keyboard hidden
-    // Keyboard shown
-    // Keyboard hidden
-    // 1080x914 to 1776x1008
-
-    // locking screen in portrait
-    // (--)
-    // locking screen in portrait with keyboard open
-    // Keyboard hidden
-    // 1080x914 to 1080x1704
-
-    // unlocking screen in portrait
-    // --
-    // unlocking screen in portrait (keyboard was open before lock)
-    // Keyboard shown
-    // 1080x1704 to 1080x914
-
-    // locking screen in landscape
-    // Keyboard hidden
-    // 1776x1008 to 1080x1704
-
-    // locking screen in landscape with keyboard open
-    // Keyboard hidden
-    // 1776x1008 to 1080x1704
-
-    // unlocking screen in landscape
-    // Keyboard hidden
-    // 1080x1704 to 1776x1008
-
-    // unlocking screen in landscape (keyboard was open before lock)
-    // Keyboard hidden
-    // 1776x1008 to 1080x1704
-    // Keyboard hidden
-    // 1080x1704 to 1776x1008
 
     @Override
     public void onKeyboardHidden() {

--- a/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -86,11 +86,11 @@ public class ScaleStableImageView
             return; // something fishy happened.
         }
 
-        measureViewSize(width, height, oldWidth, oldHeight, portrait);
         if (!(defaultDrawable instanceof BitmapDrawable)) {
             return; // need Bitmap for scaling and cropping.
         }
 
+        measureViewSize(width, height, oldWidth, oldHeight, portrait);
         // if the image is already fit for the screen, just show it.
         if (defaultDrawable.getIntrinsicWidth() == width &&
             defaultDrawable.getIntrinsicHeight() == height) {

--- a/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -1,0 +1,250 @@
+package org.thoughtcrime.securesms.components;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.util.Log;
+
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+
+import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.util.Util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatImageView;
+
+import static android.content.res.Configuration.ORIENTATION_PORTRAIT;
+import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
+
+/**
+ * An image view that maintains the size of the drawable provided.
+ * That means: when you set an image drawable it will be scaled to fit the screen once.
+ * If you rotate the screen it will be rescaled to fit.
+ * If you crop the screen (e.g. because the soft keyboard is displayed) the image is cropped instead.
+ *
+ * @author Angelo Fuchs
+ */
+public class ScaleStableImageView
+    extends AppCompatImageView
+    implements KeyboardAwareLinearLayout.OnKeyboardShownListener, KeyboardAwareLinearLayout.OnKeyboardHiddenListener
+{
+
+    private static final String TAG = ScaleStableImageView.class.getSimpleName();
+
+    private Drawable defaultDrawable;
+    private Drawable currentDrawable;
+    private Map<String, Drawable> storedSizes = new HashMap<>();
+
+    public ScaleStableImageView(Context context) {
+        this(context, null);
+    }
+
+    public ScaleStableImageView(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ScaleStableImageView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setImageDrawable(@Nullable Drawable drawable) {
+        defaultDrawable = drawable;
+        overrideDrawable(defaultDrawable);
+    }
+
+    private void overrideDrawable(Drawable newDrawable) {
+        if(currentDrawable == newDrawable) return;
+        currentDrawable = newDrawable;
+        super.setImageDrawable(newDrawable);
+    }
+
+    private int landscapeWidth = 0;
+    private int landscapeHeight = 0;
+    private int portraitWidth = 0;
+    private int portraitHeight = 0;
+    private boolean keyboardShown = false;
+
+    @Override
+    protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
+        if(width == 0 || height == 0) return;
+        final String newKey = width + "x" + height;
+        int orientation = getResources().getConfiguration().orientation;
+        boolean portrait;
+        if(orientation == ORIENTATION_PORTRAIT) {
+            portrait = true;
+        } else if (orientation == ORIENTATION_LANDSCAPE) {
+            portrait = false;
+        } else {
+            Log.i(TAG, "orientation was: " + orientation);
+            return; // something fishy happened.
+        }
+
+        measureViewSize(width, height, oldWidth, oldHeight, portrait);
+        if (!(defaultDrawable instanceof BitmapDrawable)) {
+            return; // need Bitmap for scaling and cropping.
+        }
+
+        // if the image is already fit for the screen, just show it.
+        if (defaultDrawable.getIntrinsicWidth() == width &&
+            defaultDrawable.getIntrinsicHeight() == height) {
+            overrideDrawable(defaultDrawable);
+        }
+
+        // check if we have the new one already
+        if (storedSizes.containsKey(newKey)) {
+            super.setImageDrawable(storedSizes.get(newKey));
+            return;
+        }
+
+        if(keyboardShown) {
+            // don't scale; Crop.
+            Drawable large;
+            if(portrait)
+                large = storedSizes.get(portraitWidth+"x"+portraitHeight);
+            else
+                large = storedSizes.get(landscapeWidth+"x"+landscapeHeight);
+            if(large == null) return; // no baseline. can't work.
+            Bitmap original = ((BitmapDrawable) large).getBitmap();
+            Bitmap cropped = Bitmap.createBitmap(original, 0, 0, width, height);
+            Drawable croppedDrawable = new BitmapDrawable(getResources(), cropped);
+            overrideDrawable(croppedDrawable);
+        } else {
+            Util.runOnBackground(() -> {
+                Bitmap bitmap = ((BitmapDrawable) defaultDrawable).getBitmap();
+                Context context = getContext();
+                try {
+                    Bitmap scaledBitmap = GlideApp.with(context)
+                        .asBitmap()
+                        .load(bitmap)
+                        .centerCrop()
+                        .skipMemoryCache(true)
+                        .diskCacheStrategy(DiskCacheStrategy.NONE)
+                        .submit(width, height)
+                        .get();
+                    Drawable rescaled = new BitmapDrawable(getResources(), scaledBitmap);
+                    storedSizes.put(newKey, rescaled);
+                    Util.runOnMain(() -> overrideDrawable(rescaled));
+                } catch (ExecutionException | InterruptedException ex) {
+                    Log.e(TAG, "could not rescale background", ex);
+                    // No background set.
+                }
+            });
+        }
+        super.onSizeChanged(width, height, oldWidth, oldHeight);
+    }
+
+    private void measureViewSize(int width, int height, int oldWidth, int oldHeight, boolean portrait) {
+        if(portraitWidth != 0 && portraitHeight != 0 && landscapeWidth != 0 && landscapeHeight != 0) return;
+
+        if(oldWidth == 0 && oldHeight == 0) { // screen just opened from inside the app
+            if(portrait) { // portrait
+                portraitHeight = height;
+                portraitWidth = width;
+            } else { // landscape
+                landscapeHeight = height;
+                landscapeWidth = width;
+            }
+        } else {
+            if(oldWidth == portraitWidth) { // was in portrait
+                if(!portrait) { // rotate to landscape
+                    landscapeHeight = height;
+                    landscapeWidth = width;
+                }
+            } else if (oldHeight == landscapeHeight) {
+                if(portrait) {
+                    portraitHeight = height;
+                    portraitWidth = width;
+                }
+            }
+        }
+    }
+
+    // opening in portrait
+    // Keyboard hidden
+    // 0x0 to 1080x1704
+
+    // opening in landscape
+    // Keyboard hidden
+    // 0x0 to 1776x1008
+
+    // opening keyboard in portrait
+    // Keyboard shown
+    // 1080x1704 to 1080x914
+    // closing keyboard in portrait
+    // Keyboard hidden
+    // 1080x914 to 1080x1704
+
+    // opening keyboard in landscape
+    // (nothing)
+    // closing keyboard in landscape
+    // (nothing)
+
+    // going from landscape to portrait
+    // Keyboard hidden
+    // 1776x1008 to 1080x1704
+
+    // going from portrait to landscape
+    // Keyboard hidden
+    // 1080x1704 to 1776x1008
+
+    // going with open keyboard from landscape to portrait
+    // Keyboard hidden
+    // 1776x1008 to 1080x1704
+    // Keyboard shown
+    // 1080x1704 to 1080x914
+
+    // going with open keyboard from portrait to landscape
+    // Keyboard hidden
+    // Keyboard shown
+    // Keyboard hidden
+    // 1080x914 to 1776x1008
+
+    // locking screen in portrait
+    // (--)
+    // locking screen in portrait with keyboard open
+    // Keyboard hidden
+    // 1080x914 to 1080x1704
+
+    // unlocking screen in portrait
+    // --
+    // unlocking screen in portrait (keyboard was open before lock)
+    // Keyboard shown
+    // 1080x1704 to 1080x914
+
+    // locking screen in landscape
+    // Keyboard hidden
+    // 1776x1008 to 1080x1704
+
+    // locking screen in landscape with keyboard open
+    // Keyboard hidden
+    // 1776x1008 to 1080x1704
+
+    // unlocking screen in landscape
+    // Keyboard hidden
+    // 1080x1704 to 1776x1008
+
+    // unlocking screen in landscape (keyboard was open before lock)
+    // Keyboard hidden
+    // 1776x1008 to 1080x1704
+    // Keyboard hidden
+    // 1080x1704 to 1776x1008
+
+    @Override
+    public void onKeyboardHidden() {
+        keyboardShown = false;
+        Log.i(TAG, "Keyboard hidden");
+    }
+
+    @Override
+    public void onKeyboardShown() {
+        keyboardShown = true;
+        Log.i(TAG, "Keyboard shown");
+    }
+}

--- a/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
@@ -136,13 +136,15 @@ public class ChatBackgroundActivity extends PassphraseRequiredActionBarActivity 
             Display display = ServiceUtil.getWindowManager(context).getDefaultDisplay();
             Point size = new Point();
             display.getSize(size);
+            // resize so that the larger side fits the screen accurately
+            int largerSide = (size.x > size.y ? size.x : size.y);
             Bitmap scaledBitmap = GlideApp.with(context)
                     .asBitmap()
                     .load(imageUri)
-                    .centerCrop()
+                    .fitCenter()
                     .skipMemoryCache(true)
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .submit(size.x, size.y)
+                    .submit(largerSide, largerSide)
                     .get();
             FileOutputStream outStream = new FileOutputStream(destinationPath);
             scaledBitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream);


### PR DESCRIPTION
continues where #1429 left off due to rebase issues.

fixes #466

When finished needs to:

 -   Keep aspect ratio of background image in landscape and portrait orientation in the chat view
 -   Fill screen with image (no empty borders)
 -   Maintain position when the keyboard is opened.

@cyBerta Your suggestion to move the `measureViewSize` call after the early return is included.