### PR TITLE
direct forward to "saved messages"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -287,6 +287,8 @@
     <string name="chat_self_talk_subtitle">Messages I sent to myself</string>
     <string name="saved_messages">Saved messages</string>
     <string name="saved_messages_explain">• Forward messages here for easy access\n\n• Take notes or voice memos\n\n• Attach media to save them</string>
+    <!-- this "Saved" should match the "Saved" from "Saved messages" -->
+    <string name="saved">Saved</string>
     <string name="chat_contact_request">Contact request</string>
     <string name="chat_no_contact_requests">No contact requests.\n\nIf you want classic emails to appear here as contact requests, you can change the corresponding setting in the app settings.</string>
     <string name="retry_send">Retry to send message</string>


### PR DESCRIPTION
when forwarding to "saved messages",
the ui goes back to the chat and the position in the original chat
and shows a short "saved" hint.

this saves at least one tap (cc @hpk42 :)
and makes saving multiple messages easier
as you stay in context.
btw, this is also how telegram handles things
and makes the saving as easy to use as starring eg. in whatsapp.

forwarding messasges to other chats is not changed.

<img width=400 src=https://user-images.githubusercontent.com/9800740/95398316-b91b6980-0905-11eb-94ef-f6a5a321305a.jpg>
