### PR TITLE
reword protection message and make it translatable

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1337,6 +1337,12 @@ JNIEXPORT jboolean Java_com_b44t_messenger_DcMsg_isInfo(JNIEnv *env, jobject obj
 }
 
 
+JNIEXPORT jint Java_com_b44t_messenger_DcMsg_getInfoType(JNIEnv *env, jobject obj)
+{
+    return (jint)dc_msg_get_info_type(get_dc_msg(env, obj));
+}
+
+
 JNIEXPORT jboolean Java_com_b44t_messenger_DcMsg_isSetupMessage(JNIEnv *env, jobject obj)
 {
     return dc_msg_is_setupmessage(get_dc_msg(env, obj));

--- a/res/drawable/ic_protected_24.xml
+++ b/res/drawable/ic_protected_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12L21,5l-9,-4zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94L12,12L5,12L5,6.3l7,-3.11v8.8z"/>
+</vector>

--- a/res/drawable/ic_unprotected_24.xml
+++ b/res/drawable/ic_unprotected_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM4,12c0,-4.42 3.58,-8 8,-8 1.85,0 3.55,0.63 4.9,1.69L5.69,16.9C4.63,15.55 4,13.85 4,12zM12,20c-1.85,0 -3.55,-0.63 -4.9,-1.69L18.31,7.1C19.37,8.45 20,10.15 20,12c0,4.42 -3.58,8 -8,8z"/>
+</vector>

--- a/res/layout/conversation_item_update.xml
+++ b/res/layout/conversation_item_update.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.thoughtcrime.securesms.ConversationUpdateItem
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<org.thoughtcrime.securesms.ConversationUpdateItem xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@drawable/conversation_item_background"
     android:focusable="true"
     android:gravity="center"
@@ -18,6 +18,23 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:orientation="vertical">
+
+        <FrameLayout
+            android:id="@+id/big_icon_container"
+            android:layout_width="108dp"
+            android:layout_height="108dp"
+            android:layout_marginLeft="2dp"
+            android:layout_marginRight="2dp"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone"
+            android:background="@drawable/circle_universal_overlay">
+            <ImageView android:id="@+id/big_icon"
+                android:layout_width="72dp"
+                android:layout_height="72dp"
+                android:layout_gravity="center"
+                android:gravity="center"
+                app:srcCompat="@drawable/ic_protected_24" />
+        </FrameLayout>
 
         <!--Links should be clickable, see https://github.com/deltachat/deltachat-android/issues/1546-->
         <TextView

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -594,6 +594,12 @@
     <string name="systemmsg_ephemeral_timer_week">Disappearing messages timer set to 1 week.</string>
     <string name="systemmsg_ephemeral_timer_four_weeks">Disappearing messages timer set to 4 weeks.</string>
 
+    <!-- Translators: Protection disabled/enabled messages will be displayed together with a big "shield" and may be suffixed by systemmsg_action_by_user or systemmsg_action_by_me -->
+    <string name="systemmsg_chat_protection_disabled">Chat protection disabled.</string>
+    <string name="systemmsg_chat_protection_enabled">Chat protection enabled.</string>
+    <!-- Translators: The details are typically shown directly below systemmsg_chat_protection_enabled -->
+    <string name="systemmsg_chat_protection_enabled_explain">From now on, messages shown in this chat are protected even against compromised servers.</string>
+
 
     <!-- screen lock -->
     <string name="screenlock_title">Screen lock</string>

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -38,6 +38,9 @@ public class DcMsg {
     public final static int DC_VIDEOCHATTYPE_UNKNOWN = 0;
     public final static int DC_VIDEOCHATTYPE_BASICWEBRTC = 1;
 
+    public final static int DC_INFO_PROTECTION_ENABLED = 11;
+    public final static int DC_INFO_PROTECTION_DISABLED = 12;
+
     private static final String TAG = DcMsg.class.getSimpleName();
 
     public DcMsg(DcContext context, int viewtype) {
@@ -113,6 +116,7 @@ public class DcMsg {
     public native long    getFilebytes       ();
     public native boolean isForwarded        ();
     public native boolean isInfo             ();
+    public native int     getInfoType        ();
     public native boolean isSetupMessage     ();
     public native String  getSetupCodeBegin  ();
     public native String  getVideochatUrl    ();

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -71,7 +71,12 @@ public class ConversationUpdateItem extends LinearLayout
   }
 
   private void setGenericInfoRecord(DcMsg messageRecord) {
-    body.setText(messageRecord.getDisplayBody());
+    String text = messageRecord.getText();
+    if (messageRecord.getInfoType()==DcMsg.DC_INFO_PROTECTION_ENABLED) {
+      text += "\n" + getContext().getString(R.string.systemmsg_chat_protection_enabled_explain);
+    }
+    body.setText(text);
+
     body.setVisibility(VISIBLE);
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -23,6 +25,8 @@ public class ConversationUpdateItem extends LinearLayout
   private Set<DcMsg>    batchSelected;
 
   private TextView      body;
+  private FrameLayout   bigIconContainer;
+  private ImageView     bigIconImage;
   private DcMsg         messageRecord;
 
   public ConversationUpdateItem(Context context) {
@@ -37,7 +41,9 @@ public class ConversationUpdateItem extends LinearLayout
   public void onFinishInflate() {
     super.onFinishInflate();
 
-    this.body  = findViewById(R.id.conversation_update_body);
+    this.body             = findViewById(R.id.conversation_update_body);
+    this.bigIconContainer = findViewById(R.id.big_icon_container);
+    this.bigIconImage     = findViewById(R.id.big_icon);
   }
 
   @Override
@@ -72,12 +78,22 @@ public class ConversationUpdateItem extends LinearLayout
 
   private void setGenericInfoRecord(DcMsg messageRecord) {
     String text = messageRecord.getText();
-    if (messageRecord.getInfoType()==DcMsg.DC_INFO_PROTECTION_ENABLED) {
-      text += "\n" + getContext().getString(R.string.systemmsg_chat_protection_enabled_explain);
-    }
-    body.setText(text);
+    int    bigIcon = 0;
 
-    body.setVisibility(VISIBLE);
+    if (messageRecord.getInfoType()==DcMsg.DC_INFO_PROTECTION_ENABLED) {
+      text += "\n\n" + getContext().getString(R.string.systemmsg_chat_protection_enabled_explain);
+      bigIcon = R.drawable.ic_protected_24;
+    } else if (messageRecord.getInfoType()==DcMsg.DC_INFO_PROTECTION_DISABLED) {
+      bigIcon = R.drawable.ic_unprotected_24;
+    }
+
+    body.setText(text);
+    if (bigIcon!=0) {
+      bigIconContainer.setVisibility(VISIBLE);
+      bigIconImage.setImageDrawable(getContext().getResources().getDrawable(bigIcon));
+    } else {
+      bigIconContainer.setVisibility(GONE);
+    }
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -165,6 +165,8 @@ public class ApplicationDcContext extends DcContext {
     setStockTranslation(82, context.getString(R.string.videochat_invitation));
     setStockTranslation(83, context.getString(R.string.videochat_invitation_body));
     setStockTranslation(84, context.getString(R.string.configuration_failed_with_error));
+    setStockTranslation(88, context.getString(R.string.systemmsg_chat_protection_enabled));
+    setStockTranslation(89, context.getString(R.string.systemmsg_chat_protection_disabled));
     setStockTranslation(90, context.getString(R.string.reply_noun));
   }
 


### PR DESCRIPTION
with this pr, the system messages will look like ...

<img width=300 src=https://user-images.githubusercontent.com/9800740/96354816-2fc11f80-10db-11eb-9712-ea9f3cef4a57.png> <img width=300 src=https://user-images.githubusercontent.com/9800740/96354815-2b950200-10db-11eb-84c7-8627706d5299.png>

**please regard the icons as placeholders,** they will probably be changed/refined at some point later, this pr is about the wording of the message, so that it can go to the translators.

the "... by ..." suffix cannot be changed for now, this would cause too much troubles. so wordings as "I enabled ..." are out of scope.

suggestions welcome :)
