### PR TITLE
Always release the media player before setting it to null

### DIFF
--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -159,6 +159,7 @@ public class AudioSlidePlayer {
             Log.i(TAG, "onComplete");
             synchronized (AudioSlidePlayer.this) {
               getListener().onReceivedDuration(Long.valueOf(mediaPlayer.getDuration()).intValue());
+              mediaPlayer.release();
               mediaPlayer = null;
             }
 
@@ -172,6 +173,7 @@ public class AudioSlidePlayer {
         Log.w(TAG, "MediaPlayer Error: " + error);
 
         synchronized (AudioSlidePlayer.this) {
+          mediaPlayer.release();
           mediaPlayer = null;
         }
 


### PR DESCRIPTION
I can't tell if it helps, I personally was able to both play a 60min
audio and to play 32 voice messages after each other. Shouldn't hurt to
release them, though.

I tested my change, and at least it seems not to worsen anything.

Fix maybe https://github.com/deltachat/deltachat-android/issues/1755