### PR TITLE
Fix sharing again 2

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -736,10 +736,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     return getIntent() != null && getIntent().getData() != null && MAILTO.equals(getIntent().getData().getScheme());
   }
 
-  boolean isInitializedFromRelay() {
-    return RelayUtil.getSharedText(this) != null;
-  }
-
   private ListenableFuture<Boolean> initializeDraftFromIntent() {
     SettableFuture<Boolean> result = new SettableFuture<>();
     final String draftText = RelayUtil.getSharedText(this);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -779,7 +779,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       return future;
     }
 
-    ListenableFuture.Listener listener = new ListenableFuture.Listener<Boolean>() {
+    ListenableFuture.Listener<Boolean> listener = new ListenableFuture.Listener<Boolean>() {
       @Override
       public void onSuccess(Boolean result) {
         future.set(result || !text.isEmpty());

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -776,6 +776,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       composeText.setSelection(composeText.getText().length());
     }
 
+    String filename = draft.getFile();
+    if (filename.isEmpty() || !new File(filename).exists()) {
+      future.set(!text.isEmpty());
+      updateToggleButtonState();
+      return future;
+    }
+
     ListenableFuture.Listener listener = new ListenableFuture.Listener<Boolean>() {
       @Override
       public void onSuccess(Boolean result) {
@@ -789,13 +796,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         updateToggleButtonState();
       }
     };
-
-    String filename = draft.getFile();
-    if (filename.isEmpty() || !new File(filename).exists()) {
-      future.set(!text.isEmpty());
-      updateToggleButtonState();
-      return future;
-    }
 
     File file = new File(filename);
     Uri uri = Uri.fromFile(file);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -725,14 +725,14 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
    * @return
    */
   private ListenableFuture<Boolean> initializeDraft() {
-    if (isInitializedFromMailToIntent()) {
+    if (isMailToIntent()) {
       return initializeDraftFromIntent();
     } else {
       return initializeDraftFromDatabase();
     }
   }
 
-  boolean isInitializedFromMailToIntent() {
+  boolean isMailToIntent() {
     return getIntent() != null && getIntent().getData() != null && MAILTO.equals(getIntent().getData().getScheme());
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -782,7 +782,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     ListenableFuture.Listener listener = new ListenableFuture.Listener<Boolean>() {
       @Override
       public void onSuccess(Boolean result) {
-        future.set(true);
+        future.set(result || !text.isEmpty());
         updateToggleButtonState();
       }
 

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -52,7 +52,7 @@ public class NewConversationActivity extends ContactSelectionActivity {
 
   @SuppressWarnings("unused")
   private static final String TAG = NewConversationActivity.class.getSimpleName();
-  private static final String MAILTO = "mailto";
+  public  static final String MAILTO = "mailto";
   private static final String SUBJECT = "subject";
   private static final String BODY = "body";
   private static final String QUERY_SEPARATOR = "&";

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -212,7 +212,7 @@ public class AttachmentManager {
   */
 
   @SuppressLint("StaticFieldLeak")
-  public ListenableFuture<Boolean> setMedia(@NonNull final GlideRequests glideRequests,
+  public SettableFuture<Boolean> setMedia(@NonNull final GlideRequests glideRequests,
                                             @NonNull final Uri uri,
                                             @NonNull final MediaType mediaType,
                                             @NonNull final MediaConstraints constraints,

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -212,7 +212,7 @@ public class AttachmentManager {
   */
 
   @SuppressLint("StaticFieldLeak")
-  public SettableFuture<Boolean> setMedia(@NonNull final GlideRequests glideRequests,
+  public ListenableFuture<Boolean> setMedia(@NonNull final GlideRequests glideRequests,
                                             @NonNull final Uri uri,
                                             @NonNull final MediaType mediaType,
                                             @NonNull final MediaConstraints constraints,


### PR DESCRIPTION
proposal to simplify the code. Since we're saving drafts to the database while `handleSharing()` and do `immediatelyRelay` for all cases we do forwarding  (see ConversationActivity for the details) all we need to do is to distinguish between sendto: links or loading drafts from the database in `initializeDraft()`

@Hocuri Unfortunately I lost my phone so I don't have telegram or whatsapp. Signal/wire doesn't allow to share both text and images. Could you please try if sharing both works with this PR?


I also removed the AsyncTask which was only there to load a message object. I don't think this is needed and it seems to be a relict from old Signal code.