### PR TITLE
Fix disappearing drafts

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -307,6 +307,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     titleView.setTitle(glideRequests, dcChat);
 
     dcContext.notificationCenter.updateVisibleChat(chatId);
+
+    // If the user opens a chat, goes to another app, and shares some content to the same chat, we will have two ConversationActivity's
+    // with the same chat (because sharing uses startActivityForResult() and all activities started this way will be created a second time,
+    // without affecting the existing activity). So, load the draft in case the user modified it in the other activity.
+    // See https://github.com/deltachat/deltachat-android/pull/1770
+    initializeDraft();
   }
 
   @Override


### PR DESCRIPTION
Some people reported that drafts were disappearing, and I found a way to
reproduce it (my interpretation in brackets):
- Open Saved Messages chat, could be any other chat too
- Go to another app and share to DC
- In DC select Saved Messages. Now a draft with the share text is created. Edit the text if you like (but don't put too much effort in it as the draft will vanish :) ). _Don't_ hit the Send button.
  - (as sharing is done using startActivityForResult(), a second
  ConversationActivity is created without affecting the existing one)
- Leave DC. (The second ConversationActivity will correctly save its
draft to the db)
- Open DC again from the "Recent apps". (this is where my fix comes into play) (The first ConversationActivity
will be loaded. It will not know that there is a newer draft and still
show the old draft, or nothing if there was none. When it's closed, it
will overwrite the draft)

I came to this conclusion by logging all writes to the draft in the db.
Also, when I set `REQUEST_RELAY` to -1, `startActivityForResult(intent, -1)` 
will behave the same as `startActivity(intent)`) (but that's not a solution,
sometimes we need startActivityForResult(), see e.g.
https://github.com/deltachat/deltachat-android/pull/1412)

What's still a little weird: I tried replacing all calls to
`startActivityForResult(-intent for ConversationActivity-)` with
startActivity(), and the issue didn't go away. Apparently it's only
enough if all calls are replaced, which is the same as setting
`REQUEST_RELAY` to -1. Maybe it's enough if one activity in the call
chain is called using startActivityForResult().

The call to `initializeDraft()` makes the activity start & resume 2-3ms
slower, which is probably acceptable.

While going back and forth with activities & sharing, I also encountered
some more bugs (without trying to reproduce them), but they are not too
annoying (as opposed to losing your draft) and I'm hesitant to changing
the activity-switching logic too much as it is so easy to just break
things again.