### PR TITLE
adapt to new dc_configure() error handling

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -374,6 +374,8 @@
     <string name="delete_account">Delete account</string>
     <string name="delete_account_ask">Are you sure you want to delete your account data?</string>
     <string name="switching_account">Switching account…</string>
+    <!-- Translations: %1$s will be replaced by a more detailed error message -->
+    <string name="configuration_failed_with_error">Configuration failed. Error: %1$s</string>
 
     <!-- share and forward messages -->
     <!-- Translators: Title shown above a chat/contact list; the user selects the recipient of the messages he wants to forward to -->

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -20,7 +20,6 @@ import androidx.appcompat.app.AlertDialog;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.text.util.Linkify;
 import android.util.Patterns;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -555,19 +554,7 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
                 dcContext.maybeStartIo(); // start-io is also needed on errors to make previous config work in case of changes
                 dcContext.endCaptureNextError();
                 progressDialog.dismiss();
-                if (dcContext.hasCapturedError()) {
-                    AlertDialog d = new AlertDialog.Builder(this)
-                            .setMessage(dcContext.getCapturedError())
-                            .setPositiveButton(android.R.string.ok, null)
-                            .create();
-                    d.show();
-                    try {
-                        //noinspection ConstantConditions
-                        Linkify.addLinks((TextView) d.findViewById(android.R.id.message), Linkify.WEB_URLS | Linkify.EMAIL_ADDRESSES);
-                    } catch(NullPointerException e) {
-                        e.printStackTrace();
-                    }
-                }
+                WelcomeActivity.maybeShowConfigurationError(this, data2);
             }
             else if (progress<1000/*progress in permille*/) {
                 int percent = (int)progress / 10;

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -135,6 +135,7 @@ public class ApplicationDcContext extends DcContext {
     setStockTranslation(81, context.getString(R.string.systemmsg_ephemeral_timer_four_weeks));
     setStockTranslation(82, context.getString(R.string.videochat_invitation));
     setStockTranslation(83, context.getString(R.string.videochat_invitation_body));
+    setStockTranslation(84, context.getString(R.string.configuration_failed_with_error));
   }
 
   public File getImexDir() {


### PR DESCRIPTION
errors that should be shown to the user
come from DC_EVENT_CONFIGURE_PROGRESS(data1=0) as data2 since https://github.com/deltachat/deltachat-core-rust/pull/1905;
there is no need to show the captured error any longer
(which was unreliable and hard to handle from core site).

there is some capturing-code left as needed for other parts,
but it is not used for configuration anymore.