### PR TITLE
make 'disappearing messages' a standard-feature

### DIFF
--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -26,8 +26,7 @@
         app:showAsAction="always"/>
 
     <item android:id="@+id/menu_ephemeral_messages"
-        android:title="@string/ephemeral_messages"
-        android:visible="false" />
+        android:title="@string/ephemeral_messages" />
 
     <item android:title="@string/menu_mute"
         android:id="@+id/menu_mute_notifications"/>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -56,11 +56,6 @@
             android:key="pref_location_streaming_enabled"
             android:title="@string/pref_on_demand_location_streaming"/>
 
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_ephemeral_messages"
-            android:title="Disappearing messages options"/>
-
         <Preference android:key="pref_webrtc_instance"
             android:title="Video chat instance"
             android:summary="@string/none"/>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -447,10 +447,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       menu.findItem(R.id.menu_show_map).setVisible(false);
     }
 
-    if (Prefs.isEphemeralMessagesEnabled(this) || dcContext.getChatEphemeralTimer(chatId) != 0) {
-      menu.findItem(R.id.menu_ephemeral_messages).setVisible(true);
-    }
-
     if (!dcContext.isWebrtcConfigOk() || !dcChat.canVideochat()) {
       menu.findItem(R.id.menu_videochat_invite).setVisible(false);
     }

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -51,7 +51,6 @@ public class Prefs {
   private static final String PROMPTED_DOZE_MSG_ID_PREF        = "pref_prompted_doze_msg_id";
   private static final String IN_THREAD_NOTIFICATION_PREF      = "pref_key_inthread_notifications";
   public  static final String MESSAGE_BODY_TEXT_SIZE_PREF      = "pref_message_body_text_size";
-  public  static final String EPHEMERAL_MESSAGES_PREF          = "pref_ephemeral_messages";
 
   public  static final String NOTIFICATION_PRIVACY_PREF        = "pref_notification_privacy";
   public  static final String NOTIFICATION_PRIORITY_PREF       = "pref_notification_priority";
@@ -185,10 +184,6 @@ public class Prefs {
     catch(Exception e) {
       return false;
     }
-  }
-
-  public static boolean isEphemeralMessagesEnabled(Context context) {
-      return getBooleanPreference(context, EPHEMERAL_MESSAGES_PREF, false);
   }
 
   // ringtone


### PR DESCRIPTION
this pr removes the requirement to enable the experimental feature 'disappearing messages' before disappearing messages can finally be used.

the experimental feature is available and is tested since about two months and i think, it can become a normal feature now.

we also hesitated to enable the feature by default to ensure, recipients using Delta Chat actually follow the deletion requests, this is now the case since july and since several updates.

counterpart of https://github.com/deltachat/deltachat-ios/pull/919