### PR TITLE
[wip] fix launch if there is an ongoing process

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -100,9 +100,8 @@
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
               android:exported="true" />
 
-    <activity-alias android:name=".RoutingActivity"
-                    android:targetActivity=".ConversationListActivity"
-                    android:exported="true">
+    <activity android:name=".RoutingActivity"
+              android:exported="true">
 
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
@@ -122,7 +121,7 @@
         <meta-data android:name="com.sec.minimode.icon.landscape.normal"
                    android:resource="@mipmap/ic_launcher" />
 
-    </activity-alias>
+    </activity>
 
     <activity android:name=".ConversationListArchiveActivity"
               android:label="@string/chat_archived_chats_title"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -98,7 +98,16 @@
               android:launchMode="singleTask"
               android:theme="@style/TextSecure.LightNoActionBar"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
-              android:exported="true" />
+              android:exported="true">
+
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW"/>
+            <category android:name="android.intent.category.DEFAULT"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+            <data android:scheme="openpgp4fpr" />
+        </intent-filter>
+
+    </activity>
 
     <activity android:name=".RoutingActivity"
               android:exported="true">
@@ -107,13 +116,6 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
             <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
-        </intent-filter>
-
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
-            <data android:scheme="openpgp4fpr" />
         </intent-filter>
 
         <meta-data android:name="com.sec.minimode.icon.portrait.normal"

--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -1,0 +1,38 @@
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import org.thoughtcrime.securesms.service.GenericForegroundService;
+
+// if there is a ongoing task running,
+// we might not be able to create new activities as eg. the database is blocked.
+// therefore, we do not want to create new activities
+// but just show the existing one with the progress dialog.
+// (this is a little hack, in theory, the ongoing task should be decoupled completely from activities,
+// and activities should be recreated as needed and reflect the ongoing task state -
+// however, handling all that is quite some effort)
+//
+// - for normal activities, aborting creation is easy - just call finish() in onCreate()
+//
+// - for singleTask activities (as ConversationListActivity),
+//   however, the system just calls onNewIntent() - with the activity stack already altered,
+//   so there is no way to abort getting to a weird state if the new activity cannot be shown
+//   because of the ongoing task (eg. database blocked by backup)
+//
+// therefore, this little RoutingActivity exist - it is a non-singleTask activity
+// that creates the singleTask ConversationListActivity if possible.
+public class RoutingActivity extends Activity {
+  @Override
+  protected final void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    if (!GenericForegroundService.isForegroundTaskStarted()) {
+      Intent intent = new Intent(this, ConversationListActivity.class);
+      startActivity(intent);
+    }
+
+    finish();
+  }
+}

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.service;
 import android.annotation.TargetApi;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -18,6 +19,7 @@ import androidx.core.app.NotificationCompat.Builder;
 import androidx.core.content.ContextCompat;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.RoutingActivity;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
 
 import java.util.Iterator;
@@ -115,6 +117,7 @@ public final class GenericForegroundService extends Service {
                                                            .setTicker(active.contentText)
                                                            .setContentText(active.contentText)
                                                            .setProgress(active.progressMax, active.progress, active.indeterminate)
+                                                           .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, RoutingActivity.class), 0))
                                                            .build());
   }
 

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -47,6 +47,7 @@ public final class GenericForegroundService extends Service {
   private static final AtomicInteger NEXT_ID = new AtomicInteger();
   private static final AtomicBoolean CHANNEL_CREATED = new AtomicBoolean(false);
 
+  private static int startedCounter = 0;
 
   private final LinkedHashMap<Integer, Entry> allActiveMessages = new LinkedHashMap<>();
 
@@ -124,6 +125,7 @@ public final class GenericForegroundService extends Service {
 
 
   public static NotificationController startForegroundTask(@NonNull Context context, @NonNull String task) {
+    startedCounter++;
     final int id = NEXT_ID.getAndIncrement();
 
     createFgNotificationChannel(context);
@@ -145,6 +147,11 @@ public final class GenericForegroundService extends Service {
     intent.putExtra(EXTRA_ID, id);
 
     ContextCompat.startForegroundService(context, intent);
+    startedCounter = Math.max(startedCounter-1, 0);
+  }
+
+  public static boolean isForegroundTaskStarted() {
+    return startedCounter > 0;
   }
 
   synchronized void replaceProgress(int id, int progressMax, int progress, boolean indeterminate, String message) {


### PR DESCRIPTION
this pr converts RoutingActivity to a real activity instead of being just an alias.

this way, we can forward to the ConversationListActivity only if there is _no_ ongoing process.

todo:
- [x] do not open activities that won't work correctly eg. during import/export
- [x] check for possible side-effects - eg. is there a "flash" or so? EDIT: seems to be fine, RoutingActivity is finish()'d immediately, that seems to have no noticeable impact
- [x] check if the other intent assigned to RoutingActivity alias are still working
- [ ] RoutingActivity does not start ConversationListActivity but just open the existing one 
- [ ] the routing does not work if the activity stack is thrown away (eg. by swiping from the tasklist) - what to do in this case?

fixes #1610 
successor of #1504

some reasoning about the explicit RoutingActivity:  
we could avoid activity-creation also in PassphraseRequiredActionBarActivity::onCreate() by calling finish() there, however, the ConversationListActivity has the singleTask flag, so onCreate() is not called when there is an activity somewhere (which is virtually always the case except for the WelcomeActivities)