### PR TITLE
tune down usage of screen-lock

### DIFF
--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -13,7 +13,7 @@
         android:summary="@string/pref_incognito_keyboard_explain"
         android:title="@string/pref_incognito_keyboard" />
 
-    <PreferenceCategory android:title="@string/screenlock_title">
+    <PreferenceCategory android:key="pref_android_screen_lock_category" android:title="@string/screenlock_title">
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -176,8 +176,6 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
 
       this.findPreference(PREFERENCE_CATEGORY_NOTIFICATIONS)
           .setSummary(NotificationsPreferenceFragment.getSummary(getActivity()));
-      this.findPreference(PREFERENCE_CATEGORY_APP_PROTECTION)
-          .setSummary(AppProtectionPreferenceFragment.getSummary(getActivity()));
       this.findPreference(PREFERENCE_CATEGORY_APPEARANCE)
           .setSummary(AppearancePreferenceFragment.getSummary(getActivity()));
       this.findPreference(PREFERENCE_CATEGORY_CHATS)

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -62,6 +62,35 @@ public class ApplicationDcContext extends DcContext {
     // if ui-based migrations are needed, this is a good place
     // (see eg. https://github.com/deltachat/deltachat-android/pull/1618 for an example)
 
+    // screen-lock is deprecated, inform users still using it
+    try {
+      if (!Prefs.getBooleanPreference(context, "pref_android_screen_lock_checked", false)) {
+        Prefs.setBooleanPreference(context, "pref_android_screen_lock_checked", true);
+        if (Prefs.isScreenLockEnabled(context)) {
+          Prefs.setBooleanPreference(context, "pref_android_screen_lock_keep_for_now", true);
+          DcMsg msg = new DcMsg(this, DcMsg.DC_MSG_TEXT);
+          msg.setText("⚠️ You are using the function \"Screen lock\" " +
+            "that will be removed in one of the next versions for the following reasons:\n" +
+            "\n" +
+            "• It does not add much protection as one just has to repeat the system secret.\n" +
+            "\n" +
+            "• It is hard to maintain across different Android versions and is not even doable on some." +
+            " We like to put the resources to other things.\n" +
+            "\n" +
+            "• It is not planned/possible on iOS or Desktop this way" +
+            " and stands in the way of moving towards unified solutions.\n" +
+            "\n" +
+            "• Same or even better functionality is available by other apps or maybe by the device itself.\n" +
+            "\n" +
+            "\uD83D\uDC49 For the future, we suggest to keep your phone locked " +
+            "or use an appropriate app or check the device settings.");
+          addDeviceMsg("android-screen-lock-deprecated14", msg);
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
     new Thread(() -> {
       DcEventEmitter emitter = getEventEmitter();
       while (true) {

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -7,18 +7,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.provider.Settings;
 import androidx.annotation.Nullable;
-import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+
 import android.widget.Toast;
 
-import com.b44t.messenger.DcContext;
-
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
-import org.thoughtcrime.securesms.BlockedAndShareContactsActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.SwitchPreferenceCompat;
-import org.thoughtcrime.securesms.connect.ApplicationDcContext;
-import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
 
@@ -73,6 +69,16 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
         if (!screenLockPreference.isChecked()) {
             manageScreenLockChildren(false);
         }
+
+        // screen-lock is deprecated
+        try {
+            if (!Prefs.getBooleanPreference(getContext(), "pref_android_screen_lock_keep_for_now", false)) {
+                PreferenceCategory screenLockCategory = findPreference("pref_android_screen_lock_category");
+                screenLockCategory.setVisible(false);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private void manageScreenLockChildren(boolean enable) {
@@ -103,13 +109,6 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
             ScreenLockUtil.setShouldLockApp(false);
             return true;
         }
-    }
-
-    public static CharSequence getSummary(Context context) {
-        final String onRes = context.getString(R.string.on);
-        final String offRes = context.getString(R.string.off);
-        String screenLockState = Prefs.isScreenLockEnabled(context) ? onRes : offRes;
-        return context.getString(R.string.screenlock_title) + " " + screenLockState;
     }
 
     private class ChangePassphraseClickListener implements Preference.OnPreferenceClickListener {


### PR DESCRIPTION
for various reasons,
screen-lock will be removed completely in one of the next versions.

- if screen-lock was enabled before, add a warning
  and keep the options (user can switch screen-lock on and off
  until it will be finally removed)

- if screen lock was disabled before,
  hide the corresponding options,
  (the user will not be able to enable screen-lock anymore)

reasons for removing are:

- hard maintainability on different android versions, see discussions at
  https://github.com/deltachat/deltachat-android/issues/1208 and
  https://github.com/deltachat/deltachat-android/pull/1319 and offline.
  ftr, also the used api createConfirmDeviceCredentialIntent() is deprectated,
  so another set of api calls would be needed in the soon future.

- compared to the effort, few security is added,
  the function is only available if the system is protected anyway,
  one just have to repeat the system secret.

- might even worsen overall security - if app login secret is peeked,
  and attacker will also have the system secret.

- the functions stands in the way of moving forward to a
  cross-platform solution (however, not sure if this will really come)

this is what the device-message looks like:
<img width="300" alt="Screen Shot 2020-09-17 at 16 07 33" src="https://user-images.githubusercontent.com/9800740/93484148-dd38eb80-f901-11ea-866b-607afa043193.png">
it will be shown only to users that have the function enabled before,
so i do not think it is worth making that localizable -
also as the reasoning might be hard to translate
for ppl not deep into the issue.

targets #1208