### PR TITLE
Dark theme / DayNight: Add option to follow system

### DIFF
--- a/res/values-v29/arrays.xml
+++ b/res/values-v29/arrays.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+	<string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
+		<item>@string/pref_system_default</item>
+		<item>@string/pref_light_theme</item>
+		<item>@string/pref_dark_theme</item>
+	</string-array>
+
+	<string-array name="pref_theme_values" translatable="false" tools:ignore="InconsistentArrays">
+		<item>system</item>
+		<item>light</item>
+		<item>dark</item>
+	</string-array>
+
+</resources>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -84,7 +84,8 @@
       <item>te</item>
   </string-array>
 
-    <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
+  <!-- "InconsistentArrays" is needed as the array is duplicated in values-v29/arrays.xml with a different size -->
+  <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
       <item>@string/pref_light_theme</item>
       <item>@string/pref_dark_theme</item>
   </string-array>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
   <!-- take care, language_entries and languages_values are in sync ...
        ... some one has to clean up this mess some day ... -->
@@ -84,12 +84,12 @@
       <item>te</item>
   </string-array>
 
-    <string-array name="pref_theme_entries">
+    <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
       <item>@string/pref_light_theme</item>
       <item>@string/pref_dark_theme</item>
   </string-array>
 
-  <string-array name="pref_theme_values" translatable="false">
+  <string-array name="pref_theme_values" translatable="false" tools:ignore="InconsistentArrays">
       <item>light</item>
       <item>dark</item>
   </string-array>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -457,6 +457,7 @@
     <string name="pref_silent">Silent</string>
     <string name="pref_privacy">Privacy</string>
     <string name="pref_chats_and_media">Chats and media</string>
+    <string name="pref_system_default">System default</string>
     <!-- Translators: "light" in the meaning "opposite of dark" -->
     <string name="pref_light_theme">Light</string>
     <string name="pref_dark_theme">Dark</string>

--- a/res/xml-v29/preferences_appearance.xml
+++ b/res/xml-v29/preferences_appearance.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- when changing this file, consider adapting values/preferences_appearance.xml as well
+ (values/preferences_appearance.xml differs only wrt theme default value) -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <ListPreference

--- a/res/xml-v29/preferences_appearance.xml
+++ b/res/xml-v29/preferences_appearance.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <ListPreference
+            android:key="pref_theme"
+            android:title="@string/pref_theme"
+            android:entries="@array/pref_theme_entries"
+            android:entryValues="@array/pref_theme_values"
+            android:defaultValue="system"/>
+
+    <Preference
+        android:key="pref_chat_background"
+        android:title="@string/pref_background"/>
+
+    <ListPreference
+        android:key="pref_message_body_text_size"
+        android:title="@string/pref_message_text_size"
+        android:entries="@array/pref_message_font_size_entries"
+        android:entryValues="@array/pref_message_font_size_values"
+        android:defaultValue="16"/>
+
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="pref_system_emoji"
+        android:title="@string/pref_use_system_emoji"
+        android:summary="@string/pref_use_system_emoji_explain" />
+
+    <ListPreference
+            android:key="pref_language"
+            android:title="@string/pref_language"
+            android:entries="@array/language_entries"
+            android:entryValues="@array/language_values"
+            android:defaultValue="zz"/>
+
+</PreferenceScreen>

--- a/res/xml/preferences_appearance.xml
+++ b/res/xml/preferences_appearance.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- when changing this file, consider adapting values-v29/preferences_appearance.xml as well
+ (values-v29/preferences_appearance.xml differs only wrt theme default value) -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <ListPreference

--- a/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
@@ -1,16 +1,15 @@
 package org.thoughtcrime.securesms.util;
 
-import android.app.Activity;
+import androidx.annotation.StyleRes;
 
 import org.thoughtcrime.securesms.R;
 
 public class DynamicNoActionBarTheme extends DynamicTheme {
-  @Override
-  protected int getSelectedTheme(Activity activity) {
-    String theme = Prefs.getTheme(activity);
-
-    if (theme.equals("dark")) return R.style.TextSecure_DarkNoActionBar;
-
+  protected @StyleRes int getLightThemeStyle() {
     return R.style.TextSecure_LightNoActionBar;
+  }
+
+  protected @StyleRes int getDarkThemeStyle() {
+    return R.style.TextSecure_DarkNoActionBar;
   }
 }

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -138,7 +138,7 @@ public class Prefs {
   }
 
   public static String getTheme(Context context) {
-    return getStringPreference(context, THEME_PREF, "light");
+    return getStringPreference(context, THEME_PREF, DynamicTheme.systemThemeAvailable() ? DynamicTheme.SYSTEM : DynamicTheme.LIGHT);
   }
 
   public static boolean isScreenLockTimeoutEnabled(Context context) {


### PR DESCRIPTION
fix maybe #1748. Maybe not, because actually I don't understand why issue #1748 even happened because we don't use the system background for the bubble but an own one, `conversation_item_outgoing_bubble_color`, defined in `themes.xml`. They are retrived in `org.thoughtcrime.securesms.ConversationItem#initializeAttributes` (org/thoughtcrime/securesms/ConversationItem.java:263` and set on our own. The standard background color should be white (see conversation_item_sent.xml:50).

Probably the system is somehow trying to forcefully apply a dark mode, no idea how. Maybe it looks for a combination of "background" and "white" and then sets it to dark, similar to [ForceDark](https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#disable-force-dark) (which is opt-in though, and also when I enabled force-dark in the developer options, this worked better than in #1748; esp. there was no black-on-black text). BTW, I also run Android 10 and never had this issue.

So, let's see whether this PR fixes the issue, if not, I'll try again.

Unfortunately, we now have `preferences_appearance.xml` twice. Signal also has it twice but it's way shorter there.
If we don't want this duplication, we have to use `<include>` or set the default programmatically (the problem is that before API29 the default should be `Light` and at API29+ it should be `SystemDefault`