### PR TITLE
show name of forwarder in groups

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="audio">Audio</string>
     <string name="voice_message">Voice message</string>
     <string name="forwarded_message">Forwarded message</string>
+    <string name="forwarded_by">Forwarded by %1$s</string>
     <string name="video">Video</string>
     <string name="documents">Documents</string>
     <string name="contact">Contact</string>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -654,12 +654,15 @@ public class ConversationItem extends LinearLayout
 
   private void setGroupMessageStatus() {
     if (messageRecord.isForwarded()) {
-      this.groupSender.setText(context.getString(R.string.forwarded_message));
+      if (groupThread && !messageRecord.isOutgoing() && dcContact !=null) {
+        this.groupSender.setText(context.getString(R.string.forwarded_by, messageRecord.getSenderName(dcContact)));
+      } else {
+        this.groupSender.setText(context.getString(R.string.forwarded_message));
+      }
       this.groupSender.setTextColor(context.getResources().getColor(R.color.unknown_sender));
     }
     else if (groupThread && !messageRecord.isOutgoing() && dcContact !=null) {
       this.groupSender.setText(messageRecord.getSenderName(dcContact));
-
       this.groupSender.setTextColor(dcContact.getArgbColor());
     }
   }

--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -143,8 +143,13 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
       authorView.setVisibility(GONE);
       quoteBarView.setBackgroundColor(getForwardedColor());
     } else if (quotedMsg.isForwarded()) {
+      DcContact contact = author.getDcContact();
       authorView.setVisibility(VISIBLE);
-      authorView.setText(getContext().getString(R.string.forwarded_message));
+      if (contact == null) {
+        authorView.setText(getContext().getString(R.string.forwarded_message));
+      } else {
+        authorView.setText(getContext().getString(R.string.forwarded_by, quotedMsg.getSenderName(contact)));
+      }
       authorView.setTextColor(getForwardedColor());
       quoteBarView.setBackgroundColor(getForwardedColor());
     } else {


### PR DESCRIPTION
recent discussions with @adbenitez @flub @Simon-Laux and other on DC, this was also one of the suggestions of @Simon-Laux at https://github.com/deltachat/deltachat-desktop/issues/1977 : 

<img width=320  src=https://user-images.githubusercontent.com/9800740/107160065-3f1eee00-6994-11eb-97c7-7937bdcf2b3b.png>
