### PR TITLE
show permanent hint about server-delete impact

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -541,6 +541,8 @@
     <string name="autodel_device_ask">Do you want to delete %1$d messages now and all newly fetched messages \"%2$s\" in the future?\n\n• This includes all media\n\n• Messages will be deleted whether they were seen or not\n\n• \"Saved messages\" will be skipped from local deletion</string>
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
     <string name="autodel_server_ask">Do you want to delete %1$d messages now and all newly fetched messages \"%2$s\" in the future?\n\n⚠️ This includes emails, media and \"Saved messages\" in all server folders\n\n⚠️ Do not use this function if you want to keep data on the server\n\n⚠️ Do not use this function if you are using other email clients besides Delta Chat</string>
+    <!-- shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact -->
+    <string name="autodel_server_enabled_hint">This includes emails, media and \"Saved messages\" in all server folders. Do not use this function if you want to keep data on the server or if you are using other email clients besides Delta Chat.</string>
     <string name="autodel_confirm">I understand, delete all these messages</string>
     <string name="autodel_at_once">At once</string>
     <string name="after_30_seconds">After 30 seconds</string>

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -98,7 +98,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   private void initAutodelFromCore() {
     String value = Integer.toString(dcContext.getConfigInt("delete_server_after"));
     autoDelServer.setValue(value);
-    updateListSummary(autoDelServer, value);
+    updateListSummary(autoDelServer, value, value.equals("0")? null : getString(R.string.autodel_server_enabled_hint));
 
     value = Integer.toString(dcContext.getConfigInt("delete_device_after"));
     autoDelDevice.setValue(value);

--- a/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -81,8 +81,16 @@ public abstract class ListSummaryPreferenceFragment extends CorrectedPreferenceF
   }
 
   protected void updateListSummary(Preference preference, Object value) {
+    updateListSummary(preference, value, null);
+  }
+
+  protected void updateListSummary(Preference preference, Object value, String hint) {
     ListPreference listPref = (ListPreference) preference;
-    listPref.setSummary(getSelectedSummary(preference, value));
+    String summary = getSelectedSummary(preference, value);
+    if (hint != null) {
+      summary += "\n\n" + hint;
+    }
+    listPref.setSummary(summary);
   }
 
   protected void initializeListSummary(ListPreference pref) {


### PR DESCRIPTION
when server-deletion is enabled, always show a hint about the impact below the option.

the hint is a summary of the conformation-dialog so that the user is more aware of the impact if enabling was some time ago or the option was even enabled by the provider-db.

<img width="354" alt="Screen Shot 2020-11-18 at 21 48 09" src="https://user-images.githubusercontent.com/9800740/99586789-76f74480-29e8-11eb-9d3f-fe0f478735a1.png">

just came into my mind :) successor of https://github.com/deltachat/deltachat-android/pull/1736