### PR TITLE
disable forwarding info-messages

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -347,6 +347,16 @@ public class ConversationFragment extends Fragment
             boolean showReplyPrivately = chat.isGroup() && !messageRecord.isOutgoing() && canReply;
             menu.findItem(R.id.menu_context_reply_privately).setVisible(showReplyPrivately);
         }
+
+        // if one of the selected item cannot be forwarded, disable forwarding.
+        boolean canForward = true;
+        for (DcMsg messageRecord : messageRecords) {
+            if (messageRecord.isInfo()) {
+                canForward = false;
+                break;
+            }
+        }
+        menu.findItem(R.id.menu_context_forward).setVisible(canForward);
     }
 
     static boolean canReplyToMsg(DcMsg dcMsg) {


### PR DESCRIPTION
i also cannot see a usecase for forwarding info-messages as "member added",
so it might also confuse users when the option is offered at all.

as all selected messages are loaded into memory anyway,
this was easy to implement.

tbh, if we would track the selection by message-ids only and
this would have require a larger refactoring or performace issues
(imaging 100 messages to be checked on each new selected message),
i would not have implemented that now :)

i do not think, that sensitive information can be send accidentially this way,
even if Bob can forward an info-message as "Alice invited Claire" -
it is pretty clear to Bob that he forwards exactly that text.
(this is different from adding "Honey" to the group -
where "Honey" is an only locally given name for "Dr. Someone" ;)

closes #1705