### PR TITLE
Don't open media preview for attachments with file viewtype

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -772,7 +772,7 @@ public class ConversationItem extends LinearLayout
         handleDeadDropClick();
       } else if (shouldInterceptClicks(messageRecord) || !batchSelected.isEmpty()) {
         performClick();
-      } else if (MediaPreviewActivity.isContentTypeSupported(slide.getContentType()) && slide.getUri() != null) {
+      } else if (MediaPreviewActivity.isTypeSupported(slide) && slide.getUri() != null) {
         Intent intent = new Intent(context, MediaPreviewActivity.class);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.putExtra(MediaPreviewActivity.DC_MSG_ID, slide.getDcMsgId());

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -26,14 +26,6 @@ import android.os.AsyncTask;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.Loader;
-import androidx.viewpager.widget.PagerAdapter;
-import androidx.viewpager.widget.ViewPager;
-import androidx.appcompat.app.AlertDialog;
-
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -44,7 +36,14 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
-import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.Loader;
+import androidx.viewpager.widget.PagerAdapter;
+import androidx.viewpager.widget.ViewPager;
 
 import com.b44t.messenger.DcMediaGalleryElement;
 import com.b44t.messenger.DcMsg;
@@ -57,6 +56,7 @@ import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.loaders.PagingMediaLoader;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.GlideRequests;
+import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientModifiedListener;
@@ -230,13 +230,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
     // if you search for the place where the media are loaded, go to 'onCreateLoader'.
 
-    if (!isContentTypeSupported(initialMedia.type)) {
-      Log.w(TAG, "Unsupported media type sent to MediaPreviewActivity, finishing.");
-      Toast.makeText(getApplicationContext(), R.string.error, Toast.LENGTH_LONG).show();
-      finish();
-      return;
-    }
-
     Log.w(TAG, "Loading Part URI: " + initialMedia);
 
     if (messageRecord != null) {
@@ -407,8 +400,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  public static boolean isContentTypeSupported(final String contentType) {
-    return contentType != null && (contentType.startsWith("image/") || contentType.startsWith("video/"));
+  public static boolean isTypeSupported(final Slide slide) {
+    return slide != null && (slide.hasVideo() || slide.hasImage());
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/database/loaders/PagingMediaLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/PagingMediaLoader.java
@@ -43,7 +43,7 @@ public class PagingMediaLoader extends AsyncLoader<DcMediaGalleryElement> {
     if(currentIndex == -1) {
       currentIndex = 0;
       DcMsg unfound = context.getMsg(msg.getId());
-      Log.d(TAG, "did not find message in list: " + unfound.getId() + " / " + unfound.getFile() + " / " + unfound.getText());
+      Log.e(TAG, "did not find message in list: " + unfound.getId() + " / " + unfound.getFile() + " / " + unfound.getText());
     }
     DcMediaGalleryElement retVal = new DcMediaGalleryElement(mediaMessages, currentIndex, context, leftIsRecent);
     return retVal;

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -29,13 +29,13 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.provider.MediaStore;
 import android.provider.OpenableColumns;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import android.view.View;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.MediaPreviewActivity;
@@ -524,7 +524,7 @@ public class AttachmentManager {
   }
 
   private void previewImageDraft(final @NonNull Slide slide) {
-    if (MediaPreviewActivity.isContentTypeSupported(slide.getContentType()) && slide.getUri() != null) {
+    if (MediaPreviewActivity.isTypeSupported(slide) && slide.getUri() != null) {
       Intent intent = new Intent(context, MediaPreviewActivity.class);
       intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
       intent.putExtra(MediaPreviewActivity.DC_MSG_ID, slide.getDcMsgId());


### PR DESCRIPTION
fix #1816

The problem was:
- as @link2xt already wrote, the onclick listener only checks if the mime type is `image/` or `video/`.
- then `PagingMediaLoader` loads all images and videos of the current chat with `context.getChatMedia(msg.getChatId(), DcMsg.DC_MSG_IMAGE, DcMsg.DC_MSG_GIF, DcMsg.DC_MSG_VIDEO)`. We need _all_ images so that the user can swipe back and forth.
- The correct image to be shown can't be found, the MediaPreview is opened anyway. As the correct image can't be shown, the first image in the chat is shown.