### PR TITLE
add rationale to ignore-battery-optimization request

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -718,6 +718,7 @@
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
     <string name="pref_background_notifications">Background notifications</string>
     <string name="pref_background_notifications_explain">Uses a background connection to your server and requires ignored battery optimizations.</string>
+    <string name="pref_background_notifications_ask">Do you want to receive messages in the background?\n\nThis requires ignored battery optimizations, however, Delta Chat uses few resources and takes care not to drain your battery.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -718,7 +718,7 @@
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
     <string name="pref_background_notifications">Background notifications</string>
     <string name="pref_background_notifications_explain">Uses a background connection to your server and requires ignored battery optimizations.</string>
-    <string name="pref_background_notifications_ask">To maintain connection to your server and receive messages in the background, ignore battery optimizations in the next step.\n\nDelta Chat uses few resources and takes care not to drain your battery.</string>
+    <string name="pref_background_notifications_rationale">To maintain connection to your email server and receive messages in the background, ignore battery optimizations in the next step.\n\nDelta Chat uses few resources and takes care not to drain your battery.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -718,7 +718,7 @@
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
     <string name="pref_background_notifications">Background notifications</string>
     <string name="pref_background_notifications_explain">Uses a background connection to your server and requires ignored battery optimizations.</string>
-    <string name="pref_background_notifications_ask">Do you want to receive messages in the background?\n\nThis requires ignored battery optimizations, however, Delta Chat uses few resources and takes care not to drain your battery.</string>
+    <string name="pref_background_notifications_ask">To maintain connection to your server and receive messages in the background, ignore battery optimizations in the next step.\n\nDelta Chat uses few resources and takes care not to drain your battery.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Reliable background connection</string>
     <string name="pref_reliable_service_explain">Requires a permanent notification</string>

--- a/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -113,8 +113,8 @@ public class DozeReminder {
           && !((PowerManager) context.getSystemService(Context.POWER_SERVICE)).isIgnoringBatteryOptimizations(context.getPackageName())) {
         new AlertDialog.Builder(context)
             .setTitle(R.string.pref_background_notifications)
-            .setMessage(R.string.pref_background_notifications_ask)
-            .setPositiveButton(R.string.ok, (dialog, which) -> {
+            .setMessage(R.string.pref_background_notifications_rationale)
+            .setPositiveButton(R.string.perm_continue, (dialog, which) -> {
                   Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
                       Uri.parse("package:" + context.getPackageName()));
                   context.startActivity(intent);

--- a/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.PowerManager;
 import android.provider.Settings;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
@@ -110,10 +111,17 @@ public class DozeReminder {
           && !Prefs.getBooleanPreference(context, Prefs.DOZE_ASKED_DIRECTLY, false)
           && ContextCompat.checkSelfPermission(context, Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS) == PackageManager.PERMISSION_GRANTED
           && !((PowerManager) context.getSystemService(Context.POWER_SERVICE)).isIgnoringBatteryOptimizations(context.getPackageName())) {
-
-        Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-            Uri.parse("package:" + context.getPackageName()));
-        context.startActivity(intent);
+        new AlertDialog.Builder(context)
+            .setTitle(R.string.pref_background_notifications)
+            .setMessage(R.string.pref_background_notifications_ask)
+            .setPositiveButton(R.string.perm_continue, (dialog, which) -> {
+                  Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                      Uri.parse("package:" + context.getPackageName()));
+                  context.startActivity(intent);
+            })
+            .setNegativeButton(R.string.not_now, null)
+            .setCancelable(false)
+            .show();
       }
       // Prefs.DOZE_ASKED_DIRECTLY is also used above in isEligible().
       // As long as Prefs.DOZE_ASKED_DIRECTLY is false, isEligible() will return false

--- a/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -114,12 +114,11 @@ public class DozeReminder {
         new AlertDialog.Builder(context)
             .setTitle(R.string.pref_background_notifications)
             .setMessage(R.string.pref_background_notifications_ask)
-            .setPositiveButton(R.string.perm_continue, (dialog, which) -> {
+            .setPositiveButton(R.string.ok, (dialog, which) -> {
                   Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
                       Uri.parse("package:" + context.getPackageName()));
                   context.startActivity(intent);
             })
-            .setNegativeButton(R.string.not_now, null)
             .setCancelable(false)
             .show();
       }

--- a/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -66,8 +66,8 @@ public class DozeReminder {
   public static void addDozeReminderDeviceMsg(Context context) {
     DcContext dcContext = DcHelper.getContext(context);
     DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
-    msg.setText(context.getString(R.string.perm_enable_bg_reminder_title)+"\n\n"
-               +context.getString(R.string.perm_enable_bg_reminder_text));
+    msg.setText("\uD83D\uDC49 "+context.getString(R.string.perm_enable_bg_reminder_title)+" \uD83D\uDC48\n\n"
+               +context.getString(R.string.pref_background_notifications_rationale));
     int msgId = dcContext.addDeviceMsg("android.doze-reminder", msg);
     if(msgId!=0) {
       Prefs.setPromptedDozeMsgId(context, msgId);


### PR DESCRIPTION
with #1505 we ask the user directly after configure to allow running Delta Chat in background.

while it is more straight-forward to let the system ask the user directly -
as we do for most other permissions -
this is probably not favorable for requesting ignore-battery-optimization:

- other permissions requests are preceded by a clear user intention -
  tap on the camera, record voice etc.
  so it is clear to the user why a permission is needed.
  this is not true at the moment after installation
  (maybe the moment can be improved, btw)

- different systems have completely different text,
  partly focusing on "battery drain" - it is not clear to the user
  what would be the advantage of that

- some guidelines say, user interaction is needed before querying permission.
  there is room for interpretation, of couse,
  however, adding a rational with a "continue" button
  seems to fit better to these guidelines.

the current rationale:

<img width=320 src=https://user-images.githubusercontent.com/9800740/92336094-4d8f7380-f09d-11ea-8cfd-63f7f5ccc3d8.png>

some permission requests wordings (from the system, we cannot influence that part):

<img width=250 src=https://user-images.githubusercontent.com/9800740/92336343-e2936c00-f09f-11ea-961c-b474a29c75fc.png> <img width=250 src=https://user-images.githubusercontent.com/9800740/92336107-7283e680-f09d-11ea-8764-5d62976e6901.png> <img width=250 src=https://user-images.githubusercontent.com/9800740/92336106-7283e680-f09d-11ea-8b9b-1b812219acd7.png>
(left to right: lg/android6, motog/android7, google/android9)

prior discussions at https://github.com/deltachat/deltachat-android/pull/1505
still targets #1477 
