### PR TITLE
use auto-linkify together with custom-linkify

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -81,6 +81,7 @@ public class ConversationItem extends LinearLayout
 {
   private static final String TAG = ConversationItem.class.getSimpleName();
 
+  private static final Pattern CMD_PATTERN = Pattern.compile("(?<=^|\\s)/[a-zA-Z][a-zA-Z@\\d_/.-]{0,254}");
   private static final int MAX_MEASURE_CALLS = 3;
 
   private DcMsg         messageRecord;
@@ -517,8 +518,7 @@ public class ConversationItem extends LinearLayout
 
     // linkify commands such as `/echo` -
     // do this first to avoid `/xkcd_123456` to be treated partly as a phone number
-    Pattern cmdPattern = Pattern.compile("(?<=^|\\s)/[a-zA-Z][a-zA-Z@\\d_/.-]{0,254}");
-    if (Linkify.addLinks(messageBody, cmdPattern, "cmd:", null, null)) {
+    if (Linkify.addLinks(messageBody, CMD_PATTERN, "cmd:", null, null)) {
       replaceURLSpan(messageBody); // replace URLSpan so that it is not removed on the next addLinks() call
     }
 

--- a/src/org/thoughtcrime/securesms/util/LongClickCopySpan.java
+++ b/src/org/thoughtcrime/securesms/util/LongClickCopySpan.java
@@ -8,19 +8,18 @@ import android.content.Intent;
 import androidx.annotation.ColorInt;
 import androidx.appcompat.app.AlertDialog;
 import android.text.TextPaint;
-import android.text.style.URLSpan;
+import android.text.style.ClickableSpan;
 import android.view.View;
 import android.widget.Toast;
 
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
-import com.b44t.messenger.DcMsg;
 
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcHelper;
 
-public class LongClickCopySpan extends URLSpan {
+public class LongClickCopySpan extends ClickableSpan {
   private static final String PREFIX_MAILTO = "mailto:";
   private static final String PREFIX_TEL = "tel:";
   private static final String PREFIX_CMD = "cmd:";
@@ -28,10 +27,11 @@ public class LongClickCopySpan extends URLSpan {
   private boolean isHighlighted;
   @ColorInt
   private int highlightColor;
+  private final String url;
   private int chatId;
 
   public LongClickCopySpan(String url, int chatId) {
-    super(url);
+    this.url = url;
     this.chatId = chatId;
   }
 
@@ -47,7 +47,6 @@ public class LongClickCopySpan extends URLSpan {
 
   @Override
   public void onClick(View widget) {
-    String url = getURL();
     if (url.startsWith(PREFIX_CMD)) {
       try {
         String cmd = url.substring(PREFIX_CMD.length());
@@ -77,13 +76,12 @@ public class LongClickCopySpan extends URLSpan {
         e.printStackTrace();
       }
     } else {
-      super.onClick(widget);
+      IntentUtils.showBrowserIntent(widget.getContext(), url);
     }
   }
 
   void onLongClick(View widget) {
     Context context = widget.getContext();
-    String url = getURL();
 
     if (url.startsWith(PREFIX_CMD)) {
       copyUrl(context, url.substring(PREFIX_CMD.length()));


### PR DESCRIPTION
unfortunately, auto-linking such as Linkify.addLinks(WEB_URLS...)
replaces custom-links set before by Linkify.addLinks(custom-pattern).

calling custom-linking after auto-linking may be too inaccurate
as in case of bot-commands such as /xkcd_123456
are treated partly as a phone number.

skipping auto-linking is hard as there are lots of things to do to get a
similar experience, see #1600.

finally, we solve the problem by replacing URLSpan by some other span after.
in fact, we do that anyway to get a different long-click behaviour.

the only important thing is that the span-replacement
must not be derived from URLSpan.

fixes #1600
reverts the pattern-approach of #1567 and targets https://github.com/deltachat/deltachat-android/pull/1570#pullrequestreview-468412214