### PR TITLE
Handle sendto intents with ShareActivity, not NewConversationActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -77,6 +77,13 @@
         </intent-filter>
 
         <intent-filter>
+            <data android:scheme="mailto"/>
+            <action android:name="android.intent.action.SENDTO"/>
+            <category android:name="android.intent.category.DEFAULT"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+        </intent-filter>
+
+        <intent-filter>
             <action android:name="android.intent.action.SEND_MULTIPLE" />
             <category android:name="android.intent.category.DEFAULT" />
             <data android:mimeType="audio/*" />
@@ -154,7 +161,6 @@
         <intent-filter>
             <data android:scheme="mailto"/>
             <action android:name="android.intent.action.VIEW"/>
-            <action android:name="android.intent.action.SENDTO"/>
             <category android:name="android.intent.category.DEFAULT"/>
             <category android:name="android.intent.category.BROWSABLE"/>
         </intent-filter>


### PR DESCRIPTION
Fix #1701 

I am not 100% sure if this is the way to go. On first sight, this seems totally legit: ShareActivity should handle `SENDTO` intents, I mean, why should NewConversationActivity do this? But then, there may be a reason why NewConversationActivity was chosen to do the job.

Of course NewConversationActivity could do the same as ShareActivity does or relay it to ShareActivity, but this seems like very bad code style (it currently does relay to ShareActivity sometimes in `handleIntent()` but then forgets to relay all the extras; that's why the recipient is lost).

I think it's best to ping @flub as he also did sharing-related stuff in the past and then wait until after the release.