### PR TITLE
Don't use quickContact in the ConversationListItem

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -213,7 +213,7 @@ public class ConversationListItem extends RelativeLayout
     deliveryStatusIndicator.setNone();
 
     setBatchState(false);
-    contactPhotoImage.setAvatar(glideRequests, recipient, true);
+    contactPhotoImage.setAvatar(glideRequests, recipient, false);
   }
 
   public void bind(@NonNull  DcMsg         messageResult,
@@ -244,7 +244,7 @@ public class ConversationListItem extends RelativeLayout
     deliveryStatusIndicator.setNone();
 
     setBatchState(false);
-    contactPhotoImage.setAvatar(glideRequests, recipient, true);
+    contactPhotoImage.setAvatar(glideRequests, recipient, false);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/components/AvatarImageView.java
+++ b/src/org/thoughtcrime/securesms/components/AvatarImageView.java
@@ -59,7 +59,7 @@ public class AvatarImageView extends AppCompatImageView {
       }
     } else {
       setImageDrawable(new GeneratedContactPhoto("+").asDrawable(getContext(), ThemeUtil.getDummyContactColor(getContext())));
-      super.setOnClickListener(listener);
+      if (listener != null) super.setOnClickListener(listener);
     }
   }
 


### PR DESCRIPTION
quickContact means that you get to the contact details screen by
clicking the avatar. In the conversations list this is usually disabled,
just for the search it stayed enabled, which was unexpected
(because it was usually disabled ;-) ).

Even worse, in the search clicking the avatar sometimes got me to the
wrong contact details. No idea why, but I think disabling is better
anyway.