### PR TITLE
remove android dependencies from bindings

### DIFF
--- a/src/com/b44t/messenger/DcChatlist.java
+++ b/src/com/b44t/messenger/DcChatlist.java
@@ -1,8 +1,5 @@
 package com.b44t.messenger;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 public class DcChatlist {
 
     public DcChatlist(long chatlistCPtr) {
@@ -17,10 +14,10 @@ public class DcChatlist {
 
     public native int       getCnt    ();
     public native int       getChatId (int index);
-    public @NonNull DcChat  getChat   (int index) { return new DcChat(getChatCPtr(index)); }
+    public DcChat           getChat   (int index) { return new DcChat(getChatCPtr(index)); }
     public native int       getMsgId  (int index);
-    public @NonNull DcMsg   getMsg    (int index) { return new DcMsg(getMsgCPtr(index)); }
-    public @NonNull DcLot   getSummary(int index, @Nullable DcChat chat) { return new DcLot(getSummaryCPtr(index, chat==null? 0 : chat.getChatCPtr())); }
+    public DcMsg            getMsg    (int index) { return new DcMsg(getMsgCPtr(index)); }
+    public DcLot            getSummary(int index, DcChat chat) { return new DcLot(getSummaryCPtr(index, chat==null? 0 : chat.getChatCPtr())); }
 
     public class Item {
         public DcLot summary;

--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -1,7 +1,5 @@
 package com.b44t.messenger;
 
-import android.graphics.Color;
-
 public class DcContact {
 
     public final static int DC_CONTACT_ID_SELF               = 1;
@@ -59,9 +57,4 @@ public class DcContact {
     // working with raw c-data
     private long        contactCPtr;    // CAVE: the name is referenced in the JNI
     private native void unrefContactCPtr();
-
-    public int getArgbColor() {
-        int rgb = getColor();
-        return Color.argb(0xFF, Color.red(rgb), Color.green(rgb), Color.blue(rgb));
-    }
 }

--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -1,7 +1,6 @@
 package com.b44t.messenger;
 
 import android.graphics.Color;
-import android.util.Log;
 
 public class DcContact {
 

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -1,8 +1,5 @@
 package com.b44t.messenger;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 public class DcContext {
 
     public final static int DC_PREF_DEFAULT_MDNS_ENABLED = 1;
@@ -124,14 +121,14 @@ public class DcContext {
     public native int          lookupContactIdByAddr(String addr);
     public native int[]        getContacts          (int flags, String query);
     public native int[]        getBlockedContacts   ();
-    public @NonNull DcContact  getContact           (int contact_id) { return new DcContact(getContactCPtr(contact_id)); }
+    public DcContact           getContact           (int contact_id) { return new DcContact(getContactCPtr(contact_id)); }
     public native int          createContact        (String name, String addr);
     public native void         blockContact         (int id, int block);
     public native String       getContactEncrInfo   (int contact_id);
     public native boolean      deleteContact        (int id);
     public native int          addAddressBook       (String adrbook);
-    public @NonNull DcChatlist getChatlist          (int listflags, String query, int queryId) { return new DcChatlist(getChatlistCPtr(listflags, query, queryId)); }
-    public @NonNull DcChat     getChat              (int chat_id) { return new DcChat(getChatCPtr(chat_id)); }
+    public DcChatlist          getChatlist          (int listflags, String query, int queryId) { return new DcChatlist(getChatlistCPtr(listflags, query, queryId)); }
+    public DcChat              getChat              (int chat_id) { return new DcChat(getChatCPtr(chat_id)); }
     public native String       getChatEncrInfo      (int chat_id);
     public native void         markseenMsgs         (int msg_ids[]);
     public native void         marknoticedChat      (int chat_id);
@@ -143,7 +140,7 @@ public class DcContext {
     public native int          addContactToChat     (int chat_id, int contact_id);
     public native int          removeContactFromChat(int chat_id, int contact_id);
     public native void         setDraft             (int chat_id, DcMsg msg/*null=delete*/);
-    public @Nullable DcMsg     getDraft             (int chat_id) { return new DcMsg(getDraftCPtr(chat_id)); }
+    public DcMsg               getDraft             (int chat_id) { return new DcMsg(getDraftCPtr(chat_id)); }
     public native int          setChatName          (int chat_id, String name);
     public native int          setChatProfileImage  (int chat_id, String name);
     public native int[]        getChatMsgs          (int chat_id, int flags, int marker1before);
@@ -157,7 +154,7 @@ public class DcContext {
     public native boolean      setChatMuteDuration  (int chat_id, long duration);
     public native void         deleteChat           (int chat_id);
     public native int          decideOnContactRequest(int msg_id, int decision);
-    public @NonNull DcMsg      getMsg               (int msg_id) { return new DcMsg(getMsgCPtr(msg_id)); }
+    public DcMsg               getMsg               (int msg_id) { return new DcMsg(getMsgCPtr(msg_id)); }
     public native String       getMsgInfo           (int id);
     public native String       getMsgHtml           (int msg_id);
     public native int          getFreshMsgCount     (int chat_id);
@@ -170,14 +167,14 @@ public class DcContext {
     public native int          sendVideochatInvitation(int chat_id);
     public native int          addDeviceMsg         (String label, DcMsg msg);
     public native boolean      wasDeviceMsgEverAdded(String label);
-    public @NonNull DcLot      checkQr              (String qr) { return new DcLot(checkQrCPtr(qr)); }
+    public DcLot               checkQr              (String qr) { return new DcLot(checkQrCPtr(qr)); }
     public native String       getSecurejoinQr      (int chat_id);
     public native int          joinSecurejoin       (String qr);
     public native void         sendLocationsToChat  (int chat_id, int seconds);
     public native boolean      isSendingLocationsToChat(int chat_id);
-    public @NonNull DcArray    getLocations         (int chat_id, int contact_id, long timestamp_start, long timestamp_end) { return new DcArray(getLocationsCPtr(chat_id, contact_id, timestamp_start, timestamp_end)); }
+    public DcArray             getLocations         (int chat_id, int contact_id, long timestamp_start, long timestamp_end) { return new DcArray(getLocationsCPtr(chat_id, contact_id, timestamp_start, timestamp_end)); }
     public native void         deleteAllLocations   ();
-    public @Nullable DcProvider getProviderFromEmail (String email) { long cptr = getProviderFromEmailCPtr(email); return cptr!=0 ? new DcProvider(cptr) : null; }
+    public DcProvider          getProviderFromEmail (String email) { long cptr = getProviderFromEmailCPtr(email); return cptr!=0 ? new DcProvider(cptr) : null; }
 
     /**
      * @return true if at least one chat has location streaming enabled

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -1,12 +1,5 @@
 package com.b44t.messenger;
 
-import android.util.Log;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import org.thoughtcrime.securesms.connect.ApplicationDcContext;
-
 import java.io.File;
 import java.util.Set;
 
@@ -58,9 +51,6 @@ public class DcMsg {
 
     @Override
     public int hashCode() {
-        if (this.getId() == 0) {
-            Log.e(TAG, "encountered a DcMsg with id 0.");
-        }
         return this.getId();
     }
 
@@ -77,7 +67,7 @@ public class DcMsg {
     /**
      * If given a message, calculates the position of the message in the chat
      */
-    public static int getMessagePosition(DcMsg msg, ApplicationDcContext dcContext) {
+    public static int getMessagePosition(DcMsg msg, DcContext dcContext) {
         int msgs[] = dcContext.getChatMsgs(msg.getChatId(), 0, 0);
         int startingPosition = -1;
         int msgId = msg.getId();
@@ -105,7 +95,7 @@ public class DcMsg {
     public native int     getHeight          (int def);
     public native int     getDuration        ();
     public native void    lateFilingMediaSize(int width, int height, int duration);
-    public @NonNull DcLot getSummary         (DcChat chat) { return new DcLot(getSummaryCPtr(chat.getChatCPtr())); }
+    public DcLot          getSummary         (DcChat chat) { return new DcLot(getSummaryCPtr(chat.getChatCPtr())); }
     public native String  getSummarytext     (int approx_characters);
     public native int     showPadlock        ();
     public boolean        hasFile            () { String file = getFile(); return file!=null && !file.isEmpty(); }
@@ -129,9 +119,9 @@ public class DcMsg {
     public void           setQuote           (DcMsg quote) { setQuoteCPtr(quote.msgCPtr); }
     public native String  getQuotedText      ();
     public native String  getError           ();
-    private native @Nullable String getOverrideSenderName();
+    private native String getOverrideSenderName();
 
-    public @NonNull String getSenderName(@NonNull DcContact dcContact, boolean markOverride) {
+    public String getSenderName(DcContact dcContact, boolean markOverride) {
         String overrideName = getOverrideSenderName();
         if (overrideName != null) {
             return (markOverride ? "~" : "") + overrideName;

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -21,7 +21,6 @@ import androidx.annotation.NonNull;
 import androidx.multidex.MultiDexApplication;
 
 import com.b44t.messenger.DcContext;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.FetchWorker;

--- a/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedAndShareContactsActivity.java
@@ -17,10 +17,10 @@ import android.widget.TextView;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcContactsLoader;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListAdapter;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListItem;

--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -50,11 +50,11 @@ import android.widget.Toast;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.components.RecyclerViewFastScroller;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcContactsLoader;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.contacts.ContactAccessor;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListAdapter;

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -64,7 +64,6 @@ import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcMsg;
 
 import org.thoughtcrime.securesms.attachments.Attachment;
@@ -85,6 +84,7 @@ import org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer.Drawer
 import org.thoughtcrime.securesms.components.emoji.EmojiKeyboardProvider;
 import org.thoughtcrime.securesms.components.emoji.MediaKeyboard;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.map.MapActivity;
 import org.thoughtcrime.securesms.mms.AttachmentManager;

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -58,12 +58,12 @@ import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcMsg;
 
 import org.thoughtcrime.securesms.ConversationAdapter.ItemClickListener;
 import org.thoughtcrime.securesms.components.reminder.DozeReminder;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.mms.GlideApp;

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -68,6 +68,7 @@ import org.thoughtcrime.securesms.util.LongClickCopySpan;
 import org.thoughtcrime.securesms.util.LongClickMovementMethod;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.Prefs;
+import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.views.Stub;
 
@@ -663,7 +664,7 @@ public class ConversationItem extends LinearLayout
     }
     else if (groupThread && !messageRecord.isOutgoing() && dcContact !=null) {
       this.groupSender.setText(messageRecord.getSenderName(dcContact, true));
-      this.groupSender.setTextColor(dcContact.getArgbColor());
+      this.groupSender.setTextColor(Util.rgbToArgbColor(dcContact.getColor()));
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -51,7 +51,6 @@ import com.b44t.messenger.DcChatlist;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcMsg;
 import com.google.android.material.snackbar.Snackbar;
 
@@ -61,6 +60,7 @@ import org.thoughtcrime.securesms.components.registration.PulsingFloatingActionB
 import org.thoughtcrime.securesms.components.reminder.DozeReminder;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
 import org.thoughtcrime.securesms.connect.DcChatlistLoader;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.util.RelayUtil;

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -22,13 +22,13 @@ import android.widget.Toast;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.bumptech.glide.request.transition.Transition;
 import com.soundcloud.android.crop.Crop;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.contacts.avatars.ResourceContactPhoto;
 import org.thoughtcrime.securesms.database.Address;

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -26,9 +26,9 @@ import android.widget.EditText;
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.util.DynamicLanguage;

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -25,11 +25,11 @@ import android.widget.TextView;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcMsg;
 import com.codewaves.stickyheadergrid.StickyHeaderGridLayoutManager;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader;
 import org.thoughtcrime.securesms.util.ViewUtil;

--- a/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
@@ -25,11 +25,11 @@ import android.widget.TextView;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcMsg;
 import com.codewaves.stickyheadergrid.StickyHeaderGridLayoutManager;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader;

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -26,9 +26,9 @@ import com.b44t.messenger.DcChatlist;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.qr.QrShowActivity;

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -32,9 +32,9 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.b44t.messenger.DcContext;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.DynamicTheme;

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -16,13 +16,13 @@ import androidx.appcompat.app.AlertDialog;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcLot;
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 
 import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.qr.RegistrationQrActivity;

--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -32,6 +32,7 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientForeverObserver;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.ThemeUtil;
+import org.thoughtcrime.securesms.util.Util;
 
 import java.util.List;
 
@@ -160,8 +161,8 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
       } else {
         authorView.setVisibility(VISIBLE);
         authorView.setText(quotedMsg.getSenderName(contact, false));
-        authorView.setTextColor(contact.getArgbColor());
-        quoteBarView.setBackgroundColor(contact.getArgbColor());
+        authorView.setTextColor(Util.rgbToArgbColor(contact.getColor()));
+        quoteBarView.setBackgroundColor(Util.rgbToArgbColor(contact.getColor()));
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
+++ b/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java
@@ -21,7 +21,6 @@ import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcEventEmitter;
 import com.b44t.messenger.DcLot;
 import com.b44t.messenger.DcMsg;

--- a/src/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -1,4 +1,6 @@
-package com.b44t.messenger;
+package org.thoughtcrime.securesms.connect;
+
+import com.b44t.messenger.DcEvent;
 
 import org.thoughtcrime.securesms.util.Util;
 

--- a/src/org/thoughtcrime/securesms/map/MapDataManager.java
+++ b/src/org/thoughtcrime/securesms/map/MapDataManager.java
@@ -9,7 +9,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
@@ -28,6 +27,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiProvider;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.map.DataCollectionTask.DataCollectionCallback;
 import org.thoughtcrime.securesms.map.GenerateInfoWindowTask.GenerateInfoWindowCallback;

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -17,11 +17,11 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import com.b44t.messenger.DcContext;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.LogViewActivity;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;

--- a/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -11,10 +11,10 @@ import androidx.preference.Preference;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.service.GenericForegroundService;
 import org.thoughtcrime.securesms.service.NotificationController;

--- a/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -10,7 +10,6 @@ import android.widget.Toast;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.b44t.messenger.DcLot;
 import com.google.zxing.integration.android.IntentResult;
 
@@ -18,6 +17,7 @@ import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.Util;

--- a/src/org/thoughtcrime/securesms/qr/QrShowActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/QrShowActivity.java
@@ -6,10 +6,9 @@ import android.view.MenuItem;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.b44t.messenger.DcEventCenter;
-
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;

--- a/src/org/thoughtcrime/securesms/qr/QrShowFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/QrShowFragment.java
@@ -24,7 +24,6 @@ import androidx.fragment.app.Fragment;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcEventCenter;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.WriterException;
@@ -32,6 +31,7 @@ import com.google.zxing.common.BitMatrix;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 
 public class QrShowFragment extends Fragment implements DcEventCenter.DcEventDelegate {

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -22,6 +22,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -321,5 +322,11 @@ public class Util {
     } catch (InterruptedException e) {
       throw new AssertionError(e);
     }
+  }
+
+  /// Converts a rgb-color as returned eg. by DcContact.getColor()
+  /// to argb-color as used by Android.
+  public static int rgbToArgbColor(int rgb) {
+    return Color.argb(0xFF, Color.red(rgb), Color.green(rgb), Color.blue(rgb));
   }
 }


### PR DESCRIPTION
targets https://github.com/deltachat-bot/echo/issues/9

now, it should be possible to check out the android project and use only the `jni`  and the `src/com/b44t/messenger` directory in combination with plain java, without android.

at some point, we could think over to move the bindings to a separate project, however, i am not in favor of doing that now as this would comes at costs wrt android development. but if it is actually in use independently of android, we can think over it.