### PR TITLE
reinitialize camera on orientation change

### DIFF
--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -108,11 +108,12 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
     final boolean rotationChanged = this.rotation != rotation;
     this.rotation = rotation;
     if (rotationChanged) {
-      if (isShowing()) {
-        cameraView.onPause();
-      }
       updateControlsView();
       setDrawerStateAndUpdate(drawerState, true);
+      if (isShowing()) {
+        cameraView.onPause();
+        cameraView.onResume();
+      }
     }
   }
 


### PR DESCRIPTION
fixes #1549 

it is 'inspired' by the way the Flip button works: https://github.com/deltachat/deltachat-android/blob/master/src/org/thoughtcrime/securesms/components/camera/CameraView.java#L264

however the aspect ratio is still awful (at least on my device), but that's an unrelated issue. 