### PR TITLE
message-html-view: harden settings, add pinch-to-zoom

### DIFF
--- a/src/org/thoughtcrime/securesms/FullMsgActivity.java
+++ b/src/org/thoughtcrime/securesms/FullMsgActivity.java
@@ -37,6 +37,11 @@ public class FullMsgActivity extends WebViewActivity
     loadRemoteContent = Prefs.getAlwaysLoadRemoteContent(this);
     webView.getSettings().setBlockNetworkLoads(!loadRemoteContent);
 
+    // setBuiltInZoomControls() adds pinch-to-zoom as well as two ugly buttons;
+    // the latter are hidden with setDisplayZoomControls() again.
+    webView.getSettings().setBuiltInZoomControls(true);
+    webView.getSettings().setDisplayZoomControls(false);
+
     getSupportActionBar().setTitle(getString(R.string.chat_input_placeholder));
 
     dcContext = DcHelper.getContext(this);

--- a/src/org/thoughtcrime/securesms/FullMsgActivity.java
+++ b/src/org/thoughtcrime/securesms/FullMsgActivity.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.webkit.WebSettings;
 
 import androidx.appcompat.app.AlertDialog;
 
@@ -37,10 +38,22 @@ public class FullMsgActivity extends WebViewActivity
     loadRemoteContent = Prefs.getAlwaysLoadRemoteContent(this);
     webView.getSettings().setBlockNetworkLoads(!loadRemoteContent);
 
-    // setBuiltInZoomControls() adds pinch-to-zoom as well as two ugly buttons;
-    // the latter are hidden with setDisplayZoomControls() again.
+    // setBuiltInZoomControls() adds pinch-to-zoom as well as two on-screen zoom control buttons.
+    // The latter are a bit annoying, however, they are deprecated anyway,
+    // and also Android docs recommend to disable them with setDisplayZoomControls().
     webView.getSettings().setBuiltInZoomControls(true);
     webView.getSettings().setDisplayZoomControls(false);
+
+    // disable useless and unwanted features:
+    // - JavaScript and Plugins are disabled by default, however,
+    //   doing it explicitly here protects against changed base classes or bugs
+    // - Content- and File-access is enabled by default and disabled here
+    // - the other setAllow*() functions are related to enabled JavaScript only
+    // - "safe browsing" comes with privacy issues and already disabled in the base class
+    webView.getSettings().setJavaScriptEnabled(false);
+    webView.getSettings().setPluginState(WebSettings.PluginState.OFF);
+    webView.getSettings().setAllowContentAccess(false);
+    webView.getSettings().setAllowFileAccess(false);
 
     getSupportActionBar().setTitle(getString(R.string.chat_input_placeholder));
 


### PR DESCRIPTION
this pr adds pinch-to-zoom to the message-html-view and hardens the settings.

i've read through the settings at https://developer.android.com/reference/android/webkit/WebView and https://developer.android.com/reference/android/webkit/WebSettings and https://wiki.sei.cmu.edu/confluence/display/android/DRD02-J.+Do+not+allow+WebView+to+access+sensitive+local+resource+through+file+scheme

successor of #1763 