### PR TITLE
Add APNG and animated webp support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation "me.leolin:ShortcutBadger:1.1.16" // display messagecount on the home screen icon.
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9' // used in the emoji selector for the tab selection.
     implementation 'com.github.chrisbanes:PhotoView:2.1.3' // does the zooming on photos / media
+    implementation 'com.github.penfeizhou.android.animation:glide-plugin:2.10.0' // APNG & animated webp support.
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     annotationProcessor 'androidx.annotation:annotation:1.1.0'


### PR DESCRIPTION
besides support on normal image messages, this means Delta Chat Android will also have "animated stickers" which, btw, already work in Delta Chat Desktop.

Images for testing:
* animated web:
https://isparta.github.io/compare-webp/image/gif_webp/webp/2.webp
* animated png:
https://misc.aotu.io/ONE-SUNDAY/SteamEngine.png