### PR TITLE
mark overridden senders in quotes

### DIFF
--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -160,7 +160,7 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
         quoteBarView.setBackgroundColor(getForwardedColor());
       } else {
         authorView.setVisibility(VISIBLE);
-        authorView.setText(quotedMsg.getSenderName(contact, false));
+        authorView.setText(quotedMsg.getSenderName(contact, true));
         authorView.setTextColor(Util.rgbToArgbColor(contact.getColor()));
         quoteBarView.setBackgroundColor(Util.rgbToArgbColor(contact.getColor()));
       }


### PR DESCRIPTION
if the original author of a quote is shown
and known to be overridden,
that should be marked with the character `~`
as for the normal names,
esp. as they are look very similar otherwise,
eg. also bold, also colored.
the missing `~` looks like a bug here.

successor of #1808

this also aligns display of overridden names with desktop, where the `~` is also added to quotes at https://github.com/deltachat/deltachat-desktop/pull/2132