### PR TITLE
Fix sharing both an image and a text to DC

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -212,7 +212,7 @@ public class AttachmentManager {
   */
 
   @SuppressLint("StaticFieldLeak")
-  public ListenableFuture<Boolean> setMedia(@NonNull final GlideRequests glideRequests,
+  public SettableFuture<Boolean> setMedia(@NonNull final GlideRequests glideRequests,
                                             @NonNull final Uri uri,
                                             @NonNull final MediaType mediaType,
                                             @NonNull final MediaConstraints constraints,


### PR DESCRIPTION
This bug was re-introduced in https://github.com/deltachat/deltachat-android/pull/1475/.

Steps: Share media+text from another app to DC.

@cyBerta for the next time: could you please ping me when you revert one of my commits?
@r10s please wait until @cyBerta commented, maybe it is possible to prevent adding another bug again this time.

Concerning this SettableFuture: Turns out it is only used to determine whether to go to lastseen (or not) but this does not work anyway: #1528.