### PR TITLE
connect immediately after burner account scan

### DIFF
--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -224,6 +224,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                 progressUpdate((int)progress);
             }
             else if (progress==1000/*done*/) {
+                dcContext.maybeStartIo();
                 progressSuccess(true);
             }
         }


### PR DESCRIPTION
the startIo() call after scanning a burner account was just missing,
putting the app for a second to background fixes the issue,
so it was maybe not that visible.
the issue was probably introduced on the switch to async,
before, startIo() was not existant.

fixes #1598 