### PR TITLE
remove unused strings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -59,8 +59,6 @@
     <string name="now">Now</string>
     <!-- Translators: used as a headline in sections with actions that cannot be undone. could also be "Caution" or "Cave" or so. -->
     <string name="danger">Danger</string>
-    <!-- n_min_ago is deprecated, use n_minutes instead -->
-    <string name="n_min_ago">%d min</string>
     <string name="today">Today</string>
     <string name="yesterday">Yesterday</string>
     <string name="this_week">This week</string>
@@ -175,8 +173,6 @@
     <string name="menu_select_all">Select all</string>
     <string name="menu_expand">Expand</string>
     <string name="menu_edit_name">Edit name</string>
-    <string name="menu_edit_group_name">Edit group name</string>
-    <string name="menu_edit_group_image">Edit group image</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_advanced">Advanced</string>
     <string name="menu_deaddrop">Contact requests</string>
@@ -371,11 +367,8 @@
     <string name="login_error_cannot_login">Cannot login as \"%1$s\". Please check if the email address and the password are correct.</string>
     <!-- Translators: %1$s will be replaced by the server name (eg. imap.somewhere.org) and %2$s will be replaced by the human-readable response from the server. this response may be a single word or some sentences and may or may not be localized. -->
     <string name="login_error_server_response">Response from %1$s: %2$s\n\nSome providers may email you additional information about this problem; you should be able to check your inbox using your regular email app or web site. Consult your provider or friends if you run into problems.</string>
-
     <!-- TLS certificate checks -->
-    <string name="accept_invalid_hostnames">Accept invalid hostnames</string>
     <string name="accept_invalid_certificates">Accept invalid certificates</string>
-
     <string name="used_settings">Used settings:</string>
     <string name="switch_account">Switch account</string>
     <string name="add_account">Add account</string>
@@ -425,7 +418,6 @@
     <string name="pref_notifications_show">Show</string>
     <string name="pref_notifications_priority">Priority</string>
     <string name="pref_led_color">LED color</string>
-    <string name="pref_led_pattern">LED blink pattern</string>
     <string name="pref_sound">Sound</string>
     <string name="pref_silent">Silent</string>
     <string name="pref_privacy">Privacy</string>
@@ -484,11 +476,6 @@
     <string name="pref_show_emails_no">No, chats only</string>
     <string name="pref_show_emails_accepted_contacts">For accepted contacts</string>
     <string name="pref_show_emails_all">All</string>
-    <string name="pref_empty_server_title">Delete emails from server</string>
-    <string name="pref_empty_server_msg">This function helps free up space on your IMAP server by deleting all emails, including chat messages, in the given folders. Messages on this device will not be deleted. The deletion cannot be undone!</string>
-    <string name="pref_empty_server_inbox">Delete all emails in \"Inbox\" folder</string>
-    <string name="pref_empty_server_mvbox">Delete all emails in \"DeltaChat\" folder</string>
-    <string name="pref_empty_server_do_button">Delete emails</string>
     <string name="pref_experimental_features">Experimental features</string>
     <string name="pref_on_demand_location_streaming">On-demand location streaming</string>
     <string name="pref_background_default">Default background</string>
@@ -498,13 +485,12 @@
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>
-    <string name="ephemeral_dialog_title">Delete read messages</string>
 
 
     <!-- automatically delete message -->
     <string name="delete_old_messages">Delete old messages</string>
+    <!-- devs: autodel_title is deprecated, use delete_old_messages instead -->
     <string name="autodel_title">Auto-delete messages</string>
-    <string name="autodel_title_short">Auto-delete</string>
     <string name="autodel_device_title">Delete messages from device</string>
     <string name="autodel_server_title">Delete messages from server</string>
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
@@ -678,8 +664,6 @@
     <string name="more_info_desktop">More info</string>
     <string name="logout_desktop">Logout</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <string name="no_archived_chats_desktop">No archived chats</string>
-    <string name="no_chats_desktop">No chats</string>
     <string name="encryption_info_desktop">Show encryption info</string>
     <string name="verified_desktop">verified</string>
     <string name="remove_desktop">Remove</string>
@@ -738,6 +722,5 @@
 
 
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
-    <string name="update_1_10_android">New Delta Chat 1.10 features at a glance: faster, multi-account, blur images, new emojis, reworked notifications, better error-reporting but most importantly:\n\nClick an avatar in profile and enlarge it 🚀</string>
 
 </resources>


### PR DESCRIPTION
removing unneeded strings makes work of translators easier
and also, in sum, saves some amount of data.

checked by ./tools/grep-string.sh that the strings are not in use by other os.

as checking is some work, i only targeted low hanging fruits,
there may be some more strings unused.