### PR TITLE
Fix #1585 User asked for camera permission twice

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1366,7 +1366,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         Permissions.with(ConversationActivity.this)
                    .request(Manifest.permission.CAMERA)
                    .ifNecessary()
-                   .withRationaleDialog(getString(R.string.perm_explain_need_for_camera_access), R.drawable.ic_photo_camera_white_48dp)
                    .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_camera_denied))
                    .onAllGranted(() -> {
                      composeText.clearFocus();


### PR DESCRIPTION
The R.string.perm_explain_need_for_camera_access string is also used elsewhere, so we can't delete it.