### PR TITLE
implement sticker visualization

### DIFF
--- a/res/drawable/sticker_missing_background.xml
+++ b/res/drawable/sticker_missing_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="8dp" />
+    <solid android:color="@color/universal_overlay" />
+
+</shape>

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -119,6 +119,12 @@
                 android:layout="@layout/conversation_item_received_thumbnail" />
 
             <ViewStub
+		android:id="@+id/sticker_view_stub"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout="@layout/conversation_item_received_sticker" />
+
+            <ViewStub
                 android:id="@+id/audio_view_stub"
                 android:layout="@layout/conversation_item_received_audio"
                 android:layout_width="210dp"
@@ -182,6 +188,19 @@
                 android:clipToPadding="false"
                 android:alpha="0.7"
                 app:footer_text_color="?conversation_item_incoming_text_secondary_color"/>
+
+        <org.thoughtcrime.securesms.components.ConversationItemFooter
+            android:id="@+id/conversation_item_sticker_footer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/message_bubble_horizontal_padding"
+            android:layout_marginRight="@dimen/message_bubble_horizontal_padding"
+            android:layout_marginBottom="@dimen/message_bubble_bottom_padding"
+            android:layout_gravity="end"
+            android:gravity="end"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            app:footer_text_color="@color/gray50"/>
 
         </LinearLayout>
 

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -189,18 +189,18 @@
                 android:alpha="0.7"
                 app:footer_text_color="?conversation_item_incoming_text_secondary_color"/>
 
-        <org.thoughtcrime.securesms.components.ConversationItemFooter
-            android:id="@+id/conversation_item_sticker_footer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/message_bubble_horizontal_padding"
-            android:layout_marginRight="@dimen/message_bubble_horizontal_padding"
-            android:layout_marginBottom="@dimen/message_bubble_bottom_padding"
-            android:layout_gravity="end"
-            android:gravity="end"
-            android:clipChildren="false"
-            android:clipToPadding="false"
-            app:footer_text_color="@color/gray50"/>
+            <org.thoughtcrime.securesms.components.ConversationItemFooter
+		android:id="@+id/conversation_item_sticker_footer"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_marginLeft="@dimen/message_bubble_horizontal_padding"
+		android:layout_marginRight="@dimen/message_bubble_horizontal_padding"
+		android:layout_marginBottom="@dimen/message_bubble_bottom_padding"
+		android:layout_gravity="end"
+		android:gravity="end"
+		android:clipChildren="false"
+		android:clipToPadding="false"
+		app:footer_text_color="@color/gray50"/>
 
         </LinearLayout>
 

--- a/res/layout/conversation_item_received_sticker.xml
+++ b/res/layout/conversation_item_received_sticker.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.thoughtcrime.securesms.components.BorderlessImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/image_view"
+    android:layout_width="@dimen/media_bubble_sticker_dimens"
+    android:layout_height="@dimen/media_bubble_sticker_dimens"
+    android:contentDescription="@string/image" />

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -97,6 +97,12 @@
                 android:layout="@layout/conversation_item_sent_thumbnail" />
 
             <ViewStub
+		android:id="@+id/sticker_view_stub"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout="@layout/conversation_item_received_sticker" />
+
+            <ViewStub
                 android:id="@+id/audio_view_stub"
                 android:layout="@layout/conversation_item_sent_audio"
                 android:layout_width="210dp"
@@ -159,6 +165,19 @@
                 android:clipChildren="false"
                 android:clipToPadding="false"
                 app:footer_text_color="?attr/conversation_item_outgoing_text_secondary_color"/>
+
+        <org.thoughtcrime.securesms.components.ConversationItemFooter
+            android:id="@+id/conversation_item_sticker_footer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/message_bubble_horizontal_padding"
+            android:layout_marginRight="@dimen/message_bubble_horizontal_padding"
+            android:layout_marginBottom="@dimen/message_bubble_bottom_padding"
+            android:layout_gravity="end"
+            android:gravity="end"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            app:footer_text_color="@color/gray50"/>
 
         </LinearLayout>
 

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -166,18 +166,18 @@
                 android:clipToPadding="false"
                 app:footer_text_color="?attr/conversation_item_outgoing_text_secondary_color"/>
 
-        <org.thoughtcrime.securesms.components.ConversationItemFooter
-            android:id="@+id/conversation_item_sticker_footer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/message_bubble_horizontal_padding"
-            android:layout_marginRight="@dimen/message_bubble_horizontal_padding"
-            android:layout_marginBottom="@dimen/message_bubble_bottom_padding"
-            android:layout_gravity="end"
-            android:gravity="end"
-            android:clipChildren="false"
-            android:clipToPadding="false"
-            app:footer_text_color="@color/gray50"/>
+            <org.thoughtcrime.securesms.components.ConversationItemFooter
+		android:id="@+id/conversation_item_sticker_footer"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_marginLeft="@dimen/message_bubble_horizontal_padding"
+		android:layout_marginRight="@dimen/message_bubble_horizontal_padding"
+		android:layout_marginBottom="@dimen/message_bubble_bottom_padding"
+		android:layout_gravity="end"
+		android:gravity="end"
+		android:clipChildren="false"
+		android:clipToPadding="false"
+		app:footer_text_color="@color/gray50"/>
 
         </LinearLayout>
 

--- a/res/layout/conversation_item_sent_sticker.xml
+++ b/res/layout/conversation_item_sent_sticker.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.thoughtcrime.securesms.components.BorderlessImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/image_view"
+    android:layout_width="@dimen/media_bubble_sticker_dimens"
+    android:layout_height="@dimen/media_bubble_sticker_dimens"
+    android:contentDescription="@string/image" />

--- a/res/layout/sticker_view.xml
+++ b/res/layout/sticker_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:parentTag="org.thoughtcrime.securesms.components.BorderlessImageView">
+
+    <View
+        android:id="@+id/sticker_missing_shade"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/sticker_missing_background"
+        android:visibility="gone"
+        tools:visibility="visible"/>
+
+    <org.thoughtcrime.securesms.components.ThumbnailView
+        android:id="@+id/sticker_thumbnail"
+        android:layout_width="@dimen/media_bubble_sticker_dimens"
+        android:layout_height="@dimen/media_bubble_sticker_dimens"
+        app:thumbnail_radius="0dp"
+        app:thumbnail_fit="fit_center"
+        app:minWidth="@dimen/media_bubble_min_width"
+        app:maxWidth="@dimen/media_bubble_max_width"
+        app:minHeight="@dimen/media_bubble_min_height"
+        app:maxHeight="@dimen/media_bubble_max_height" />
+
+</merge>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -180,6 +180,10 @@
         <attr name="minHeight" format="dimension" />
         <attr name="maxHeight" format="dimension" />
         <attr name="thumbnail_radius" format="dimension" />
+        <attr name="thumbnail_fit" format="enum">
+            <enum name="center_crop" value="0" />
+            <enum name="fit_center" value="1" />
+        </attr>
     </declare-styleable>
 
     <declare-styleable name="CircleColorImageView">

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -31,6 +31,8 @@
     <dimen name="media_bubble_max_height">320dp</dimen>
     <dimen name="below_bubble">3dp</dimen>
 
+    <dimen name="media_bubble_sticker_dimens">175dp</dimen>
+
     <dimen name="gallery_thumbnail_radius">1dp</dimen>
 
     <dimen name="media_keyboard_provider_icon_padding">5dp</dimen>

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -16,6 +16,7 @@ public class DcMsg {
     public final static int DC_MSG_TEXT = 10;
     public final static int DC_MSG_IMAGE = 20;
     public final static int DC_MSG_GIF = 21;
+    public final static int DC_MSG_STICKER = 23;
     public final static int DC_MSG_AUDIO = 40;
     public final static int DC_MSG_VOICE = 41;
     public final static int DC_MSG_VIDEO = 50;

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -81,6 +81,8 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
   private static final int MESSAGE_TYPE_DOCUMENT_OUTGOING  = 7;
   private static final int MESSAGE_TYPE_DOCUMENT_INCOMING  = 8;
   private static final int MESSAGE_TYPE_VIDEOCHAT_INVITE   = 9;
+  private static final int MESSAGE_TYPE_STICKER_INCOMING   = 10;
+  private static final int MESSAGE_TYPE_STICKER_OUTGOING   = 11;
 
   private final Set<DcMsg> batchSelected = Collections.synchronizedSet(new HashSet<DcMsg>());
 
@@ -275,10 +277,12 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
       case MESSAGE_TYPE_AUDIO_OUTGOING:
       case MESSAGE_TYPE_THUMBNAIL_OUTGOING:
       case MESSAGE_TYPE_DOCUMENT_OUTGOING:
+      case MESSAGE_TYPE_STICKER_OUTGOING:
       case MESSAGE_TYPE_OUTGOING:        return R.layout.conversation_item_sent;
       case MESSAGE_TYPE_AUDIO_INCOMING:
       case MESSAGE_TYPE_THUMBNAIL_INCOMING:
       case MESSAGE_TYPE_DOCUMENT_INCOMING:
+      case MESSAGE_TYPE_STICKER_INCOMING:
       case MESSAGE_TYPE_INCOMING:        return R.layout.conversation_item_received;
       case MESSAGE_TYPE_INFO:            return R.layout.conversation_item_update;
       case MESSAGE_TYPE_VIDEOCHAT_INVITE:return R.layout.conversation_item_videochat;
@@ -301,6 +305,9 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     }
     else if (type==DcMsg.DC_MSG_IMAGE || type==DcMsg.DC_MSG_GIF || type==DcMsg.DC_MSG_VIDEO) {
       return dcMsg.isOutgoing()? MESSAGE_TYPE_THUMBNAIL_OUTGOING : MESSAGE_TYPE_THUMBNAIL_INCOMING;
+    }
+    else if (type == DcMsg.DC_MSG_STICKER) {
+      return dcMsg.isOutgoing()? MESSAGE_TYPE_STICKER_OUTGOING : MESSAGE_TYPE_STICKER_INCOMING;
     }
     else if (type == DcMsg.DC_MSG_VIDEOCHAT_INVITATION) {
       return MESSAGE_TYPE_VIDEOCHAT_INVITE;

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -695,7 +695,7 @@ public class ConversationItem extends LinearLayout
       this.groupSender.setVisibility(GONE);
       return;
     } else {
-	this.groupSender.setVisibility(VISIBLE);
+      this.groupSender.setVisibility(VISIBLE);
     }
 
     if (messageRecord.isForwarded()) {

--- a/src/org/thoughtcrime/securesms/components/BorderlessImageView.java
+++ b/src/org/thoughtcrime/securesms/components/BorderlessImageView.java
@@ -1,0 +1,74 @@
+package org.thoughtcrime.securesms.components;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.bumptech.glide.load.resource.bitmap.CenterCrop;
+import com.bumptech.glide.load.resource.bitmap.CenterInside;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.mms.GlideRequests;
+import org.thoughtcrime.securesms.mms.Slide;
+import org.thoughtcrime.securesms.mms.SlideClickListener;
+
+public class BorderlessImageView extends FrameLayout {
+
+  private ThumbnailView image;
+  private View          missingShade;
+
+  public BorderlessImageView(@NonNull Context context) {
+    super(context);
+    init();
+  }
+
+  public BorderlessImageView(@NonNull Context context, @Nullable AttributeSet attrs) {
+    super(context, attrs);
+    init();
+  }
+
+  private void init() {
+    inflate(getContext(), R.layout.sticker_view, this);
+
+    this.image        = findViewById(R.id.sticker_thumbnail);
+    this.missingShade = findViewById(R.id.sticker_missing_shade);
+  }
+
+  @Override
+  public void setFocusable(boolean focusable) {
+    image.setFocusable(focusable);
+  }
+
+  @Override
+  public void setClickable(boolean clickable) {
+    image.setClickable(clickable);
+  }
+
+  @Override
+  public void setOnLongClickListener(@Nullable OnLongClickListener l) {
+    image.setOnLongClickListener(l);
+  }
+
+  public void setSlide(@NonNull GlideRequests glideRequests, @NonNull Slide slide) {
+    boolean showControls = slide.asAttachment().getDataUri() == null;
+
+    if (slide.hasSticker()) {
+      image.setFit(new CenterInside());
+      image.setImageResource(glideRequests, slide);
+    } else {
+      image.setFit(new CenterCrop());
+      image.setImageResource(glideRequests, slide, slide.asAttachment().getWidth(), slide.asAttachment().getHeight());
+    }
+
+    missingShade.setVisibility(showControls ? View.VISIBLE : View.GONE);
+  }
+
+  public void setThumbnailClickListener(@NonNull SlideClickListener listener) {
+    image.setThumbnailClickListener(listener);
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/components/BorderlessImageView.java
+++ b/src/org/thoughtcrime/securesms/components/BorderlessImageView.java
@@ -4,13 +4,9 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
-import android.widget.ImageView.ScaleType;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import com.bumptech.glide.load.resource.bitmap.CenterCrop;
-import com.bumptech.glide.load.resource.bitmap.CenterInside;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.mms.GlideRequests;
@@ -58,10 +54,8 @@ public class BorderlessImageView extends FrameLayout {
     boolean showControls = slide.asAttachment().getDataUri() == null;
 
     if (slide.hasSticker()) {
-      image.setScaleType(ScaleType.CENTER_INSIDE);
       image.setImageResource(glideRequests, slide);
     } else {
-      image.setScaleType(ScaleType.CENTER_CROP);
       image.setImageResource(glideRequests, slide, slide.asAttachment().getWidth(), slide.asAttachment().getHeight());
     }
 

--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -176,7 +176,7 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
   }
 
   private void setQuoteAttachment(@NonNull GlideRequests glideRequests, @NonNull SlideDeck slideDeck) {
-    List<Slide> imageVideoSlides = Stream.of(slideDeck.getSlides()).filter(s -> s.hasImage() || s.hasVideo()).limit(1).toList();
+    List<Slide> imageVideoSlides = Stream.of(slideDeck.getSlides()).filter(s -> s.hasImage() || s.hasVideo() || s.hasSticker()).limit(1).toList();
     List<Slide> audioSlides = Stream.of(slideDeck.getSlides()).filter(s -> s.hasAudio()).limit(1).toList();
     List<Slide> documentSlides = Stream.of(attachments.getSlides()).filter(Slide::hasDocument).limit(1).toList();
 

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -332,9 +332,9 @@ public class ThumbnailView extends FrameLayout {
     }
     request = request.override(size[WIDTH], size[HEIGHT]);
     if (radius > 0) {
-	return request.transforms(fitting, new RoundedCorners(radius));
+      return request.transforms(fitting, new RoundedCorners(radius));
     } else {
-	return request.transforms(fitting);
+      return request.transforms(fitting);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/mms/Slide.java
+++ b/src/org/thoughtcrime/securesms/mms/Slide.java
@@ -80,6 +80,8 @@ public abstract class Slide {
     return false;
   }
 
+  public boolean hasSticker() { return false; }
+
   public boolean hasVideo() {
     return false;
   }

--- a/src/org/thoughtcrime/securesms/mms/StickerSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/StickerSlide.java
@@ -1,0 +1,33 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import com.b44t.messenger.DcMsg;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.attachments.DcAttachment;
+
+
+public class StickerSlide extends Slide {
+
+  public static final int WIDTH  = 512;
+  public static final int HEIGHT = 512;
+
+  public StickerSlide(@NonNull Context context, @NonNull DcMsg dcMsg) {
+    super(context, new DcAttachment(dcMsg));
+  }
+
+  public StickerSlide(@NonNull Context context, @NonNull Uri uri,
+                      long size, @NonNull String contentType)
+  {
+    super(context, constructAttachmentFromUri(context, uri, contentType, size, WIDTH, HEIGHT, uri, null, false));
+  }
+
+  @Override
+  public boolean hasSticker() {
+    return true;
+  }
+}

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -24,6 +24,7 @@ import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.mms.Slide;
+import org.thoughtcrime.securesms.mms.StickerSlide;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 
@@ -52,6 +53,8 @@ public class MediaUtil {
       slide = new GifSlide(context, dcMsg);
     } else if (dcMsg.getType() == DcMsg.DC_MSG_IMAGE) {
       slide = new ImageSlide(context, dcMsg);
+    } else if (dcMsg.getType() == DcMsg.DC_MSG_STICKER) {
+      slide = new StickerSlide(context, dcMsg);
     } else if (dcMsg.getType() == DcMsg.DC_MSG_VIDEO) {
       slide = new VideoSlide(context, dcMsg);
     } else if (dcMsg.getType() == DcMsg.DC_MSG_AUDIO


### PR DESCRIPTION
Sticker picker is not implemented, just receiving(from DC Desktop, bots or future DC versions) and forwarding stickers
(code adapted from Signal)

## Screenshot:
![deltachat-2021-03-03-045259](https://user-images.githubusercontent.com/24558636/109787592-6310d080-7bdc-11eb-96b2-f61b791b4ff0.jpg)

Feel free to tweak at taste :)