### PR TITLE
priorize delete-function over export/copy

### DIFF
--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -10,15 +10,15 @@
           android:icon="?menu_info_icon"
           app:showAsAction="always" />
 
-    <item android:title="@string/menu_export_attachment"
-          android:id="@+id/menu_context_save_attachment"
-          android:visible="false"
-          android:icon="?menu_save_icon"
-          app:showAsAction="always" />
-
     <item android:title="@string/menu_delete_messages"
         android:id="@+id/menu_context_delete_message"
         android:icon="?menu_trash_icon"
+        app:showAsAction="always" />
+
+    <item android:title="@string/menu_export_attachment"
+        android:id="@+id/menu_context_save_attachment"
+        android:visible="false"
+        android:icon="?menu_save_icon"
         app:showAsAction="always" />
 
     <item android:title="@string/menu_copy_to_clipboard"


### PR DESCRIPTION
in the long-tap context-menu, on smaller screens,
functions go to the overflow menu from right to left.

this pr gives the "delete" a higher priority than the
only sometimes available "export" function

- delete is always available on smaller screen -
  before, the icon was sometimes there and sometimes not,
  which is a bit irritating

- export gets a similar priority as copy

- on/off icons are now functions that are used
  less frequently

the change is needed now as, due to quoting, there are more functions in the long-tap context-menu.