### PR TITLE
Improve profile menus

### DIFF
--- a/res/menu/profile_context.xml
+++ b/res/menu/profile_context.xml
@@ -10,6 +10,11 @@
         android:icon="@drawable/ic_delete_white_24dp"
         app:showAsAction="always"/>
 
+    <item android:id="@+id/share"
+        android:title="@string/menu_share"
+        android:icon="@drawable/ic_share_white_24dp"
+        app:showAsAction="always" />
+
     <item android:id="@+id/show_in_chat"
         android:title="@string/show_in_chat"
         app:showAsAction="never"/>

--- a/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -91,4 +91,8 @@ public abstract class MessageSelectorFragment
     intent.putExtra(ConversationActivity.STARTING_POSITION_EXTRA, DcMsg.getMessagePosition(dcMsg, dcContext));
     startActivity(intent);
   }
+
+  protected void handleShare(final DcMsg dcMsg) {
+    dcContext.openForViewOrShare(getContext(), dcMsg.getId(), Intent.ACTION_SEND);
+  }
 }

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -177,6 +177,7 @@ public class ProfileDocumentsFragment
     menu.findItem(R.id.details).setVisible(singleSelection);
     menu.findItem(R.id.show_in_chat).setVisible(singleSelection);
     menu.findItem(R.id.save).setVisible(singleSelection);
+    menu.findItem(R.id.share).setVisible(false);
   }
 
   private ProfileDocumentsAdapter getListAdapter() {

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -177,7 +177,7 @@ public class ProfileDocumentsFragment
     menu.findItem(R.id.details).setVisible(singleSelection);
     menu.findItem(R.id.show_in_chat).setVisible(singleSelection);
     menu.findItem(R.id.save).setVisible(singleSelection);
-    menu.findItem(R.id.share).setVisible(false);
+    menu.findItem(R.id.share).setVisible(singleSelection);
   }
 
   private ProfileDocumentsAdapter getListAdapter() {
@@ -217,6 +217,9 @@ public class ProfileDocumentsFragment
         case R.id.delete:
           handleDeleteMessages(getListAdapter().getSelectedMedia());
           mode.finish();
+          return true;
+        case R.id.share:
+          handleShare(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
           return true;
         case R.id.show_in_chat:
           handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));

--- a/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
@@ -189,6 +189,7 @@ public class ProfileGalleryFragment
     menu.findItem(R.id.details).setVisible(singleSelection);
     menu.findItem(R.id.show_in_chat).setVisible(singleSelection);
     menu.findItem(R.id.save).setVisible(singleSelection);
+    menu.findItem(R.id.share).setVisible(singleSelection);
   }
 
   private ProfileGalleryAdapter getListAdapter() {
@@ -228,6 +229,9 @@ public class ProfileGalleryFragment
         case R.id.delete:
           handleDeleteMessages(getListAdapter().getSelectedMedia());
           mode.finish();
+          return true;
+        case R.id.share:
+          handleShare(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
           return true;
         case R.id.show_in_chat:
           handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -250,6 +250,9 @@ public class ProfileSettingsFragment extends Fragment
       mode.getMenuInflater().inflate(R.menu.profile_context, menu);
       DcChat dcChat = dcContext.getChat(chatId);
       menu.findItem(R.id.delete).setVisible(!dcChat.isMailingList());
+      menu.findItem(R.id.details).setVisible(false);
+      menu.findItem(R.id.show_in_chat).setVisible(false);
+      menu.findItem(R.id.save).setVisible(false);
       mode.setTitle("1");
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -253,6 +253,7 @@ public class ProfileSettingsFragment extends Fragment
       menu.findItem(R.id.details).setVisible(false);
       menu.findItem(R.id.show_in_chat).setVisible(false);
       menu.findItem(R.id.save).setVisible(false);
+      menu.findItem(R.id.share).setVisible(false);
       mode.setTitle("1");
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
with #1868 new items were added to `profile_context.xml` menu, which are used by the gallery and documents tabs, it turns out that the settings tab also uses this menu, so unneeded items should be hidden.

Also, in the Gallery menu, would be nice to show the share button directly without having to open the image to share