### PR TITLE
prefix log by a hint about sensitive information

### DIFF
--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -161,7 +161,8 @@ public class LogViewFragment extends Fragment {
       Context context = weakContext.get();
       if (context == null) return null;
 
-      return buildDescription(context) + "\n" + new Scrubber().scrub(grabLogcat());
+      return "**This log may contain sensitive information. If you want to post it publicly you may examine and edit it beforehand.**\n\n" +
+          buildDescription(context) + "\n" + new Scrubber().scrub(grabLogcat());
     }
 
     @Override


### PR DESCRIPTION
- having this is the text has the advantage that the hint is
  also in place when the log is already exported,
  editing is maybe even easier later

- if needed, we can make the hint translatable at a later point,
  not sure, however, if this is useful as most of the log is english anyway.

closes https://github.com/deltachat/deltachat-android/issues/1501