### PR TITLE
setting stock translations after context switch

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -102,6 +102,7 @@ public class AccountManager {
         appContext.dcContext.stopIo();
         appContext.dcContext.unref();
         appContext.dcContext = new ApplicationDcContext(context);
+        appContext.dcContext.setStockTranslations();
     }
 
 


### PR DESCRIPTION
The context contains the proper translations to be used by the core ("stock translations")
After a context switch they are unset.

This change sets them so they are of the appropriate language again.

fixes #1502 