### PR TITLE
do not use cached value to check for notifications

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -139,18 +139,6 @@ public class ConversationListItem extends RelativeLayout
     int state       = dcSummary.getState();
     int unreadCount = (state==DcMsg.DC_STATE_IN_FRESH || state==DcMsg.DC_STATE_IN_NOTICED)? thread.getUnreadCount() : 0;
 
-    // if the last message is not fresh or noticed, we assume, there are no unread things
-    // and also remove notifications for the chat.
-    // this might be improved at some point in core, https://github.com/deltachat/deltachat-core-rust/issues/1974
-    // and the following call to removeNotifications() can go to DC_EVENT_MSGS_NOTICED handler.
-    // however, for now it is not that bad
-    // and ensures, things answered on device-A are no longer notified on device-B.
-    if (unreadCount==0) {
-      Util.runOnAnyBackgroundThread(() -> {
-        dcContext.notificationCenter.removeNotifications((int) chatId);
-      });
-    }
-
     if (highlightSubstring != null) {
       this.fromView.setText(getHighlightedSpan(locale, recipient.getName(), highlightSubstring));
     } else {

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -452,6 +452,13 @@ public class ApplicationDcContext extends DcContext {
         }
         break;
 
+      case DC_EVENT_MSGS_NOTICED:
+        notificationCenter.removeNotifications(event.getData1Int());
+        if (eventCenter != null) {
+          eventCenter.sendToObservers(event);
+        }
+        break;
+
       default: {
         if (eventCenter != null) {
           eventCenter.sendToObservers(event);

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -504,12 +504,12 @@ public class NotificationCenter {
     public void removeNotifications(int chatId) {
         boolean removeSummary;
         synchronized (inboxes) {
-            if (inboxes.remove(chatId) == null) {
-              return; // speed up things when there is nothing to remove
-            }
+            inboxes.remove(chatId);
             removeSummary = inboxes.isEmpty();
         }
 
+        // cancel notification independently of inboxes array,
+        // due to restarts, the app may have notification even when inboxes is empty.
         try {
             NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
             notificationManager.cancel(ID_MSG_OFFSET + chatId);


### PR DESCRIPTION
the 'inboxes' value contains the last lines of notification,
however, if the app is restarted for whatever reasons,
but notifications are persisted,
they do not contain all lines.

for the notification display, this is no big deal,
however, this cached value is not suitable
to check if there is a notification or not for a chat.

even if there is a notification, 'inboxes' may be empty,
this 'speed up' check was introduced
for a workaround of notification removal that requires lots of calls.
meanwhile, however, we have DC_EVENT_MSGS_NOTICED,
so we also remove this workaround.

the bug of notifications getting stuck was reported by @adbenitez on irc/dc