### PR TITLE
Update glide to 4.12 to get rid of annoying stack traces in the log

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     implementation "me.leolin:ShortcutBadger:1.1.16" // display messagecount on the home screen icon.
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9' // used in the emoji selector for the tab selection.
     implementation 'com.github.chrisbanes:PhotoView:2.1.3' // does the zooming on photos / media
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     annotationProcessor 'androidx.annotation:annotation:1.1.0'
     implementation 'com.makeramen:roundedimageview:2.1.0' // crops the avatars to circles
     implementation 'com.pnikosis:materialish-progress:1.5' // used only in the "Progress Wheel" in Share Activity.


### PR DESCRIPTION
See https://github.com/bumptech/glide/issues/3851

Doesn't have to get in before the next release if you say that it's too risky :)

I mean these logs:
```
W/ExifInterface: Invalid image: ExifInterface got an unsupported image format file(ExifInterface supports JPEG and some RAW image formats only) or a corrupted JPEG file to ExifInterface.
    java.io.IOException: Invalid byte order: ffff8950
        at android.media.ExifInterface.readByteOrder(ExifInterface.java:3121)
        at android.media.ExifInterface.isOrfFormat(ExifInterface.java:2437)
        at android.media.ExifInterface.getMimeType(ExifInterface.java:2315)
        at android.media.ExifInterface.loadAttributes(ExifInterface.java:1753)
        at android.media.ExifInterface.<init>(ExifInterface.java:1447)
        at com.bumptech.glide.load.resource.bitmap.ExifInterfaceImageHeaderParser.getOrientation(ExifInterfaceImageHeaderParser.java:40)
        at com.bumptech.glide.load.ImageHeaderParserUtils.getOrientation(ImageHeaderParserUtils.java:91)
        at com.bumptech.glide.load.resource.bitmap.Downsampler.decodeFromWrappedStreams(Downsampler.java:236)
        at com.bumptech.glide.load.resource.bitmap.Downsampler.decode(Downsampler.java:206)
        at com.bumptech.glide.load.resource.bitmap.Downsampler.decode(Downsampler.java:162)
        at com.bumptech.glide.load.resource.bitmap.ByteBufferBitmapDecoder.decode(ByteBufferBitmapDecoder.java:33)
        at com.bumptech.glide.load.resource.bitmap.ByteBufferBitmapDecoder.decode(ByteBufferBitmapDecoder.java:16)
        at com.bumptech.glide.load.engine.DecodePath.decodeResourceWithList(DecodePath.java:72)
        at com.bumptech.glide.load.engine.DecodePath.decodeResource(DecodePath.java:55)
        at com.bumptech.glide.load.engine.DecodePath.decode(DecodePath.java:45)
        at com.bumptech.glide.load.engine.LoadPath.loadWithExceptionList(LoadPath.java:58)
        at com.bumptech.glide.load.engine.LoadPath.load(LoadPath.java:43)
        at com.bumptech.glide.load.engine.DecodeJob.runLoadPath(DecodeJob.java:515)
        at com.bumptech.glide.load.engine.DecodeJob.decodeFromFetcher(DecodeJob.java:480)
        at com.bumptech.glide.load.engine.DecodeJob.decodeFromData(DecodeJob.java:466)
        at com.bumptech.glide.load.engine.DecodeJob.decodeFromRetrievedData(DecodeJob.java:418)
        at com.bumptech.glide.load.engine.DecodeJob.onDataFetcherReady(DecodeJob.java:387)
        at com.bumptech.glide.load.engine.SourceGenerator.onDataFetcherReady(SourceGenerator.java:135)
        at com.bumptech.glide.load.engine.DataCacheGenerator.onDataReady(DataCacheGenerator.java:95)
        at com.bumptech.glide.load.model.ByteBufferFileLoader$ByteBufferFetcher.loadData(ByteBufferFileLoader.java:74)
        at com.bumptech.glide.load.engine.DataCacheGenerator.startNext(DataCacheGenerator.java:75)
        at com.bumptech.glide.load.engine.SourceGenerator.startNext(SourceGenerator.java:49)
        at com.bumptech.glide.load.engine.DecodeJob.runGenerators(DecodeJob.java:309)
        at com.bumptech.glide.load.engine.DecodeJob.runWrapped(DecodeJob.java:279)
        at com.bumptech.glide.load.engine.DecodeJob.run(DecodeJob.java:235)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
        at com.bumptech.glide.load.engine.executor.GlideExecutor$DefaultThreadFactory$1.run(GlideExecutor.java:446)
```