### PR TITLE
Almost fix #1544 image rotation not working sometimes

### DIFF
--- a/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -112,7 +112,7 @@ public class ScaleStableImageView
                 large = storedSizes.get(landscapeWidth + "x" + landscapeHeight);
             if (large == null) return; // no baseline. can't work.
             Bitmap original = ((BitmapDrawable) large).getBitmap();
-            if (height <= original.getHeight() && width <= original.getWidth()) {
+            if (height <= original.getHeight() || width <= original.getWidth()) {
                 Bitmap cropped = Bitmap.createBitmap(original, 0, 0, width, height);
                 Drawable croppedDrawable = new BitmapDrawable(getResources(), cropped);
                 overrideDrawable(croppedDrawable);

--- a/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -112,9 +112,12 @@ public class ScaleStableImageView
                 large = storedSizes.get(landscapeWidth + "x" + landscapeHeight);
             if (large == null) return; // no baseline. can't work.
             Bitmap original = ((BitmapDrawable) large).getBitmap();
-            Bitmap cropped = Bitmap.createBitmap(original, 0, 0, width, height);
-            Drawable croppedDrawable = new BitmapDrawable(getResources(), cropped);
-            overrideDrawable(croppedDrawable);
+            if (height <= original.getHeight()) {
+                Bitmap cropped = Bitmap.createBitmap(original, 0, 0, width, height);
+                Drawable croppedDrawable = new BitmapDrawable(getResources(), cropped);
+                overrideDrawable(croppedDrawable);
+            } // else we do not know what to do.
+            // At least it does not crash anymore but only jumps a little, see https://github.com/deltachat/deltachat-android/issues/1544.
         } else {
             Util.runOnBackground(() -> {
                 Bitmap bitmap = ((BitmapDrawable) defaultDrawable).getBitmap();

--- a/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -112,12 +112,11 @@ public class ScaleStableImageView
                 large = storedSizes.get(landscapeWidth + "x" + landscapeHeight);
             if (large == null) return; // no baseline. can't work.
             Bitmap original = ((BitmapDrawable) large).getBitmap();
-            if (height <= original.getHeight()) {
+            if (height <= original.getHeight() && width <= original.getWidth()) {
                 Bitmap cropped = Bitmap.createBitmap(original, 0, 0, width, height);
                 Drawable croppedDrawable = new BitmapDrawable(getResources(), cropped);
                 overrideDrawable(croppedDrawable);
-            } // else we do not know what to do.
-            // At least it does not crash anymore but only jumps a little, see https://github.com/deltachat/deltachat-android/issues/1544.
+            }
         } else {
             Util.runOnBackground(() -> {
                 Bitmap bitmap = ((BitmapDrawable) defaultDrawable).getBitmap();


### PR DESCRIPTION
Almost fix #1544 image rotation not working sometimes.

I did not find any better way to do this. Now it is not crashing anymore but it jumps again.