### PR TITLE
Show status

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1547,6 +1547,15 @@ JNIEXPORT jint Java_com_b44t_messenger_DcContact_getColor(JNIEnv *env, jobject o
 }
 
 
+JNIEXPORT jstring Java_com_b44t_messenger_DcContact_getStatus(JNIEnv *env, jobject obj)
+{
+    char* temp = dc_contact_get_status(get_dc_contact(env, obj));
+        jstring ret = JSTRING_NEW(temp);
+    dc_str_unref(temp);
+    return ret;
+}
+
+
 JNIEXPORT jboolean Java_com_b44t_messenger_DcContact_isBlocked(JNIEnv *env, jobject obj)
 {
     return (jboolean)(dc_contact_is_blocked(get_dc_contact(env, obj))!=0);

--- a/res/layout/profile_status_item.xml
+++ b/res/layout/profile_status_item.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.thoughtcrime.securesms.ProfileStatusItem
+             xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content"
+             android:background="?attr/conversation_list_item_background"
+             android:focusable="true"
+             android:padding="16dp">
+
+    <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+              android:id="@+id/status_text"
+              android:layout_width="fill_parent"
+              android:layout_height="wrap_content"
+              android:gravity="start|center_vertical"
+              style="@style/Signal.Text.Body"
+              android:textColor="?attr/emoji_text_color"/>
+
+</org.thoughtcrime.securesms.ProfileStatusItem>

--- a/res/layout/profile_status_item.xml
+++ b/res/layout/profile_status_item.xml
@@ -3,7 +3,6 @@
              xmlns:android="http://schemas.android.com/apk/res/android"
              android:layout_width="match_parent"
              android:layout_height="wrap_content"
-             android:background="?attr/conversation_list_item_background"
              android:focusable="true"
              android:padding="16dp">
 

--- a/res/menu/profile_common.xml
+++ b/res/menu/profile_common.xml
@@ -6,6 +6,10 @@
           android:id="@+id/edit_name"
           app:showAsAction="never"/>
 
+    <item android:title="@string/menu_copy_to_clipboard"
+        android:id="@+id/copy_addr_to_clipboard"
+        app:showAsAction="never"/>
+
     <item android:title="@string/menu_mute"
         android:id="@+id/menu_mute_notifications"
         app:showAsAction="never"/>

--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -51,6 +51,7 @@ public class DcContact {
     public native String  getNameNAddr   ();
     public native String  getProfileImage();
     public native int     getColor       ();
+    public native String  getStatus      ();
     public native boolean isBlocked      ();
     public native boolean isVerified     ();
 

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -118,7 +118,8 @@ public class ConversationTitleView extends RelativeLayout {
     avatar.setAvatar(glideRequests, DcHelper.getContext(getContext()).getRecipient(contact), false);
     title.setText(contact.getDisplayName());
     title.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
-    subtitle.setVisibility(View.GONE);
+    subtitle.setText(contact.getAddr());
+    subtitle.setVisibility(View.VISIBLE);
   }
 
   public void hideAvatar() {

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -18,7 +18,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
@@ -251,7 +250,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   }
 
   private boolean isContactProfile() {
-    // there may still be a single-chat lined to the contact profile
+    // contact-profiles are profiles without a chat or with a one-to-one chat
     return contactId!=0 && (chatId==0 || !chatIsGroup);
   }
 
@@ -307,7 +306,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       switch(tabId) {
         case TAB_SETTINGS:
           if(isContactProfile()) {
-            return getString(contactId==DcContact.DC_CONTACT_ID_SELF? R.string.self : R.string.tab_contact);
+            return getString(R.string.tab_contact);
           }
           else if (chatIsMailingList) {
             return getString(R.string.mailing_list);
@@ -369,7 +368,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     return false;
   }
 
-  public void onNotifyOnOff() {
+  private void onNotifyOnOff() {
     if (Prefs.isChatMuted(dcContext.getChat(chatId))) {
       setMuted(0);
     }
@@ -384,7 +383,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  public void onSoundSettings() {
+  private void onSoundSettings() {
     Uri current = Prefs.getChatRingtone(this, chatId);
     Uri defaultUri = Prefs.getNotificationRingtone(this);
 
@@ -401,7 +400,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     startActivityForResult(intent, REQUEST_CODE_PICK_RINGTONE);
   }
 
-  public void onVibrateSettings() {
+  private void onVibrateSettings() {
     int checkedItem = Prefs.getChatVibrate(this, chatId).getId();
     int[] selectedChoice = new int[]{checkedItem};
     new AlertDialog.Builder(this)
@@ -414,7 +413,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
             .show();
   }
 
-  public void onEnlargeAvatar() {
+  private void onEnlargeAvatar() {
     String profileImagePath;
     String title;
     Uri profileImageUri;
@@ -441,7 +440,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     startActivity(intent);
   }
 
-  public void onEditName() {
+  private void onEditName() {
     if (chatIsGroup) {
       Intent intent = new Intent(this, GroupCreateActivity.class);
       intent.putExtra(GroupCreateActivity.EDIT_GROUP_CHAT_ID, chatId);
@@ -468,7 +467,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  public void onEncrInfo() {
+  private void onEncrInfo() {
     String info_str = isContactProfile() ?
       dcContext.getContactEncrInfo(contactId) : dcContext.getChatEncrInfo(chatId);
     new AlertDialog.Builder(this)
@@ -477,7 +476,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
         .show();
   }
 
-  public void onBlockContact() {
+  private void onBlockContact() {
     DcContact dcContact = dcContext.getContact(contactId);
     if(dcContact.isBlocked()) {
       new AlertDialog.Builder(this)

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -21,6 +21,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
@@ -34,6 +35,7 @@ import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.Prefs;
+import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 import java.io.File;
@@ -128,8 +130,10 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
         if (chatIsDeviceTalk) {
           menu.findItem(R.id.edit_name).setVisible(false);
           menu.findItem(R.id.show_encr_info).setVisible(false);
+          menu.findItem(R.id.copy_addr_to_clipboard).setVisible(false);
         } else if (chatIsGroup) {
           menu.findItem(R.id.edit_name).setTitle(R.string.menu_group_name_and_image);
+          menu.findItem(R.id.copy_addr_to_clipboard).setVisible(false);
         }
       } else {
         menu.findItem(R.id.menu_mute_notifications).setVisible(false);
@@ -238,7 +242,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     }
     else if (chatId > 0) {
       DcChat dcChat  = dcContext.getChat(chatId);
-      titleView.setTitle(GlideApp.with(this), dcChat, false);
+      titleView.setTitle(GlideApp.with(this), dcChat, isContactProfile());
     }
     else if (isContactProfile()){
       titleView.setTitle(GlideApp.with(this), dcContext.getContact(contactId));
@@ -357,6 +361,9 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       case R.id.edit_name:
         onEditName();
         break;
+      case R.id.copy_addr_to_clipboard:
+        onCopyAddrToClipboard();
+        break;
       case R.id.show_encr_info:
         onEncrInfo();
         break;
@@ -465,6 +472,12 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
           .setNegativeButton(android.R.string.cancel, null)
           .show();
     }
+  }
+
+  private void onCopyAddrToClipboard() {
+    DcContact dcContact = dcContext.getContact(contactId);
+    Util.writeTextToClipboard(this, dcContact.getAddr());
+    Toast.makeText(this, getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT).show();
   }
 
   private void onEncrInfo() {

--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -33,15 +33,6 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
 {
   public static final int SETTING_CONTACT_ADDR = 110;
   public static final int SETTING_NEW_CHAT = 120;
-  public static final int SETTING_CONTACT_NAME = 130;
-  public static final int SETTING_ENCRYPTION = 140;
-  public static final int SETTING_BLOCK_CONTACT = 150;
-
-  public static final int SETTING_GROUP_NAME_N_IMAGE = 210;
-
-  public static final int SETTING_NOTIFY = 310;
-  public static final int SETTING_SOUND = 320;
-  public static final int SETTING_VIBRATE = 330;
 
   private final @NonNull Context              context;
   private final @NonNull Locale               locale;
@@ -62,7 +53,6 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
     static final int TYPE_PRIMARY_SETTING = 1;
     static final int TYPE_MEMBER = 2;
     static final int TYPE_SHARED_CHAT = 3;
-    static final int TYPE_SECONDARY_SETTING = 4;
     int type;
     int contactId;
     int chatlistIndex;
@@ -279,13 +269,10 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
       for (int value : memberList) {
         itemData.add(new ItemData(ItemData.TYPE_MEMBER, value, 0));
       }
-//      itemData.add(new ItemData(ItemData.TYPE_SECONDARY_SETTING, SETTING_GROUP_NAME_N_IMAGE, context.getString(R.string.menu_group_name_and_image)));
     }
     else if (sharedChats!=null && dcContact!=null) {
       itemDataContact = dcContact;
       itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_CONTACT_ADDR,dcContact.getAddr()));
-//      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_CONTACT_NAME, context.getString(R.string.menu_edit_name)));
-//      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_ENCRYPTION, context.getString(R.string.profile_encryption)));
       itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_CHAT, context.getString(R.string.send_message)));
       itemDataSharedChats = sharedChats;
       int sharedChatsCnt = sharedChats.getCnt();
@@ -293,18 +280,6 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
         itemData.add(new ItemData(ItemData.TYPE_SHARED_CHAT, 0, i));
       }
     }
-
-//    if(dcChat!=null) {
-//      itemData.add(new ItemData(ItemData.TYPE_SECONDARY_SETTING, SETTING_NOTIFY,
-//          context.getString(Prefs.isChatMuted(context, dcChat.getId())? R.string.menu_unmute : R.string.menu_mute)));
-//      itemData.add(new ItemData(ItemData.TYPE_SECONDARY_SETTING, SETTING_SOUND, context.getString(R.string.pref_sound)));
-//      itemData.add(new ItemData(ItemData.TYPE_SECONDARY_SETTING, SETTING_VIBRATE, context.getString(R.string.pref_vibrate)));
-//    }
-
-//    if (dcContact!=null) {
-//      itemData.add(new ItemData(ItemData.TYPE_SECONDARY_SETTING, SETTING_BLOCK_CONTACT,
-//          context.getString(dcContact.isBlocked()? R.string.menu_unblock_contact : R.string.menu_block_contact)));
-//    }
 
     notifyDataSetChanged();
   }

--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -31,7 +31,6 @@ import java.util.Set;
 public class ProfileSettingsAdapter extends RecyclerView.Adapter
                                     implements StickyHeaderAdapter<ProfileSettingsAdapter.HeaderViewHolder>
 {
-  public static final int SETTING_CONTACT_ADDR = 110;
   public static final int SETTING_NEW_CHAT = 120;
 
   private final @NonNull Context              context;
@@ -272,7 +271,6 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
     }
     else if (sharedChats!=null && dcContact!=null) {
       itemDataContact = dcContact;
-      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_CONTACT_ADDR,dcContact.getAddr()));
       itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_CHAT, context.getString(R.string.send_message)));
       itemDataSharedChats = sharedChats;
       int sharedChatsCnt = sharedChats.getCnt();

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
@@ -142,6 +143,22 @@ public class ProfileSettingsFragment extends Fragment
         onNewChat();
         break;
     }
+  }
+
+  @Override
+  public void onStatusLongClicked() {
+      Context context = getContext();
+      new AlertDialog.Builder(context)
+        .setTitle(R.string.pref_default_status_label)
+        .setItems(new CharSequence[]{
+            context.getString(R.string.menu_copy_to_clipboard)
+          },
+          (dialogInterface, i) -> {
+            Util.writeTextToClipboard(context, adapter.getStatusText());
+            Toast.makeText(context, context.getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT).show();
+          })
+        .setNegativeButton(R.string.cancel, null)
+        .show();
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -144,24 +144,6 @@ public class ProfileSettingsFragment extends Fragment
       case ProfileSettingsAdapter.SETTING_NEW_CHAT:
         onNewChat();
         break;
-      case ProfileSettingsAdapter.SETTING_CONTACT_NAME:
-        ((ProfileActivity)getActivity()).onEditName();
-        break;
-      case ProfileSettingsAdapter.SETTING_ENCRYPTION:
-        ((ProfileActivity)getActivity()).onEncrInfo();
-        break;
-      case ProfileSettingsAdapter.SETTING_BLOCK_CONTACT:
-        ((ProfileActivity)getActivity()).onBlockContact();
-        break;
-      case ProfileSettingsAdapter.SETTING_NOTIFY:
-        ((ProfileActivity)getActivity()).onNotifyOnOff();
-        break;
-      case ProfileSettingsAdapter.SETTING_SOUND:
-        ((ProfileActivity)getActivity()).onSoundSettings();
-        break;
-      case ProfileSettingsAdapter.SETTING_VIBRATE:
-        ((ProfileActivity)getActivity()).onVibrateSettings();
-        break;
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -138,9 +138,6 @@ public class ProfileSettingsFragment extends Fragment
   @Override
   public void onSettingsClicked(int settingsId) {
     switch(settingsId) {
-      case ProfileSettingsAdapter.SETTING_CONTACT_ADDR:
-        onContactAddrClicked();
-        break;
       case ProfileSettingsAdapter.SETTING_NEW_CHAT:
         onNewChat();
         break;
@@ -210,21 +207,6 @@ public class ProfileSettingsFragment extends Fragment
     intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
     getContext().startActivity(intent);
     getActivity().finish();
-  }
-
-  private void onContactAddrClicked() {
-    String address = dcContext.getContact(contactId).getAddr();
-    new AlertDialog.Builder(getContext())
-        .setTitle(address)
-        .setItems(new CharSequence[]{
-                getContext().getString(R.string.menu_copy_to_clipboard)
-            },
-            (dialogInterface, i) -> {
-              Util.writeTextToClipboard(getContext(), address);
-              Toast.makeText(getContext(), getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT).show();
-            })
-        .setNegativeButton(R.string.cancel, null)
-        .show();
   }
 
   private void onNewChat() {

--- a/src/org/thoughtcrime/securesms/ProfileStatusItem.java
+++ b/src/org/thoughtcrime/securesms/ProfileStatusItem.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms;
 import android.content.Context;
 import android.text.SpannableString;
 import android.util.AttributeSet;
+import android.view.View;
 import android.widget.LinearLayout;
 
 import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
@@ -11,6 +12,7 @@ import org.thoughtcrime.securesms.util.LongClickMovementMethod;
 public class ProfileStatusItem extends LinearLayout {
 
   private EmojiTextView statusTextView;
+  private final PassthroughClickListener passthroughClickListener   = new PassthroughClickListener();
 
   public ProfileStatusItem(Context context) {
     super(context);
@@ -24,10 +26,29 @@ public class ProfileStatusItem extends LinearLayout {
   protected void onFinishInflate() {
     super.onFinishInflate();
     statusTextView = findViewById(R.id.status_text);
+    statusTextView.setOnLongClickListener(passthroughClickListener);
+    statusTextView.setOnClickListener(passthroughClickListener);
+    statusTextView.setMovementMethod(LongClickMovementMethod.getInstance(getContext()));
   }
 
   public void set(String status) {
     statusTextView.setText(EmojiTextView.linkify(new SpannableString(status)));
-    statusTextView.setMovementMethod(LongClickMovementMethod.getInstance(getContext()));
+  }
+
+  private class PassthroughClickListener implements View.OnLongClickListener, View.OnClickListener {
+
+    @Override
+    public boolean onLongClick(View v) {
+      if (statusTextView.hasSelection()) {
+        return false;
+      }
+      performLongClick();
+      return true;
+    }
+
+    @Override
+    public void onClick(View v) {
+      performClick();
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/ProfileStatusItem.java
+++ b/src/org/thoughtcrime/securesms/ProfileStatusItem.java
@@ -1,0 +1,30 @@
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.LinearLayout;
+
+import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
+
+public class ProfileStatusItem extends LinearLayout {
+
+  private EmojiTextView statusTextView;
+
+  public ProfileStatusItem(Context context) {
+    super(context);
+  }
+
+  public ProfileStatusItem(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  @Override
+  protected void onFinishInflate() {
+    super.onFinishInflate();
+    statusTextView = findViewById(R.id.status_text);
+  }
+
+  public void set(String status) {
+    statusTextView.setText(status==null? "" : status);
+  }
+}

--- a/src/org/thoughtcrime/securesms/ProfileStatusItem.java
+++ b/src/org/thoughtcrime/securesms/ProfileStatusItem.java
@@ -6,6 +6,7 @@ import android.util.AttributeSet;
 import android.widget.LinearLayout;
 
 import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
+import org.thoughtcrime.securesms.util.LongClickMovementMethod;
 
 public class ProfileStatusItem extends LinearLayout {
 
@@ -27,5 +28,6 @@ public class ProfileStatusItem extends LinearLayout {
 
   public void set(String status) {
     statusTextView.setText(EmojiTextView.linkify(new SpannableString(status)));
+    statusTextView.setMovementMethod(LongClickMovementMethod.getInstance(getContext()));
   }
 }

--- a/src/org/thoughtcrime/securesms/ProfileStatusItem.java
+++ b/src/org/thoughtcrime/securesms/ProfileStatusItem.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms;
 
 import android.content.Context;
+import android.text.SpannableString;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 
@@ -25,6 +26,6 @@ public class ProfileStatusItem extends LinearLayout {
   }
 
   public void set(String status) {
-    statusTextView.setText(status==null? "" : status);
+    statusTextView.setText(EmojiTextView.linkify(new SpannableString(status)));
   }
 }

--- a/src/org/thoughtcrime/securesms/util/LongClickCopySpan.java
+++ b/src/org/thoughtcrime/securesms/util/LongClickCopySpan.java
@@ -28,11 +28,9 @@ public class LongClickCopySpan extends ClickableSpan {
   @ColorInt
   private int highlightColor;
   private final String url;
-  private int chatId;
 
-  public LongClickCopySpan(String url, int chatId) {
+  public LongClickCopySpan(String url) {
     this.url = url;
-    this.chatId = chatId;
   }
 
   private void openChat(Activity activity, DcContact contact) {


### PR DESCRIPTION
this is how it looks like:

<img width=320 src=https://user-images.githubusercontent.com/9800740/110316918-b1bed000-800b-11eb-92fc-72f2445f2ce4.png>

pretty neutral, with title (same as in the profile), i think, that should not raise many questions.

on protocol-level, the text comes in the email footer/signature, it can be defined in Delta Chat as "Signature text" in the profile and it can also be defined in nearly all other mua.

some words to the layout changes: the e-mail address went to the header (where it is also displayed in similar layouts); the 'send message' button is atop for simplicity if the footer/status becomes longer (when opening contact-profiles from group-members, this button should always be at the same position and should be easily reachable)

to the wording: as we are not using the wording "status" in the shipped apps and the predefined text is indeed more a footer/signature, i would not say "status" for now.

Todo:
- [x] some cleanup in profile code
- [x] add ffi
- [x] show basic signature
- [x] make text copyable
- [x] linkify
- [x] figure out how to make the subview clickable

closes #1804 


<details><summary>previous layouts</summary>
<img width=320 src=https://user-images.githubusercontent.com/9800740/110258470-109c2f00-7fa3-11eb-9069-40692f299d2d.png>

_while that is a bit more shiny, the new yellow color introduces a new thing to explain. also, a title is missing. so, i'd say, using a more unagitated layout is better for now, also as this thing is currently a mix of status/signature/classic-footer ..._
</details>