### PR TITLE
tweak padding of disappearing messages options

### DIFF
--- a/res/layout/dialog_extended_options.xml
+++ b/res/layout/dialog_extended_options.xml
@@ -6,7 +6,10 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="16dp"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="10dp"
             android:orientation="vertical">
             <RadioGroup
                 android:layout_width="match_parent"

--- a/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
+++ b/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
@@ -53,7 +53,6 @@ public class EphemeralMessagesDialog {
         TextView messageView = dialogView.findViewById(R.id.description);
         messageView.setText(context.getString(R.string.ephemeral_messages_hint));
 
-
         AlertDialog.Builder builder = new AlertDialog.Builder(context)
                 .setTitle(R.string.ephemeral_messages)
                 .setView(dialogView)


### PR DESCRIPTION
successor of https://github.com/deltachat/deltachat-android/pull/1503

headline and buttons have about 20dp padding,
the the same for left/right,
adapt top/bottom to look good in combination with headline and buttons.

<img width=300 src=https://user-images.githubusercontent.com/9800740/88601121-3d34b380-d070-11ea-8c95-b272f4b37bdc.png>
