### PR TITLE
add switch to enable/disable battery optimizations

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -482,12 +482,6 @@
     <string name="pref_background_default_color">Default color</string>
     <string name="pref_background_custom_image">Custom image</string>
     <string name="pref_background_custom_color">Custom color</string>
-    <string name="pref_ignore_battery">Fast notifications in background</string>
-    <string name="pref_ignore_battery_explain">Uses a background connection to your server and requires ignored battery optimizations.</string>
-    <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
-    <string name="pref_reliable_service">Reliable background connection</string>
-    <string name="pref_reliable_service_explain">Requires a permanent notification</string>
-
 
     <!-- automatically delete message -->
     <string name="delete_old_messages">Delete old messages</string>
@@ -626,9 +620,6 @@
     <string name="perm_explain_access_to_mic_denied">To send audio messages, go to the app settings, select \"Permissions\", and enable \"Microphone\".</string>
     <string name="perm_explain_access_to_storage_denied">To recieve or send files, go to the app settings, select \"Permissions\", and enable \"Storage\".</string>
     <string name="perm_explain_access_to_location_denied">To attach a location, go to the app settings, select \"Permissions\", and enable \"Location\".</string>
-    <string name="perm_enable_bg_reminder_title">Tap here to receive messages while Delta Chat is in the background.</string>
-    <string name="perm_enable_bg_reminder_text">Delta Chat uses few resources and takes care not to drain your battery.</string>
-    <string name="perm_enable_bg_already_done">You already allowed Delta Chat to receive messages in the background.\n\nIf messages still do not arrive in background, please also check your system settings.</string>
 
     <!-- ImageEditorHud -->
     <string name="ImageEditorHud_draw_anywhere_to_blur">Draw anywhere to blur</string>
@@ -715,6 +706,7 @@
     <string name="a11y_message_context_menu_btn_label">Message actions</string>
     <string name="a11y_background_preview_label">Background preview</string>
 
+
     <!-- iOS permissions, copy from "deltachat-ios/Info.plist", which is used on missing translations in "deltachat-ios/LANG.lproj/InfoPlist.strings" -->
     <string name="InfoPlist_NSCameraUsageDescription">Delta Chat uses your camera to take and send photos and videos and to scan QR codes.</string>
     <string name="InfoPlist_NSContactsUsageDescription">Delta Chat uses your contacts to show a list of email addresses you can write to. Delta Chat has no server, your contacts are not sent anywhere.</string>
@@ -724,5 +716,13 @@
 
 
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
+    <string name="pref_background_notifications">Background notifications</string>
+    <string name="pref_background_notifications_explain">Uses a background connection to your server and requires ignored battery optimizations.</string>
+    <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
+    <string name="pref_reliable_service">Reliable background connection</string>
+    <string name="pref_reliable_service_explain">Requires a permanent notification</string>
+    <string name="perm_enable_bg_reminder_title">Tap here to receive messages while Delta Chat is in the background.</string>
+    <string name="perm_enable_bg_reminder_text">Delta Chat uses few resources and takes care not to drain your battery.</string>
+    <string name="perm_enable_bg_already_done">You already allowed Delta Chat to receive messages in the background.\n\nIf messages still do not arrive in background, please also check your system settings.</string>
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -482,6 +482,8 @@
     <string name="pref_background_default_color">Default color</string>
     <string name="pref_background_custom_image">Custom image</string>
     <string name="pref_background_custom_color">Custom color</string>
+    <string name="pref_ignore_battery">Fast notifications in background</string>
+    <string name="pref_ignore_battery_explain">Uses a background connection to your server and requires ignored battery optimizations.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -10,6 +10,13 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:dependency="pref_key_enable_notifications"
             android:defaultValue="false"
+            android:key="pref_ignore_battery_optimizations"
+            android:title="@string/pref_ignore_battery"
+            android:summary="@string/pref_ignore_battery_explain"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:dependency="pref_key_enable_notifications"
+            android:defaultValue="false"
             android:key="pref_reliable_service"
             android:title="@string/pref_reliable_service"
             android:summary="@string/pref_reliable_service_explain"/>


### PR DESCRIPTION
the switch fires the intent to request-ignore-battery-optimization the intent for opening battery-optimisation-settings (the latter on errors or if ignore-battery is already enabled - there is no direct way to revert ignoring).

<img width="339" alt="Screen Shot 2020-09-01 at 01 21 43" src="https://user-images.githubusercontent.com/9800740/91778021-a7052780-ebf1-11ea-98a2-00a8e3f30e86.png">


targets #1477 