### PR TITLE
update archive menu option, rely on core for chat visibility

### DIFF
--- a/res/menu/conversation_unarchive.xml
+++ b/res/menu/conversation_unarchive.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:title="@string/menu_unarchive_chat"
-          android:id="@+id/menu_archive_chat"/>
-
-</menu>

--- a/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
@@ -8,7 +8,6 @@ import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
-import static org.thoughtcrime.securesms.ConversationActivity.IS_ARCHIVED_EXTRA;
 import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
@@ -65,7 +64,6 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
   public void onCreateConversation(int chatId) {
     Intent intent = new Intent(this, ConversationActivity.class);
     intent.putExtra(CHAT_ID_EXTRA, chatId);
-    intent.putExtra(IS_ARCHIVED_EXTRA, true);
     if (isRelayingMessageContent(this)) {
       acquireRelayMessageContent(this, intent);
       startActivityForResult(intent, REQUEST_RELAY);


### PR DESCRIPTION
fixes #1557 

* moreover it removes the intent extra `IS_ARCHIVED_EXTRA` that gets set when sending the activity intent. Instead we're using the core's chat visibility function `dc_chat_get_visibility` in order to distinguish beween archived and unarchived chats.