### PR TITLE
Improve mailto link parsing

### DIFF
--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -20,18 +20,20 @@ import android.content.Intent;
 import android.net.MailTo;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.appcompat.app.AlertDialog;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
+
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,7 +125,11 @@ public class NewConversationActivity extends ContactSelectionActivity {
       String[] queryArray = query.split(QUERY_SEPARATOR);
       for(String queryEntry : queryArray) {
         String[] queryEntryArray = queryEntry.split(KEY_VALUE_SEPARATOR);
-        mailtoQueryMap.put(queryEntryArray[0], URLDecoder.decode(queryEntryArray[1]));
+        try {
+          mailtoQueryMap.put(queryEntryArray[0], URLDecoder.decode(queryEntryArray[1], "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+          e.printStackTrace();
+        }
       }
     }
     return mailtoQueryMap;

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -78,8 +78,8 @@ public class NewConversationActivity extends ContactSelectionActivity {
             String textToShare = getTextToShare(uri);
             MailTo mailto = MailTo.parse(uri.toString());
             String recipientsList = mailto.getTo();
-            if(recipientsList != null && !recipientsList.isEmpty()) {
-              String[] recipientsArray = recipientsList.split(",");
+            if(recipientsList != null && !recipientsList.trim().isEmpty()) {
+              String[] recipientsArray = recipientsList.trim().split(",");
               if (recipientsArray.length >= 1) {
                 String recipient = recipientsArray[0];
                 if (textToShare != null && !textToShare.isEmpty()) {


### PR DESCRIPTION
* removes leading and trailing empty spaces from email adresses, so that rust core will consider email adresses as valid
* replaces call to deprecated url decode method