### PR TITLE
add missing button to new error-dialog

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -785,6 +785,7 @@ public class ConversationItem extends LinearLayout
         AlertDialog d = new AlertDialog.Builder(context)
                 .setMessage(messageRecord.getError())
                 .setTitle(R.string.error)
+                .setPositiveButton(R.string.ok, null)
                 .create();
         d.show();
         try {


### PR DESCRIPTION
following common ui expectations,
there must always be at least one "ok" button
in a dialog or alert.
there might be good reasons for doing it differently,
however, i do not see any of them here :)

i've overseen that bit when reviewing https://github.com/deltachat/deltachat-android/pull/1751 :)