### PR TITLE
fix launch if there is an ongoing process

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -482,6 +482,7 @@
     <string name="pref_background_default_color">Default color</string>
     <string name="pref_background_custom_image">Custom image</string>
     <string name="pref_background_custom_color">Custom color</string>
+    <string name="export_aborted">Export aborted.</string>
 
     <!-- automatically delete message -->
     <string name="delete_old_messages">Delete old messages</string>

--- a/src/org/thoughtcrime/securesms/DummyActivity.java
+++ b/src/org/thoughtcrime/securesms/DummyActivity.java
@@ -3,10 +3,8 @@ package org.thoughtcrime.securesms;
 import android.app.Activity;
 import android.os.Bundle;
 
-/**
- * Workaround for Android bug:
- * https://code.google.com/p/android/issues/detail?id=53313
- */
+// dummy activity that just pushes the app to foreground when fired.
+// can also be used to work around android bug https://code.google.com/p/android/issues/detail?id=53313
 public class DummyActivity extends Activity {
   @Override
   public void onCreate(Bundle bundle) {

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.service.GenericForegroundService;
 
 import java.util.Locale;
 
@@ -21,6 +22,15 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
   protected final void onCreate(Bundle savedInstanceState) {
     Log.w(TAG, "onCreate(" + savedInstanceState + ")");
     onPreCreate();
+
+    if (GenericForegroundService.isForegroundTaskStarted()) {
+      // this does not prevent intent set by onNewIntent(),
+      // however, at least during onboarding,
+      // this catches a lot of situations with otherwise weird app states.
+      super.onCreate(savedInstanceState);
+      finish();
+      return;
+    }
 
     if (!DcHelper.isConfigured(getApplicationContext())) {
       Intent intent = new Intent(this, WelcomeActivity.class);

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -47,6 +47,7 @@ public final class GenericForegroundService extends Service {
   private static final AtomicInteger NEXT_ID = new AtomicInteger();
   private static final AtomicBoolean CHANNEL_CREATED = new AtomicBoolean(false);
 
+  private static int startedCounter = 0;
 
   private final LinkedHashMap<Integer, Entry> allActiveMessages = new LinkedHashMap<>();
 
@@ -124,6 +125,7 @@ public final class GenericForegroundService extends Service {
 
 
   public static NotificationController startForegroundTask(@NonNull Context context, @NonNull String task) {
+    startedCounter++;
     final int id = NEXT_ID.getAndIncrement();
 
     createFgNotificationChannel(context);
@@ -145,6 +147,11 @@ public final class GenericForegroundService extends Service {
     intent.putExtra(EXTRA_ID, id);
 
     ContextCompat.startForegroundService(context, intent);
+    startedCounter = Math.max(startedCounter-1, 0);
+  }
+
+  public static boolean isForegroundTaskStarted() {
+    return startedCounter > 0;
   }
 
   synchronized void replaceProgress(int id, int progressMax, int progress, boolean indeterminate, String message) {

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.service;
 import android.annotation.TargetApi;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -17,6 +18,7 @@ import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat.Builder;
 import androidx.core.content.ContextCompat;
 
+import org.thoughtcrime.securesms.DummyActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
 
@@ -115,6 +117,7 @@ public final class GenericForegroundService extends Service {
                                                            .setTicker(active.contentText)
                                                            .setContentText(active.contentText)
                                                            .setProgress(active.progressMax, active.progress, active.indeterminate)
+                                                           .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, DummyActivity.class), 0))
                                                            .build());
   }
 


### PR DESCRIPTION
second attempt of https://github.com/deltachat/deltachat-android/pull/1611

this pr closes many cases of https://github.com/deltachat/deltachat-android/issues/1610, esp. all on onboarding.

~~leaving the issue on export open - this is currently hard to fix as i do not found a way to cancel the intent given to onNewIntent() - before the back stack is modified. all things i've tried raises more problems than it solves. the prober solution would be to decouple things completely from activities, but this is quite some work and maybe not worth the effort. also, the new tar-export has probably a much smaller window where there database is not accessible.~~ EDIT: the export-issue is fixed for now by aborting the export when the app is relauched, to make this clear, a toast is shown. 