### PR TITLE
Fix crash in ImageEditor

### DIFF
--- a/src/org/thoughtcrime/securesms/scribbles/ImageEditorFragment.java
+++ b/src/org/thoughtcrime/securesms/scribbles/ImageEditorFragment.java
@@ -95,7 +95,7 @@ public final class ImageEditorFragment extends Fragment implements ImageEditorHu
     super.onCreate(savedInstanceState);
 
     if (imageUri == null) {
-      throw new AssertionError("No KEY_IMAGE_URI supplied");
+      imageUri = getArguments().getParcelable(KEY_IMAGE_URI);
     }
 
     MediaConstraints mediaConstraints = new ImageEditorMediaConstraints();


### PR DESCRIPTION
For some reason it is not possible to remove `setUri`, when I tried, I
got crashes each time I tried to edit an image.