### PR TITLE
prepare 1.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Delta Chat Android Changelog
 
+## v1.12.5
+2020-08
+
+* fix notifications for Android 4
+* fix and streamline querying permissions
+* fix removing POIs from map
+* fix emojis displayed on map
+* fix: connect directly after account qr-scan
+* make bot-commands such as /echo clickable
+
+
 ## v1.12.3
 2020-08
 

--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,8 @@ android {
     }
 
     defaultConfig {
-        versionCode 592
-        versionName "1.12.3"
+        versionCode 594
+        versionName "1.12.5"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
bugfix-release, core is the same, but the fixed android4 notifications are probably worth an update.