### PR TITLE
Replace 4 weeks option with 5 weeks option

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -138,7 +138,7 @@
         <!-- 4 --> <item>@string/autodel_after_1_hour</item>
         <!-- 5 --> <item>@string/autodel_after_1_day</item>
         <!-- 6 --> <item>@string/autodel_after_1_week</item>
-        <!-- 7 --> <item>@string/autodel_after_4_weeks</item>
+        <!-- 7 --> <item>@string/after_5_weeks</item>
     </string-array>
 
     <string-array name="mute_durations">
@@ -154,7 +154,7 @@
       <item>@string/autodel_after_1_hour</item>
       <item>@string/autodel_after_1_day</item>
       <item>@string/autodel_after_1_week</item>
-      <item>@string/autodel_after_4_weeks</item>
+      <item>@string/after_5_weeks</item>
       <item>@string/autodel_after_1_year</item>
   </string-array>
 
@@ -163,7 +163,7 @@
       <item>3600</item>
       <item>86400</item>
       <item>604800</item>
-      <item>2419200</item>
+      <item>3024000</item>
       <item>31536000</item>
   </string-array>
 
@@ -173,7 +173,7 @@
       <item>@string/autodel_after_1_hour</item>
       <item>@string/autodel_after_1_day</item>
       <item>@string/autodel_after_1_week</item>
-      <item>@string/autodel_after_4_weeks</item>
+      <item>@string/after_5_weeks</item>
       <item>@string/autodel_after_1_year</item>
   </string-array>
 
@@ -183,7 +183,7 @@
       <item>3600</item>
       <item>86400</item>
       <item>604800</item>
-      <item>2419200</item>
+      <item>3024000</item>
       <item>31536000</item>
   </string-array>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -563,7 +563,7 @@
     <string name="autodel_after_1_hour">After 1 hour</string>
     <string name="autodel_after_1_day">After 1 day</string>
     <string name="autodel_after_1_week">After 1 week</string>
-    <string name="autodel_after_4_weeks">After 4 weeks</string>
+    <string name="after_5_weeks">After 5 weeks</string>
     <string name="autodel_after_1_year">After 1 year</string>
 
     <!-- autocrypt -->

--- a/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
+++ b/src/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
@@ -66,7 +66,7 @@ public class EphemeralMessagesDialog {
                         case 4:  burnAfter = TimeUnit.HOURS.toSeconds(1); break;
                         case 5:  burnAfter = TimeUnit.DAYS.toSeconds(1);  break;
                         case 6:  burnAfter = TimeUnit.DAYS.toSeconds(7);  break;
-                        case 7:  burnAfter = TimeUnit.DAYS.toSeconds(28); break;
+                        case 7:  burnAfter = TimeUnit.DAYS.toSeconds(35); break;
                         default: burnAfter = 0; break;
                     }
                     listener.onTimeSelected(burnAfter);
@@ -99,10 +99,10 @@ public class EphemeralMessagesDialog {
         if (timespan < TimeUnit.DAYS.toSeconds(7)) {
             return 5; // 1 day
         }
-        if (timespan < TimeUnit.DAYS.toSeconds(28)) {
+        if (timespan < TimeUnit.DAYS.toSeconds(35)) {
             return 6; // 1 week
         }
-        return 7; // 4 weeks
+        return 7; // 5 weeks
     }
 
 }


### PR DESCRIPTION
While 4 weeks always fits in a month,
5 weeks (35 days) always covers at least a month,
so it can be used in a situation where messages are required to
be stored for a month.