### PR TITLE
Faster conversations list load

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -50,19 +50,19 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
 
   @Override
   protected void onResume() {
-    Log.w(TAG, "onResume()");
+    Log.i(TAG, "onResume()");
     super.onResume();
   }
 
   @Override
   protected void onPause() {
-    Log.w(TAG, "onPause()");
+    Log.i(TAG, "onPause()");
     super.onPause();
   }
 
   @Override
   protected void onDestroy() {
-    Log.w(TAG, "onDestroy()");
+    Log.i(TAG, "onDestroy()");
     super.onDestroy();
   }
 

--- a/src/org/thoughtcrime/securesms/components/AvatarImageView.java
+++ b/src/org/thoughtcrime/securesms/components/AvatarImageView.java
@@ -49,7 +49,6 @@ public class AvatarImageView extends AppCompatImageView {
     if (recipient != null) {
       ContactPhoto contactPhoto = recipient.getContactPhoto(getContext());
       requestManager.load(contactPhoto)
-                    .fallback(recipient.getFallbackAvatarDrawable(getContext()))
                     .error(recipient.getFallbackAvatarDrawable(getContext()))
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
                     .circleCrop()


### PR DESCRIPTION
it's not a big difference but these are small changes, too.
- Log.i instead of Log.w (seemed to make a difference, maybe only Log.i buffers?)
- Don't set a fallback avatar
  if there is no fallbackavatar the error avatar will be shown, which is the same in our case, but this way we don't have to call getFallbackAvatarDrawable twice