### PR TITLE
mark overridden names by a "~" in the bubbles

### DIFF
--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -131,10 +131,10 @@ public class DcMsg {
     public native String  getError           ();
     private native @Nullable String getOverrideSenderName();
 
-    public @NonNull String getSenderName(@NonNull DcContact dcContact) {
+    public @NonNull String getSenderName(@NonNull DcContact dcContact, boolean markOverride) {
         String overrideName = getOverrideSenderName();
         if (overrideName != null) {
-            return overrideName;
+            return (markOverride ? "~" : "") + overrideName;
         } else {
             return dcContact.getDisplayName();
         }

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -428,7 +428,7 @@ public class ConversationFragment extends Fragment
 
             if (msg.getFromId() != prevMsg.getFromId() && !singleMsg) {
                 DcContact contact = dcContext.getContact(msg.getFromId());
-                result.append(msg.getSenderName(contact)).append(":\n");
+                result.append(msg.getSenderName(contact, false)).append(":\n");
             }
             if (msg.getType() == DcMsg.DC_MSG_TEXT || (singleMsg && !msg.getText().isEmpty())) {
                 result.append(msg.getText());

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -655,14 +655,14 @@ public class ConversationItem extends LinearLayout
   private void setGroupMessageStatus() {
     if (messageRecord.isForwarded()) {
       if (groupThread && !messageRecord.isOutgoing() && dcContact !=null) {
-        this.groupSender.setText(context.getString(R.string.forwarded_by, messageRecord.getSenderName(dcContact)));
+        this.groupSender.setText(context.getString(R.string.forwarded_by, messageRecord.getSenderName(dcContact, false)));
       } else {
         this.groupSender.setText(context.getString(R.string.forwarded_message));
       }
       this.groupSender.setTextColor(context.getResources().getColor(R.color.unknown_sender));
     }
     else if (groupThread && !messageRecord.isOutgoing() && dcContact !=null) {
-      this.groupSender.setText(messageRecord.getSenderName(dcContact));
+      this.groupSender.setText(messageRecord.getSenderName(dcContact, true));
       this.groupSender.setTextColor(dcContact.getArgbColor());
     }
   }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -490,7 +490,7 @@ public class ConversationListFragment extends Fragment
         answerBlock = context.getString(R.string.block);
       } else {
         DcContact dcContact = dcContext.getContact(dcMsg.getFromId());
-        question = context.getString(R.string.ask_start_chat_with, dcMsg.getSenderName(dcContact));
+        question = context.getString(R.string.ask_start_chat_with, dcMsg.getSenderName(dcContact, false));
         answerBlock = context.getString(R.string.menu_block_contact);
       }
     }

--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -148,7 +148,7 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
       if (contact == null) {
         authorView.setText(getContext().getString(R.string.forwarded_message));
       } else {
-        authorView.setText(getContext().getString(R.string.forwarded_by, quotedMsg.getSenderName(contact)));
+        authorView.setText(getContext().getString(R.string.forwarded_by, quotedMsg.getSenderName(contact, false)));
       }
       authorView.setTextColor(getForwardedColor());
       quoteBarView.setBackgroundColor(getForwardedColor());
@@ -159,7 +159,7 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
         quoteBarView.setBackgroundColor(getForwardedColor());
       } else {
         authorView.setVisibility(VISIBLE);
-        authorView.setText(quotedMsg.getSenderName(contact));
+        authorView.setText(quotedMsg.getSenderName(contact, false));
         authorView.setTextColor(contact.getArgbColor());
         quoteBarView.setBackgroundColor(contact.getArgbColor());
       }

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -331,7 +331,7 @@ public class NotificationCenter {
             DcMsg dcMsg = dcContext.getMsg(msgId);
             String line = privacy.isDisplayMessage()? dcMsg.getSummarytext(2000) : context.getString(R.string.notify_new_message);
             if (dcChat.isGroup() && privacy.isDisplayContact()) {
-                line = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId())) + ": " + line;
+                line = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId()), false) + ": " + line;
             }
 
             // play signal?
@@ -368,7 +368,7 @@ public class NotificationCenter {
             // prepend the sender in the ticker also for one-to-one chats (for group-chats, this is already done)
             String tickerLine = line;
             if (!dcChat.isGroup() && privacy.isDisplayContact()) {
-                line = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId())) + ": " + line;
+                line = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId()), false) + ": " + line;
             }
             builder.setTicker(tickerLine);
 


### PR DESCRIPTION
this is just a very simple approach to move forward.

to mark overridden names, a "~" is prefixed.

<img width=300 src=https://user-images.githubusercontent.com/9800740/107889444-ea8aee00-6f12-11eb-8eeb-88a7d2413862.png>

the idea with using a dedicated color for these names:
as we do not really know
if the address is a generic sender address or belongs to the user,
it makes sense to keep the color used for the name and do not use a
dedicated grey or so.

i think, it is not even worth to detect that better:
it is pretty nice to have senders in mailinglist marked nicely,
all the time.

currently, the "~" is only added to the bubbles - it is not there
in the chatlist-summary (that would needed to be done in core)
and also not in forwarded by, notifications, clipboard etc. i'd say currently,
this is not needed, however, with the current approach it would be doable
(if we mark possible impersonation by colors or icons that may be
much more complicated)

adaption on other uis would also be pretty simple with this approach,
and imho, this `~Max Mustermann` looks pretty nicely
and even intuitive in a way.

drawback of the approach is that user may user `~`
as the first character of their names, we could target that by
adapting dc_msg_get_displayname() in the core, if we want to keep this approach,
however, maybe it is also not worth, the "~" is more a flaw than a feature,
also that would result to "~~Name" in the bubbles.
i do not see how that can be used to trick users when beeing added.
names as "foo 🔒" might be more dangerous here, when it comes to trick users.