### PR TITLE
add preview-apk workflow

### DIFF
--- a/.github/workflows/preview-apk.yml
+++ b/.github/workflows/preview-apk.yml
@@ -1,0 +1,48 @@
+name: Upload Preview APK
+
+on: pull_request
+
+jobs:
+  build:
+    name: Upload Preview APK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: textbook/git-checkout-submodule-action@master
+      - run: cp jni/deltachat-core-rust/rust-toolchain .
+      - uses: actions-rs/toolchain@v1
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: jni/deltachat-core-rust
+      - uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - uses: android-actions/setup-android@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21d
+
+      - name: Compile core
+        env:
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          export PATH="${PATH}:${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/:${ANDROID_NDK_ROOT}"
+          ./scripts/install-toolchains.sh && ./ndk-make.sh armeabi-v7a
+
+      - name: Build APK
+        run: ./gradlew --no-daemon assembleGplayDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: app.apk
+          path: 'build/outputs/apk/gplay/debug/*.apk'


### PR DESCRIPTION
generate APK previews for pull request testing (for faster generation, only architecture armeabi-v7a is compiled, change it before merging, if not convenient)

## How to download the generated debug APK preview?

once the action ends to run, click in details:
![action-details](https://user-images.githubusercontent.com/24558636/105546780-ce0ce480-5ccb-11eb-8d6c-c191b9630fc9.png)

then click the artifacts drop-down menu and select the APK file:
![artifacts](https://user-images.githubusercontent.com/24558636/105547466-88045080-5ccc-11eb-9c96-3932d160e777.png)
