### PR TITLE
Do not display milliseconds when recording a voice message fix #1711

### DIFF
--- a/res/layout/conversation_input_panel.xml
+++ b/res/layout/conversation_input_panel.xml
@@ -43,7 +43,7 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="none"
                 style="@style/Signal.Text.Body"
-                android:text="00:00.00"
+                android:text="00:00.0"
                 android:textColor="?conversation_item_outgoing_text_primary_color"
                 android:singleLine="true"
                 android:visibility="gone"

--- a/src/org/thoughtcrime/securesms/components/InputPanel.java
+++ b/src/org/thoughtcrime/securesms/components/InputPanel.java
@@ -16,7 +16,6 @@ import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.AnimationSet;
 import android.view.animation.TranslateAnimation;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -376,7 +375,7 @@ public class InputPanel extends ConstraintLayout
 
     private final TextView recordTimeView;
     private final AtomicLong startTime = new AtomicLong(0);
-    private final int UPDATE_EVERY_MS = 137;
+    private final int UPDATE_EVERY_MS = 99;
 
     private RecordTime(TextView recordTimeView) {
       this.recordTimeView = recordTimeView;
@@ -409,7 +408,7 @@ public class InputPanel extends ConstraintLayout
     private String formatElapsedTime(long ms)
     {
       return DateUtils.formatElapsedTime(TimeUnit.MILLISECONDS.toSeconds(ms))
-              + String.format(".%02d", ((ms/10)%100));
+              + String.format(".%01d", ((ms/100)%10));
 
     }
   }


### PR DESCRIPTION
Also I have no idea why someone would set UPDATE_EVERY_MS to 173 but with 99 we get a totally smooth counter