### PR TITLE
do not show series of network errors while offline

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
+++ b/src/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
@@ -19,6 +19,7 @@ public class NetworkStateReceiver extends BroadcastReceiver {
             if (ni != null && ni.getState() == NetworkInfo.State.CONNECTED) {
                 Log.i("DeltaChat", "++++++++++++++++++ Connected ++++++++++++++++++");
                 ApplicationDcContext dcContext = DcHelper.getContext(context);
+                dcContext.showNetworkErrors = true;
                 new Thread(() -> {
                     // call dc_maybe_network() from a worker thread.
                     // theoretically, dc_maybe_network() can be called from the main thread and returns at once,


### PR DESCRIPTION
instead, when receiving the first network-error when being offline,
the text is substituted to "No network"
and all subsequent network-errors are ignored -
until NetworkStateReveiver reports being online again,
then the state is reset.

in fact, in the last versions not network-errors were reported at all (but normal errors were - and some of them were network-errors). reason was that android relied on the first-network-error flags, that, however, does not exist since some time, see documentation changed in the linked rust-pr.

successor of https://github.com/deltachat/deltachat-core-rust/pull/1740, closes https://github.com/deltachat/deltachat-android/issues/1490