### PR TITLE
Bugfix: open images in the media preview again

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -63,7 +63,6 @@ import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideClickListener;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.mms.StickerSlide;
-import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.LongClickMovementMethod;
 import org.thoughtcrime.securesms.util.MediaUtil;
@@ -462,13 +461,7 @@ public class ConversationItem extends LinearLayout
       if (documentViewStub.resolved()) documentViewStub.get().setVisibility(View.GONE);
       if (stickerStub.resolved())        stickerStub.get().setVisibility(View.GONE);
 
-      Slide slide;
-      if (messageRecord.getType()==DcMsg.DC_MSG_VIDEO) {
-        slide = new VideoSlide(context, messageRecord);
-      }
-      else {
-        slide = new DocumentSlide(context, messageRecord);
-      }
+      Slide slide = MediaUtil.getSlideForMsg(context, messageRecord);
 
       MediaUtil.ThumbnailSize thumbnailSize = new MediaUtil.ThumbnailSize(messageRecord.getWidth(0), messageRecord.getHeight(0));
       if ((thumbnailSize.width<=0||thumbnailSize.height<=0)) {

--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -18,7 +18,7 @@ package org.thoughtcrime.securesms.mms;
 
 import android.content.Context;
 import android.net.Uri;
-import androidx.annotation.DrawableRes;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -35,6 +35,7 @@ public class ImageSlide extends Slide {
 
   public ImageSlide(@NonNull Context context, @NonNull DcMsg dcMsg) {
     super(context, new DcAttachment(dcMsg));
+    dcMsgId = dcMsg.getId();
   }
 
   public ImageSlide(@NonNull Context context, @NonNull Attachment attachment) {


### PR DESCRIPTION
Since #1834, images were not opened in the media preview again but
opened with an external app, as reported by @adbenitez.

This was because since #1834, only slides that return true on
`hasImage()` are shown in the media preview, i.e. gifs, images and
videos.

Now, the problem was that images were shown as DocumentSlides under
some circumstances, which return `false` for `hasImage()` (naturally).