### PR TITLE
Add POI improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     }
     implementation 'com.annimon:stream:1.1.8' // brings future java streams api to SDK Version < 24
     implementation 'com.codewaves.stickyheadergrid:stickyheadergrid:0.9.4' // glues the current time segment text in the gallery to the top.
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:7.3.2'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.12'

--- a/res/layout/activity_map.xml
+++ b/res/layout/activity_map.xml
@@ -5,11 +5,16 @@
     android:layout_height="match_parent"
     tools:context=".map.MapActivity">
 
-    <FrameLayout
-        android:id="@+id/container"
+    <org.thoughtcrime.securesms.components.InputAwareLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:id="@+id/inputAwareContainer"
+        >
+        <FrameLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+    </org.thoughtcrime.securesms.components.InputAwareLayout>
 
     <include layout="@layout/bottom_map_sheet" />
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/org/thoughtcrime/securesms/map/AddPoiView.java
+++ b/src/org/thoughtcrime/securesms/map/AddPoiView.java
@@ -71,4 +71,8 @@ public class AddPoiView extends LinearLayoutCompat {
     public void setOnMessageSentListener(SendingTask.OnMessageSentListener listener) {
         this.listener = listener;
     }
+
+    public EditText getMessageView() {
+        return messageView;
+    }
 }

--- a/src/org/thoughtcrime/securesms/map/MarkerView.java
+++ b/src/org/thoughtcrime/securesms/map/MarkerView.java
@@ -45,6 +45,10 @@ public class MarkerView {
         update();
     }
 
+    public LatLng getLatLng() {
+        return latLng;
+    }
+
     /**
      * Set a callback to be invoked when position placement is calculated.
      * <p>

--- a/src/org/thoughtcrime/securesms/map/MarkerViewManager.java
+++ b/src/org/thoughtcrime/securesms/map/MarkerViewManager.java
@@ -86,9 +86,7 @@ public class MarkerViewManager implements MapView.OnDidFinishRenderingFrameListe
 
     @Override
     public void onDidFinishRenderingFrame(boolean fully) {
-        if (fully) {
-            update();
-        }
+        update();
     }
 
     private void update() {

--- a/src/org/thoughtcrime/securesms/map/MarkerViewManager.java
+++ b/src/org/thoughtcrime/securesms/map/MarkerViewManager.java
@@ -68,21 +68,6 @@ public class MarkerViewManager implements MapView.OnDidFinishRenderingFrameListe
         markers.add(markerView);
     }
 
-    /**
-     * Remove an existing markerView from the map.
-     *
-     * @param markerView the markerView to be removed from the map
-     */
-    @UiThread
-    public void removeMarker(@NonNull MarkerView markerView) {
-        if (mapView.isDestroyed() || !markers.contains(markerView)) {
-            return;
-        }
-
-        mapView.removeView(markerView.getView());
-        markers.remove(markerView);
-    }
-
     public boolean hasMarkers() {
         return markers.size() > 0;
     }

--- a/src/org/thoughtcrime/securesms/map/MarkerViewManager.java
+++ b/src/org/thoughtcrime/securesms/map/MarkerViewManager.java
@@ -72,13 +72,12 @@ public class MarkerViewManager implements MapView.OnDidFinishRenderingFrameListe
         return markers.size() > 0;
     }
 
+    @UiThread
     public void removeMarkers() {
-        if (mapView.isDestroyed()) {
-            return;
-        }
-        
-        for (MarkerView markerView : markers) {
-            mapView.removeView(markerView.getView());
+        if (!mapView.isDestroyed()) {
+            for (MarkerView markerView : markers) {
+                mapView.removeView(markerView.getView());
+            }
         }
 
         centeredMarker = null;


### PR DESCRIPTION
the map feature needed some love <3

* when adding a poi on the map, the corresponding AddPoiView gets centered on the map. This way the sent button is always reachable without scrolling.
* when the AddPoiView appears on the map, the keyboard layout automatically appears too, no need to tap another time into the EditText view to write the POI message
* if the AddPoiView gets cancelled, the keyboard disappears, too 
* sometimes the AddPoiView didn't show up at the right position on the map or it didn't move together with map movements. This has been fixed.
* updates map sdk (needed for centering feature)
