### PR TITLE
Use the message subject as the full-msg-view title

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1190,6 +1190,15 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcMsg_getText(JNIEnv *env, jobject obj
 }
 
 
+JNIEXPORT jstring Java_com_b44t_messenger_DcMsg_getSubject(JNIEnv *env, jobject obj)
+{
+    char* temp = dc_msg_get_subject(get_dc_msg(env, obj));
+        jstring ret = JSTRING_NEW(temp);
+    dc_str_unref(temp);
+    return ret;
+}
+
+
 JNIEXPORT jlong Java_com_b44t_messenger_DcMsg_getTimestamp(JNIEnv *env, jobject obj)
 {
     return JTIMESTAMP(dc_msg_get_timestamp(get_dc_msg(env, obj)));

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -82,6 +82,7 @@ public class DcMsg {
 
     public native int     getId              ();
     public native String  getText            ();
+    public native String  getSubject         ();
     public native long    getTimestamp       ();
     public native long    getSortTimestamp   ();
     public native boolean hasDeviatingTimestamp();

--- a/src/org/thoughtcrime/securesms/FullMsgActivity.java
+++ b/src/org/thoughtcrime/securesms/FullMsgActivity.java
@@ -55,10 +55,11 @@ public class FullMsgActivity extends WebViewActivity
     webView.getSettings().setAllowContentAccess(false);
     webView.getSettings().setAllowFileAccess(false);
 
-    getSupportActionBar().setTitle(getString(R.string.chat_input_placeholder));
-
     dcContext = DcHelper.getContext(this);
     msgId = getIntent().getIntExtra(MSG_ID_EXTRA, 0);
+    String title = dcContext.getMsg(msgId).getSubject();
+    if (title.isEmpty()) title = getString(R.string.chat_input_placeholder);
+    getSupportActionBar().setTitle(title);
 
     loadHtmlAsync(new WeakReference<>(this));
   }


### PR DESCRIPTION
For long subject it's ellipsized (`…`) now, but I think that there is no need to show the full subject somewhere, it usually doesn't contain _that_ important information and can be seen in full in the normal chat view