### PR TITLE
display forwarded messages also in quotes as such

### DIFF
--- a/res/layout/quote_view.xml
+++ b/res/layout/quote_view.xml
@@ -20,8 +20,8 @@
 			android:id="@+id/quote_bar"
 			android:layout_width="@dimen/quote_corner_radius_bottom"
 			android:layout_height="match_parent"
-			android:background="@color/purple_400"
-			tools:tint="@color/purple_400" />
+			android:background="@color/unknown_sender"
+			tools:tint="@color/unknown_sender" />
 
 		<LinearLayout
 			android:layout_width="0dp"

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -64,4 +64,8 @@
     <color name="pinned_bg">#eeeeee</color>
     <color name="pinned_bg_dark">#222222</color>
 
+    <!-- unknown_sender fits in dark mode and lite mode (also other chat/contact colors fit in both modes);
+         unknown_sender is used for the sender-name/quote-bar if the sender is unknown -->
+    <color name="unknown_sender">#ff999999</color>
+
 </resources>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -122,7 +122,6 @@ public class ConversationItem extends LinearLayout
 
   private int incomingBubbleColor;
   private int outgoingBubbleColor;
-  private int forwardedTitleColor;
 
   private final PassthroughClickListener        passthroughClickListener   = new PassthroughClickListener();
 
@@ -265,13 +264,11 @@ public class ConversationItem extends LinearLayout
     final int[]      attributes = new int[] {
         R.attr.conversation_item_incoming_bubble_color,
         R.attr.conversation_item_outgoing_bubble_color,
-        R.attr.conversation_item_incoming_text_secondary_color
     };
     final TypedArray attrs      = context.obtainStyledAttributes(attributes);
 
     incomingBubbleColor = attrs.getColor(0, Color.WHITE);
     outgoingBubbleColor = attrs.getColor(1, Color.WHITE);
-    forwardedTitleColor = attrs.getColor(2, Color.BLACK);
     attrs.recycle();
   }
 
@@ -641,7 +638,7 @@ public class ConversationItem extends LinearLayout
   private void setGroupMessageStatus() {
     if (messageRecord.isForwarded()) {
       this.groupSender.setText(context.getString(R.string.forwarded_message));
-      this.groupSender.setTextColor(forwardedTitleColor);
+      this.groupSender.setTextColor(context.getResources().getColor(R.color.unknown_sender));
     }
     else if (groupThread && !messageRecord.isOutgoing() && dcContact !=null) {
       this.groupSender.setText(dcContact.getDisplayName());

--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -3,7 +3,6 @@ package org.thoughtcrime.securesms.components;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
@@ -41,8 +40,6 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
   private static final String TAG = QuoteView.class.getSimpleName();
 
   private static final int MESSAGE_TYPE_PREVIEW  = 0;
-  private static final int MESSAGE_TYPE_OUTGOING = 1;
-  private static final int MESSAGE_TYPE_INCOMING = 2;
 
   private ViewGroup mainView;
   private TextView  authorView;
@@ -56,13 +53,8 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
   private DcMsg quotedMsg;
   private DcContact     author;
   private CharSequence  body;
-  //private TextView      missingLinkText;
   private SlideDeck     attachments;
   private int           messageType;
-  private int           largeCornerRadius;
-  private int           smallCornerRadius;
-//  private CornerMask    cornerMask;
-
 
   public QuoteView(Context context) {
     super(context);
@@ -96,16 +88,9 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
     this.attachmentVideoOverlayView   = findViewById(R.id.quote_video_overlay);
     this.attachmentContainerView      = findViewById(R.id.quote_attachment_container);
     this.dismissView                  = findViewById(R.id.quote_dismiss);
-//    this.largeCornerRadius            = getResources().getDimensionPixelSize(R.dimen.quote_corner_radius_large);
-//    this.smallCornerRadius            = getResources().getDimensionPixelSize(R.dimen.quote_corner_radius_bottom);
-
-//    cornerMask = new CornerMask(this);
-//    cornerMask.setRadii(largeCornerRadius, largeCornerRadius, smallCornerRadius, smallCornerRadius);
 
     if (attrs != null) {
       TypedArray typedArray     = getContext().getTheme().obtainStyledAttributes(attrs, R.styleable.QuoteView, 0, 0);
-      int        primaryColor   = typedArray.getColor(R.styleable.QuoteView_quote_colorPrimary, Color.BLACK);
-      int        secondaryColor = typedArray.getColor(R.styleable.QuoteView_quote_colorSecondary, Color.BLACK);
       messageType = typedArray.getInt(R.styleable.QuoteView_message_type, 0);
       typedArray.recycle();
 
@@ -115,27 +100,14 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
       } else {
         bodyView.setMaxLines(3);
       }
-
-//      if (messageType == MESSAGE_TYPE_PREVIEW) {
-//        int radius = getResources().getDimensionPixelOffset(R.dimen.quote_corner_radius_preview);
-//        cornerMask.setTopLeftRadius(radius);
-//        cornerMask.setTopRightRadius(radius);
-//      }
     }
 
     dismissView.setOnClickListener(view -> setVisibility(GONE));
   }
-//
-//  @Override
-//  protected void dispatchDraw(Canvas canvas) {
-//    super.dispatchDraw(canvas);
-//    cornerMask.mask(canvas);
-//  }
 
   @Override
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
-    //if (author != null) author.removeForeverObserver(this);
   }
 
   public void setQuote(GlideRequests glideRequests,
@@ -144,28 +116,17 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
                        @Nullable CharSequence body,
                        @NonNull SlideDeck attachments)
   {
-//    if (this.author != null) this.author.removeForeverObserver(this);
-
     quotedMsg        = msg;
     this.author      = author != null ? author.getDcContact() : null;
     this.body        = body;
     this.attachments = attachments;
 
-    //this.author.observeForever(this);
     setQuoteAuthor(author);
     setQuoteText(body, attachments);
     setQuoteAttachment(glideRequests, attachments);
-    //setQuoteMissingFooter(originalMissing);
   }
 
-//  public void setTopCornerSizes(boolean topLeftLarge, boolean topRightLarge) {
-//    cornerMask.setTopLeftRadius(topLeftLarge ? largeCornerRadius : smallCornerRadius);
-//    cornerMask.setTopRightRadius(topRightLarge ? largeCornerRadius : smallCornerRadius);
-//  }
-
   public void dismiss() {
-    //if (this.author != null) this.author.removeForeverObserver(this);
-
     this.author = null;
     this.body   = null;
 
@@ -240,11 +201,6 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
       dismissView.setBackgroundResource(R.drawable.circle_alpha);
     }
   }
-//
-//  private void setQuoteMissingFooter(boolean missing) {
-//    footerView.setVisibility(missing ? VISIBLE : GONE);
-//    footerView.setBackgroundColor(author.getColor());
-//  }
 
   public CharSequence getBody() {
     return body;

--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -141,15 +141,23 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
   private void setQuoteAuthor(@Nullable Recipient author) {
     if (author == null) {
       authorView.setVisibility(GONE);
-      return;
-    }
-
-    DcContact contact = author.getDcContact();
-    if (contact != null) {
+      quoteBarView.setBackgroundColor(getForwardedColor());
+    } else if (quotedMsg.isForwarded()) {
       authorView.setVisibility(VISIBLE);
-      authorView.setText(contact.getDisplayName());
-      quoteBarView.setBackgroundColor(contact.getArgbColor());
-      authorView.setTextColor(contact.getArgbColor());
+      authorView.setText(getContext().getString(R.string.forwarded_message));
+      authorView.setTextColor(getForwardedColor());
+      quoteBarView.setBackgroundColor(getForwardedColor());
+    } else {
+      DcContact contact = author.getDcContact();
+      if (contact == null) {
+        authorView.setVisibility(GONE);
+        quoteBarView.setBackgroundColor(getForwardedColor());
+      } else {
+        authorView.setVisibility(VISIBLE);
+        authorView.setText(contact.getDisplayName());
+        authorView.setTextColor(contact.getArgbColor());
+        quoteBarView.setBackgroundColor(contact.getArgbColor());
+      }
     }
   }
 
@@ -216,5 +224,9 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
 
   public DcMsg getOriginalMsg() {
     return quotedMsg;
+  }
+
+  private int getForwardedColor() {
+    return getResources().getColor(R.color.unknown_sender);
   }
 }


### PR DESCRIPTION
see #1743  for backgrounds and reasoning. this is how it looks like:

<img width="372" alt="100225763-05a31e80-2f1f-11eb-92ef-d7d996ebb96f" src="https://user-images.githubusercontent.com/9800740/100275103-be894d80-2f5f-11eb-8c7e-c17d0c3d2251.png">

i also introduced a "universal" forward color that is is also used for quotes where the sender is unknown for whatever reason (forwarded-messages and unnamed-quotes are quite similar in this regard and it makes sense to use the same color for both)

closes #1743 