### PR TITLE
fix clicks on system messages

### DIFF
--- a/src/org/thoughtcrime/securesms/BaseConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BaseConversationItem.java
@@ -42,9 +42,9 @@ public abstract class BaseConversationItem extends LinearLayout
     this.dcContext = DcHelper.getContext(context);
   }
 
-  public void bind(@NonNull DcMsg            messageRecord,
-                   @NonNull DcChat           dcChat,
-                   @NonNull Set<DcMsg>       batchSelected)
+  protected void bind(@NonNull DcMsg            messageRecord,
+                      @NonNull DcChat           dcChat,
+                      @NonNull Set<DcMsg>       batchSelected)
   {
     this.messageRecord  = messageRecord;
     this.dcChat         = dcChat;

--- a/src/org/thoughtcrime/securesms/BaseConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BaseConversationItem.java
@@ -1,0 +1,125 @@
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+import android.content.Intent;
+import android.text.util.Linkify;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+
+import com.b44t.messenger.DcChat;
+import com.b44t.messenger.DcContext;
+import com.b44t.messenger.DcMsg;
+
+import org.thoughtcrime.securesms.connect.ApplicationDcContext;
+import org.thoughtcrime.securesms.connect.DcHelper;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class BaseConversationItem extends LinearLayout
+    implements BindableConversationItem
+{
+  protected DcMsg         messageRecord;
+  protected DcChat        dcChat;
+  protected TextView      bodyText;
+
+  protected final Context              context;
+  protected final ApplicationDcContext dcContext;
+
+  protected @NonNull  Set<DcMsg> batchSelected = new HashSet<>();
+
+  protected final PassthroughClickListener passthroughClickListener = new PassthroughClickListener();
+
+  public BaseConversationItem(Context context, AttributeSet attrs) {
+    super(context, attrs);
+    this.context = context;
+    this.dcContext = DcHelper.getContext(context);
+  }
+
+  public void bind(@NonNull DcMsg            messageRecord,
+                   @NonNull DcChat           dcChat,
+                   @NonNull Set<DcMsg>       batchSelected)
+  {
+    this.messageRecord  = messageRecord;
+    this.dcChat         = dcChat;
+    this.batchSelected  = batchSelected;
+  }
+
+  @Override
+  public void setOnClickListener(OnClickListener l) {
+    super.setOnClickListener(new ClickListener(l));
+  }
+
+  protected boolean shouldInterceptClicks(DcMsg messageRecord) {
+    return batchSelected.isEmpty() && (messageRecord.isFailed());
+  }
+
+  protected void handleDeadDropClick() {
+    ConversationListFragment.DeaddropQuestionHelper helper = new ConversationListFragment.DeaddropQuestionHelper(context, messageRecord);
+    new AlertDialog.Builder(context)
+      .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+        int chatId = dcContext.decideOnContactRequest(messageRecord.getId(), DcContext.DC_DECISION_START_CHAT);
+        if( chatId != 0 ) {
+          Intent intent = new Intent(context, ConversationActivity.class);
+          intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
+          context.startActivity(intent);
+        }
+      })
+      .setNegativeButton(android.R.string.cancel, null)
+      .setNeutralButton(helper.answerBlock, (dialog, which) -> dcContext.decideOnContactRequest(messageRecord.getId(), DcContext.DC_DECISION_BLOCK))
+      .setMessage(helper.question)
+      .show();
+  }
+
+  protected class PassthroughClickListener implements View.OnLongClickListener, View.OnClickListener {
+
+    @Override
+    public boolean onLongClick(View v) {
+      if (bodyText.hasSelection()) {
+        return false;
+      }
+      performLongClick();
+      return true;
+    }
+
+    @Override
+    public void onClick(View v) {
+      performClick();
+    }
+  }
+
+  protected class ClickListener implements View.OnClickListener {
+    private OnClickListener parent;
+
+    ClickListener(@Nullable OnClickListener parent) {
+      this.parent = parent;
+    }
+
+    public void onClick(View v) {
+      if (dcChat.getId() == DcChat.DC_CHAT_ID_DEADDROP && batchSelected.isEmpty()) {
+        handleDeadDropClick();
+      } else if (!shouldInterceptClicks(messageRecord) && parent != null) {
+        parent.onClick(v);
+      } else if (messageRecord.isFailed()) {
+        AlertDialog d = new AlertDialog.Builder(context)
+                .setMessage(messageRecord.getError())
+                .setTitle(R.string.error)
+                .setPositiveButton(R.string.ok, null)
+                .create();
+        d.show();
+        try {
+          //noinspection ConstantConditions
+          Linkify.addLinks((TextView) d.findViewById(android.R.id.message), Linkify.WEB_URLS | Linkify.EMAIL_ADDRESSES);
+        } catch(NullPointerException e) {
+          e.printStackTrace();
+        }
+      }
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -7,7 +7,6 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.b44t.messenger.DcChat;
@@ -20,17 +19,10 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import java.util.Locale;
 import java.util.Set;
 
-public class ConversationUpdateItem extends LinearLayout
-    implements BindableConversationItem
+public class ConversationUpdateItem extends BaseConversationItem
 {
-  private Set<DcMsg>    batchSelected;
-
   private DeliveryStatusView  deliveryStatusView;
-  private TextView            body;
-  private DcMsg               messageRecord;
   private int                 textColor;
-
-  private final Context context;
 
   public ConversationUpdateItem(Context context) {
     this(context, null);
@@ -38,7 +30,6 @@ public class ConversationUpdateItem extends LinearLayout
 
   public ConversationUpdateItem(Context context, AttributeSet attrs) {
     super(context, attrs);
-    this.context = context;
   }
 
   @Override
@@ -47,8 +38,12 @@ public class ConversationUpdateItem extends LinearLayout
 
     initializeAttributes();
 
-    body               = findViewById(R.id.conversation_update_body);
+    bodyText           = findViewById(R.id.conversation_update_body);
     deliveryStatusView = new DeliveryStatusView(findViewById(R.id.delivery_indicator));
+
+    bodyText.setOnLongClickListener(passthroughClickListener);
+    bodyText.setOnClickListener(passthroughClickListener);
+
   }
 
   @Override
@@ -60,9 +55,9 @@ public class ConversationUpdateItem extends LinearLayout
                    @NonNull Recipient               conversationRecipient,
                             boolean                 pulseUpdate)
   {
-    this.batchSelected = batchSelected;
-
-    bind(messageRecord);
+    bind(messageRecord, dcChat, batchSelected);
+    setGenericInfoRecord(messageRecord);
+    setSelected(batchSelected.contains(messageRecord));
   }
 
   private void initializeAttributes() {
@@ -85,15 +80,9 @@ public class ConversationUpdateItem extends LinearLayout
     return messageRecord;
   }
 
-  private void bind(@NonNull DcMsg messageRecord) {
-    this.messageRecord = messageRecord;
-    setGenericInfoRecord(messageRecord);
-    setSelected(batchSelected.contains(messageRecord));
-  }
-
   private void setGenericInfoRecord(DcMsg messageRecord) {
-    body.setText(messageRecord.getDisplayBody());
-    body.setVisibility(VISIBLE);
+    bodyText.setText(messageRecord.getDisplayBody());
+    bodyText.setVisibility(VISIBLE);
 
     if      (!messageRecord.isOutgoing())  deliveryStatusView.setNone();
     else if (messageRecord.isFailed())     deliveryStatusView.setFailed();


### PR DESCRIPTION
close #1882 

:cloud_with_rain: rain of fixes related to system messages: 
* clicks on system messages in the contact requests chat now work, displaying the dialog to accept the contact request (#1882)
* clicks on system messages that failed (`msg.isFailed() == true`) now display a dialog with the error message just like normal message bubbles do
* additionally, now system messages that have `Linkify`-ed text can be selected with long tap, this didn't worked in the past and users had to long-press empty areas close to the message record.