### PR TITLE
Put a black circle behind the edit options when editing an image

### DIFF
--- a/res/layout/image_editor_hud.xml
+++ b/res/layout/image_editor_hud.xml
@@ -25,6 +25,7 @@
             android:orientation="horizontal"
             android:layout_marginEnd="20dp"
             android:layout_marginRight="20dp"
+            app:chipSpacing="8dp"
             app:layout_constraintEnd_toStartOf="@id/scribble_save_confirm_barrier"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
@@ -33,7 +34,7 @@
                 android:id="@+id/scribble_undo_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_undo_32" />
 
@@ -41,7 +42,7 @@
                 android:id="@+id/scribble_delete_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_trash_filled_32" />
 
@@ -49,7 +50,7 @@
                 android:id="@+id/scribble_text_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_text_32" />
                 
@@ -57,7 +58,7 @@
                 android:id="@+id/scribble_draw_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_brush_marker_32" />
 
@@ -65,23 +66,23 @@
                 android:id="@+id/scribble_highlight_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_brush_highlight_32" />
 
             <ImageView
                 android:id="@+id/scribble_blur_button"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:padding="8dp"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:background="@drawable/circle_universal_overlay"
+                android:padding="6dp"
                 android:src="@drawable/ic_blur_on_white_24" />
 
             <ImageView
                 android:id="@+id/scribble_sticker_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_emoji_32" />
 
@@ -89,7 +90,7 @@
                 android:id="@+id/scribble_crop_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_crop_32" />
 
@@ -97,7 +98,7 @@
                 android:id="@+id/scribble_crop_flip"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_flip_32" />
 
@@ -105,7 +106,7 @@
                 android:id="@+id/scribble_crop_rotate"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
+                android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
                 android:src="@drawable/ic_rotate_32" />
 
@@ -123,7 +124,7 @@
             android:id="@+id/scribble_confirm_button"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
+            android:background="@drawable/circle_universal_overlay"
             android:padding="6dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -137,7 +138,7 @@
             android:padding="6dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:background="?attr/selectableItemBackgroundBorderless"/>
+            android:background="@drawable/circle_universal_overlay"/>
 
         <org.thoughtcrime.securesms.scribbles.widget.VerticalSlideColorPicker
             android:id="@+id/scribble_color_picker"

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -51,7 +51,7 @@
     <color name="dummy_avatar_color">#808080</color>
     <color name="slidearrow_color">#999999</color>
 
-    <color name="universal_overlay">#44000000</color>
+    <color name="universal_overlay">#55444444</color>
 
     <color name="trackTintColor">#552090ea</color>
     <color name="trackHighlightTintColor">#ff2090ea</color>


### PR DESCRIPTION
It repeatedly annoyed me that I can't recognize the white edit tools on a bright surface. I now added a black half-opaque circle behind each one.

According to StackOverflow (if I understood correctly), selectableItemBackgroundBorderless is supposed to show some animation when pressing the icon but this seems not to have worked anyway, at least I could not recognize any animation.