### PR TITLE
generic foregroundservice

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -285,6 +285,8 @@
         </intent-filter>
     </service>
 
+    <service android:name=".service.GenericForegroundService" />
+
     <receiver android:name=".notifications.MarkReadReceiver"
               android:enabled="true"
               android:exported="false">

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -120,7 +120,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
 
     private void startImport(final String backupFile)
     {
-        notificationController = GenericForegroundService.startForegroundTask(this, getString(R.string.one_moment));
+        notificationController = GenericForegroundService.startForegroundTask(this, getString(R.string.import_backup_title));
         if( progressDialog!=null ) {
             progressDialog.dismiss();
             progressDialog = null;

--- a/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
+++ b/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
@@ -11,6 +11,8 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
 import android.util.Log;
 
 import org.thoughtcrime.securesms.ConversationListActivity;
@@ -34,14 +36,7 @@ public class KeepAliveService extends Service {
     public static void startSelf(Context context)
     {
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                // the started service has to call startForeground() within 5 seconds,
-                // see https://developer.android.com/about/versions/oreo/android-8.0-changes
-                context.startForegroundService(new Intent(context, KeepAliveService.class));
-            }
-            else {
-                context.startService(new Intent(context, KeepAliveService.class));
-            }
+            ContextCompat.startForegroundService(context, new Intent(context, KeepAliveService.class));
         }
         catch(Exception e) {
             e.printStackTrace();

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -173,6 +173,7 @@ public class NotificationCenter {
     public static final String CH_MSG_PREFIX = "ch_msg";
     public static final String CH_MSG_VERSION = "4";
     public static final String CH_PERMANENT = "dc_foreground_notification_ch";
+    public static final String CH_GENERIC = "ch_generic";
 
     private boolean notificationChannelsSupported() {
         return Build.VERSION.SDK_INT >= 26;

--- a/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -102,6 +102,7 @@ public abstract class ListSummaryPreferenceFragment extends CorrectedPreferenceF
                   .setPositiveButton(android.R.string.ok, null)
                   .show();
         }
+        notificationController.close();
       }
       else if (progress<1000/*progress in permille*/) {
         int percent = (int)progress / 10;

--- a/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -70,7 +70,7 @@ public abstract class ListSummaryPreferenceFragment extends CorrectedPreferenceF
   protected String         imexDir = "";
   protected void startImex(int what)
   {
-    notificationController = GenericForegroundService.startForegroundTask(getContext(), getString(R.string.one_moment));
+    notificationController = GenericForegroundService.startForegroundTask(getContext(), getString(R.string.export_backup_desktop));
     if( progressDialog!=null ) {
       progressDialog.dismiss();
       progressDialog = null;

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -1,0 +1,279 @@
+package org.thoughtcrime.securesms.service;
+
+import android.annotation.TargetApi;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat.Builder;
+import androidx.core.content.ContextCompat;
+
+import org.thoughtcrime.securesms.ConversationListActivity;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.notifications.NotificationCenter;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class GenericForegroundService extends Service {
+
+  private static final String TAG = GenericForegroundService.class.getSimpleName();
+
+  private final IBinder binder = new LocalBinder();
+
+  private static final int    NOTIFICATION_ID              = 849319618;
+  private static final String EXTRA_TITLE                  = "extra_title";
+  private static final String EXTRA_CONTENT_TEXT           = "extra_content_text";
+  private static final String EXTRA_CHANNEL_ID             = "extra_channel_id";
+  private static final String EXTRA_ICON_RES               = "extra_icon_res";
+  private static final String EXTRA_ID                     = "extra_id";
+  private static final String EXTRA_PROGRESS               = "extra_progress";
+  private static final String EXTRA_PROGRESS_MAX           = "extra_progress_max";
+  private static final String EXTRA_PROGRESS_INDETERMINATE = "extra_progress_indeterminate";
+
+  private static final String ACTION_START = "start";
+  private static final String ACTION_STOP  = "stop";
+
+  private static final AtomicInteger NEXT_ID = new AtomicInteger();
+  private static final AtomicBoolean CHANNEL_CREATED = new AtomicBoolean(false);
+
+
+  private final LinkedHashMap<Integer, Entry> allActiveMessages = new LinkedHashMap<>();
+
+  private static final Entry DEFAULTS = new Entry("", "", NotificationCenter.CH_GENERIC, R.drawable.icon_notification, -1, 0, 0, false);
+
+  private @Nullable Entry lastPosted;
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    if (intent == null) {
+      throw new IllegalStateException("Intent needs to be non-null.");
+    }
+
+    synchronized (GenericForegroundService.class) {
+      String action = intent.getAction();
+      if      (ACTION_START.equals(action)) handleStart(intent);
+      else if (ACTION_STOP .equals(action)) handleStop(intent);
+      else                                  throw new IllegalStateException(String.format("Action needs to be %s or %s.", ACTION_START, ACTION_STOP));
+
+      updateNotification();
+
+      return START_NOT_STICKY;
+    }
+  }
+
+  private synchronized void updateNotification() {
+    Iterator<Entry> iterator = allActiveMessages.values().iterator();
+
+    if (iterator.hasNext()) {
+      postObligatoryForegroundNotification(iterator.next());
+    } else {
+      Log.i(TAG, "Last request. Ending foreground service.");
+      postObligatoryForegroundNotification(lastPosted != null ? lastPosted : DEFAULTS);
+      stopForeground(true);
+      stopSelf();
+    }
+  }
+
+
+  private synchronized void handleStart(@NonNull Intent intent) {
+    Entry entry = Entry.fromIntent(intent);
+
+    Log.i(TAG, String.format(Locale.US, "handleStart() %s", entry));
+
+    allActiveMessages.put(entry.id, entry);
+  }
+
+  private synchronized void handleStop(@NonNull Intent intent) {
+    Log.i(TAG, "handleStop()");
+
+    int id = intent.getIntExtra(EXTRA_ID, -1);
+
+    Entry removed = allActiveMessages.remove(id);
+
+    if (removed == null) {
+      Log.w(TAG, "Could not find entry to remove");
+    }
+  }
+
+  private void postObligatoryForegroundNotification(@NonNull Entry active) {
+    lastPosted = active;
+    startForeground(NOTIFICATION_ID, new Builder(this, active.channelId)
+                                                           .setSmallIcon(active.iconRes)
+                                                           .setContentTitle(active.title)
+                                                           .setTicker(active.contentText)
+                                                           .setContentText(active.contentText)
+                                                           .setProgress(active.progressMax, active.progress, active.indeterminate)
+                                                           .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, ConversationListActivity.class), 0))
+                                                           .build());
+  }
+
+  @Override
+  public IBinder onBind(Intent intent) {
+    return binder;
+  }
+
+
+  public static NotificationController startForegroundTask(@NonNull Context context, @NonNull String task) {
+    final int id = NEXT_ID.getAndIncrement();
+
+    createFgNotificationChannel(context);
+    Intent intent = new Intent(context, GenericForegroundService.class);
+    intent.setAction(ACTION_START);
+    intent.putExtra(EXTRA_TITLE, task);
+    intent.putExtra(EXTRA_CHANNEL_ID, NotificationCenter.CH_GENERIC);
+    intent.putExtra(EXTRA_ICON_RES, R.drawable.notification_permanent);
+    intent.putExtra(EXTRA_ID, id);
+
+    ContextCompat.startForegroundService(context, intent);
+
+    return new NotificationController(context, id);
+  }
+
+  public static void stopForegroundTask(@NonNull Context context, int id) {
+    Intent intent = new Intent(context, GenericForegroundService.class);
+    intent.setAction(ACTION_STOP);
+    intent.putExtra(EXTRA_ID, id);
+
+    ContextCompat.startForegroundService(context, intent);
+  }
+
+  synchronized void replaceProgress(int id, int progressMax, int progress, boolean indeterminate, String message) {
+    Entry oldEntry = allActiveMessages.get(id);
+
+    if (oldEntry == null) {
+      Log.w(TAG, "Failed to replace notification, it was not found");
+      return;
+    }
+
+    if (message == null) {
+      message = oldEntry.contentText;
+    }
+
+    Entry newEntry = new Entry(oldEntry.title, message, oldEntry.channelId, oldEntry.iconRes, oldEntry.id, progressMax, progress, indeterminate);
+
+    if (oldEntry.equals(newEntry)) {
+      Log.d(TAG, String.format("handleReplace() skip, no change %s", newEntry));
+      return;
+    }
+
+    Log.i(TAG, String.format("handleReplace() %s", newEntry));
+
+    allActiveMessages.put(newEntry.id, newEntry);
+
+    updateNotification();
+  }
+
+  @TargetApi(Build.VERSION_CODES.O)
+  static private void createFgNotificationChannel(Context context) {
+    if(!CHANNEL_CREATED.get() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      CHANNEL_CREATED.set(true);
+      NotificationChannel channel = new NotificationChannel(NotificationCenter.CH_GENERIC,
+              "Generic Background Service", NotificationManager.IMPORTANCE_MIN);
+      channel.setDescription("Ensure app will not be killed while long ongoing background tasks are running.");
+      NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+      notificationManager.createNotificationChannel(channel);
+    }
+  }
+
+
+  private static class Entry {
+    final @NonNull     String  title;
+    final @NonNull    String  contentText;
+    final @NonNull     String  channelId;
+    final              int     id;
+    final @DrawableRes int     iconRes;
+    final              int     progress;
+    final              int     progressMax;
+    final              boolean indeterminate;
+
+    private Entry(@NonNull String title, @NonNull String contentText, @NonNull String channelId, @DrawableRes int iconRes, int id, int progressMax, int progress, boolean indeterminate) {
+      this.title         = title;
+      this.contentText   = contentText;
+      this.channelId     = channelId;
+      this.iconRes       = iconRes;
+      this.id            = id;
+      this.progress      = progress;
+      this.progressMax   = progressMax;
+      this.indeterminate = indeterminate;
+    }
+
+    private static Entry fromIntent(@NonNull Intent intent) {
+      int id = intent.getIntExtra(EXTRA_ID, DEFAULTS.id);
+
+      String title = intent.getStringExtra(EXTRA_TITLE);
+      if (title == null) title = DEFAULTS.title;
+
+      String contentText = intent.getStringExtra(EXTRA_CONTENT_TEXT);
+      if (contentText == null) contentText = DEFAULTS.contentText;
+
+      String channelId = intent.getStringExtra(EXTRA_CHANNEL_ID);
+      if (channelId == null) channelId = DEFAULTS.channelId;
+
+      int     iconRes       = intent.getIntExtra(EXTRA_ICON_RES, DEFAULTS.iconRes);
+      int     progress      = intent.getIntExtra(EXTRA_PROGRESS, DEFAULTS.progress);
+      int     progressMax   = intent.getIntExtra(EXTRA_PROGRESS_MAX, DEFAULTS.progressMax);
+      boolean indeterminate = intent.getBooleanExtra(EXTRA_PROGRESS_INDETERMINATE, DEFAULTS.indeterminate);
+
+      return new Entry(title, contentText, channelId, iconRes, id, progressMax, progress, indeterminate);
+    }
+
+    @Override
+    public @NonNull String toString() {
+      return String.format(Locale.US, "ChannelId: %s  Id: %d Progress: %d/%d %s", channelId, id, progress, progressMax, indeterminate ? "indeterminate" : "determinate");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Entry entry = (Entry) o;
+      return id == entry.id &&
+             iconRes == entry.iconRes &&
+             progress == entry.progress &&
+             progressMax == entry.progressMax &&
+             indeterminate == entry.indeterminate &&
+             title.equals(entry.title) &&
+             channelId.equals(entry.channelId);
+    }
+
+    @Override
+    public int hashCode() {
+      int hashCode = title.hashCode();
+      hashCode *= 31;
+      hashCode += channelId.hashCode();
+      hashCode *= 31;
+      hashCode += id;
+      hashCode *= 31;
+      hashCode += iconRes;
+      hashCode *= 31;
+      hashCode += progress;
+      hashCode *= 31;
+      hashCode += progressMax;
+      hashCode *= 31;
+      hashCode += indeterminate ? 1 : 0;
+      return hashCode;
+    }
+  }
+
+  class LocalBinder extends Binder {
+    GenericForegroundService getService() {
+      // Return this instance of LocalService so clients can call public methods
+      return GenericForegroundService.this;
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -3,7 +3,6 @@ package org.thoughtcrime.securesms.service;
 import android.annotation.TargetApi;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -18,7 +17,6 @@ import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat.Builder;
 import androidx.core.content.ContextCompat;
 
-import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
 
@@ -117,7 +115,6 @@ public final class GenericForegroundService extends Service {
                                                            .setTicker(active.contentText)
                                                            .setContentText(active.contentText)
                                                            .setProgress(active.progressMax, active.progress, active.indeterminate)
-                                                           .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, ConversationListActivity.class), 0))
                                                            .build());
   }
 

--- a/src/org/thoughtcrime/securesms/service/NotificationController.java
+++ b/src/org/thoughtcrime/securesms/service/NotificationController.java
@@ -1,0 +1,96 @@
+package org.thoughtcrime.securesms.service;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
+import androidx.annotation.NonNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Class to control notifications triggered by GenericForeGroundService.
+ *
+ */
+public final class NotificationController {
+
+  private final @NonNull Context context;
+  private final int id;
+
+  private int     progress;
+  private int     progressMax;
+  private boolean indeterminate;
+  private String  message = "";
+  private long    percent = -1;
+
+  private final ServiceConnection serviceConnection;
+
+  private final AtomicReference<GenericForegroundService> service = new AtomicReference<>();
+
+  NotificationController(@NonNull Context context, int id) {
+    this.context = context;
+    this.id      = id;
+
+    serviceConnection = new ServiceConnection() {
+      @Override
+      public void onServiceConnected(ComponentName name, IBinder service) {
+        GenericForegroundService.LocalBinder binder = (GenericForegroundService.LocalBinder) service;
+        GenericForegroundService genericForegroundService = binder.getService();
+
+        NotificationController.this.service.set(genericForegroundService);
+
+        updateProgressOnService();
+      }
+
+      @Override
+      public void onServiceDisconnected(ComponentName name) {
+        service.set(null);
+      }
+    };
+
+    context.bindService(new Intent(context, GenericForegroundService.class), serviceConnection, Context.BIND_AUTO_CREATE);
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void close() {
+    GenericForegroundService.stopForegroundTask(context, id);
+    context.unbindService(serviceConnection);
+  }
+
+  public void setIndeterminateProgress() {
+    setProgress(0, 0, true, message);
+  }
+
+  public void setProgress(long newProgressMax, long newProgress, @NonNull String newMessage) {
+    setProgress((int) newProgressMax, (int) newProgress, false, newMessage);
+  }
+
+  private synchronized void setProgress(int newProgressMax, int newProgress, boolean indeterminant, @NonNull String newMessage) {
+    int newPercent = newProgressMax != 0 ? 100 * newProgress / newProgressMax : -1;
+
+    boolean same = newPercent == percent && indeterminate == indeterminant && newMessage.equals(message);
+
+    percent       = newPercent;
+    progress      = newProgress;
+    progressMax   = newProgressMax;
+    indeterminate = indeterminant;
+    message       = newMessage;
+
+    if (same) return;
+
+    updateProgressOnService();
+  }
+
+  private synchronized void updateProgressOnService() {
+    GenericForegroundService genericForegroundService = service.get();
+
+    if (genericForegroundService == null) return;
+
+    genericForegroundService.replaceProgress(id, progressMax, progress, indeterminate,  message);
+  }
+}


### PR DESCRIPTION
used for import export 🚛 🚛 🚛 

closes #1447 

 changes in Signals NotificationController and GenericBackground service:
* removed AutoCloseable Interface from NotificationController because it is only supported from API 19+
* instead we assure that the service connection to the GenericBackgroundService gets explicitly closed  in close()
* added possibility to add a contentText of a notification. It is used to display and update the percentage in the notification.

![backup](https://user-images.githubusercontent.com/2614900/88564799-f759fa00-d033-11ea-888f-32ad92bbdbdf.png)
