### PR TITLE
show hint if there are no blocked contacts

### DIFF
--- a/res/layout/contact_selection_list_fragment.xml
+++ b/res/layout/contact_selection_list_fragment.xml
@@ -16,7 +16,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center|center_vertical"
-            android:layout_marginTop="15dp"
+            android:padding="16dp"
+            android:lineSpacingMultiplier="1.3"
             android:visibility="gone"
             android:text="@string/contacts_empty_hint"
             android:textSize="20sp" />

--- a/res/layout/contact_selection_list_fragment.xml
+++ b/res/layout/contact_selection_list_fragment.xml
@@ -19,8 +19,8 @@
             android:padding="16dp"
             android:lineSpacingMultiplier="1.3"
             android:visibility="gone"
-            android:text="@string/contacts_empty_hint"
-            android:textSize="20sp" />
+            android:textSize="20sp"
+            tools:text="No contacts." />
 
     <org.thoughtcrime.securesms.components.RecyclerViewFastScroller
         android:id="@+id/fast_scroller"

--- a/res/layout/contact_selection_list_fragment.xml
+++ b/res/layout/contact_selection_list_fragment.xml
@@ -4,11 +4,6 @@
              xmlns:app="http://schemas.android.com/apk/res-auto"
              xmlns:tools="http://schemas.android.com/tools"
              android:orientation="vertical">
-    
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/swipe_refresh"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler_view"
@@ -22,10 +17,9 @@
             android:layout_height="match_parent"
             android:gravity="center|center_vertical"
             android:layout_marginTop="15dp"
-            android:text="@string/one_moment"
+            android:visibility="gone"
+            android:text="@string/contacts_empty_hint"
             android:textSize="20sp" />
-
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <org.thoughtcrime.securesms.components.RecyclerViewFastScroller
         android:id="@+id/fast_scroller"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -425,6 +425,7 @@
     <string name="pref_profile_info_headline">Your profile info</string>
     <string name="pref_profile_photo">Profile image</string>
     <string name="pref_blocked_contacts">Blocked contacts</string>
+    <string name="blocked_empty_hint">If you block contacts, they will be shown here.</string>
     <string name="pref_profile_photo_remove_ask">Remove profile image?</string>
     <string name="pref_password_and_account_settings">Password and account</string>
     <string name="pref_who_can_see_profile_explain">Your profile image and name will be shown alongside your messages when communicating with other users. Already sent information can not be deleted or removed.</string>

--- a/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
@@ -76,6 +77,7 @@ public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBar
 
 
     private RecyclerView recyclerView;
+    private TextView emptyStateView;
 
     private boolean showOnlyBlocked;
 
@@ -84,6 +86,8 @@ public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBar
       View view = inflater.inflate(R.layout.contact_selection_list_fragment, container, false);
       recyclerView  = ViewUtil.findById(view, R.id.recycler_view);
       recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+      emptyStateView = ViewUtil.findById(view, android.R.id.empty);
+      emptyStateView.setText(R.string.none_blocked_desktop);
       return view;
     }
 
@@ -116,7 +120,13 @@ public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBar
 
     @Override
     public void onLoadFinished(Loader<DcContactsLoader.Ret> loader, DcContactsLoader.Ret data) {
-      getContactSelectionListAdapter().changeData(data);
+      ContactSelectionListAdapter adapter = getContactSelectionListAdapter();
+      if (adapter != null) {
+        adapter.changeData(data);
+        if (emptyStateView != null) {
+          emptyStateView.setVisibility(adapter.getItemCount() > 0 ? View.GONE : View.VISIBLE);
+        }
+      }
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
@@ -87,7 +87,7 @@ public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBar
       recyclerView  = ViewUtil.findById(view, R.id.recycler_view);
       recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
       emptyStateView = ViewUtil.findById(view, android.R.id.empty);
-      emptyStateView.setText(R.string.none_blocked_desktop);
+      emptyStateView.setText(R.string.blocked_empty_hint);
       return view;
     }
 

--- a/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
@@ -6,7 +6,6 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -78,15 +77,12 @@ public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBar
 
     private RecyclerView recyclerView;
 
-    private SwipeRefreshLayout swipeRefreshLayout;
-
     private boolean showOnlyBlocked;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle bundle) {
       View view = inflater.inflate(R.layout.contact_selection_list_fragment, container, false);
       recyclerView  = ViewUtil.findById(view, R.id.recycler_view);
-      swipeRefreshLayout  = ViewUtil.findById(view, R.id.swipe_refresh);
       recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
       return view;
     }
@@ -111,8 +107,6 @@ public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBar
               false,
               false);
       recyclerView.setAdapter(adapter);
-      swipeRefreshLayout.setRefreshing(false);
-      swipeRefreshLayout.setEnabled(false);
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
@@ -16,18 +16,13 @@
  */
 package org.thoughtcrime.securesms;
 
-import android.content.Context;
-import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import org.thoughtcrime.securesms.components.ContactFilterToolbar;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.ViewUtil;
-
-import java.lang.ref.WeakReference;
 
 /**
  * Base activity container for selecting a list of contacts.
@@ -36,8 +31,7 @@ import java.lang.ref.WeakReference;
  *
  */
 public abstract class ContactSelectionActivity extends PassphraseRequiredActionBarActivity
-                                               implements SwipeRefreshLayout.OnRefreshListener,
-                                                          ContactSelectionListFragment.OnContactSelectedListener
+                                               implements ContactSelectionListFragment.OnContactSelectedListener
 {
   private static final String TAG = ContactSelectionActivity.class.getSimpleName();
 
@@ -88,7 +82,6 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
   private void initializeResources() {
     contactsFragment = (ContactSelectionListFragment) getSupportFragmentManager().findFragmentById(R.id.contact_selection_list_fragment);
     contactsFragment.setOnContactSelectedListener(this);
-    contactsFragment.setOnRefreshListener(this);
   }
 
   private void initializeSearch() {
@@ -96,38 +89,8 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
   }
 
   @Override
-  public void onRefresh() {
-    new RefreshDirectoryTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, getApplicationContext());
-  }
-
-  @Override
   public void onContactSelected(int specialId, String number) {}
 
   @Override
   public void onContactDeselected(int specialId, String number) {}
-
-  private static class RefreshDirectoryTask extends AsyncTask<Context, Void, Void> {
-
-    private final WeakReference<ContactSelectionActivity> activity;
-
-    private RefreshDirectoryTask(ContactSelectionActivity activity) {
-      this.activity = new WeakReference<>(activity);
-    }
-
-    @Override
-    protected Void doInBackground(Context... params) {
-
-      return null;
-    }
-
-    @Override
-    protected void onPostExecute(Void result) {
-      ContactSelectionActivity activity = this.activity.get();
-
-      if (activity != null && !activity.isFinishing()) {
-        activity.toolbar.clear();
-        activity.contactsFragment.resetQueryFilter();
-      }
-    }
-  }
 }

--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -30,7 +30,6 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
@@ -87,18 +86,14 @@ public class ContactSelectionListFragment extends    Fragment
   private static final String TAG = ContactSelectionListFragment.class.getSimpleName();
 
   public static final String MULTI_SELECT          = "multi_select";
-  public static final String REFRESHABLE           = "refreshable";
-  public static final String RECENTS               = "recents";
   public static final String SELECT_VERIFIED_EXTRA = "select_verified";
   public static final String FROM_SHARE_ACTIVITY_EXTRA = "from_share_activity";
   public static final String PRESELECTED_CONTACTS = "preselected_contacts";
 
   private ApplicationDcContext dcContext;
 
-  private TextView                  emptyText;
   private Set<String>               selectedContacts;
   private OnContactSelectedListener onContactSelectedListener;
-  private SwipeRefreshLayout        swipeRefresh;
   private String                    cursorFilter;
   private RecyclerView              recyclerView;
   private StickyHeaderDecoration    listDecoration;
@@ -136,9 +131,7 @@ public class ContactSelectionListFragment extends    Fragment
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     View view = inflater.inflate(R.layout.contact_selection_list_fragment, container, false);
 
-    emptyText               = ViewUtil.findById(view, android.R.id.empty);
     recyclerView            = ViewUtil.findById(view, R.id.recycler_view);
-    swipeRefresh            = ViewUtil.findById(view, R.id.swipe_refresh);
     fastScroller            = ViewUtil.findById(view, R.id.fast_scroller);
     recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
     actionModeCallback = new ActionMode.Callback() {
@@ -187,10 +180,6 @@ public class ContactSelectionListFragment extends    Fragment
         }
       }
     };
-
-    // There shouldn't be the need to pull to refresh the contacts
-    // swipeRefresh.setEnabled(getActivity().getIntent().getBooleanExtra(REFRESHABLE, true) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN);
-    swipeRefresh.setEnabled(false);
 
     return view;
   }
@@ -309,11 +298,6 @@ public class ContactSelectionListFragment extends    Fragment
 
   public void resetQueryFilter() {
     setQueryFilter(null);
-    swipeRefresh.setRefreshing(false);
-  }
-
-  public void setRefreshing(boolean refreshing) {
-    swipeRefresh.setRefreshing(refreshing);
   }
 
   public void reset() {
@@ -337,7 +321,6 @@ public class ContactSelectionListFragment extends    Fragment
   @Override
   public void onLoadFinished(Loader<DcContactsLoader.Ret> loader, DcContactsLoader.Ret data) {
     ((ContactSelectionListAdapter) recyclerView.getAdapter()).changeData(data);
-    emptyText.setText(R.string.contacts_empty_hint);
     boolean useFastScroller = (recyclerView.getAdapter().getItemCount() > 20);
     recyclerView.setVerticalScrollBarEnabled(!useFastScroller);
     if (useFastScroller) {
@@ -449,10 +432,6 @@ public class ContactSelectionListFragment extends    Fragment
 
     public void setOnContactSelectedListener(OnContactSelectedListener onContactSelectedListener) {
     this.onContactSelectedListener = onContactSelectedListener;
-  }
-
-  public void setOnRefreshListener(SwipeRefreshLayout.OnRefreshListener onRefreshListener) {
-    this.swipeRefresh.setOnRefreshListener(onRefreshListener);
   }
 
   public interface OnContactSelectedListener {


### PR DESCRIPTION
add a hint to the "blocked contacts" activity if there are no blocked contacts.

before, the whole activity was just "white" and it was unclear what can be done here.

moreover, this pr cleans up with unused `SwipeRefreshLayout`.

<img width=320 src=https://user-images.githubusercontent.com/9800740/99918492-90b1c800-2d17-11eb-9520-574cae5101c6.png>

closes #1287

once merged, we should use the string `blocked_empty_hint` instead of `none_blocked_desktop` also on ios and desktop. (the old string reads "no blocked contacts yet" which does not give a hint who blocks things and also the "yet" feels a bit weird to me - as if this is a goal or so :)