### PR TITLE
no 'disappearing messages' when a chat is not sendable

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -447,6 +447,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       menu.findItem(R.id.menu_videochat_invite).setVisible(false);
     }
 
+    if (!dcChat.canSend()) {
+      menu.findItem(R.id.menu_ephemeral_messages).setVisible(false);
+    }
+
     if (isGroupConversation()) {
       if (isActiveGroup()) {
         inflater.inflate(R.menu.conversation_push_group_options, menu);


### PR DESCRIPTION
disable 'disappearing messages' when a chat is not sendable this is currently the device-chat, but may be others in the future.

the thing did not worked anyway: the icon was displayed in the title, but the info-message was missing. timer was never started.

came over that when writing the device-message for #1689 and though ppl might try that out in the chat they're in :)