### PR TITLE
improve app accesibility

### DIFF
--- a/res/layout/attachment_type_selector.xml
+++ b/res/layout/attachment_type_selector.xml
@@ -223,7 +223,7 @@
                         android:layout_height="53dp"
                         android:src="@drawable/ic_keyboard_arrow_down_white_24dp"
                         android:scaleType="center"
-                        android:contentDescription="@string/menu_add_attachment"
+                        android:contentDescription="@string/cancel"
                         app:circleColor="?attr/close_icon_color"/>
 
                 <TextView android:layout_marginTop="10dp"

--- a/res/layout/avatar_selector.xml
+++ b/res/layout/avatar_selector.xml
@@ -92,7 +92,7 @@
 					android:layout_height="53dp"
 					android:src="@drawable/ic_delete_white_24dp"
 					android:scaleType="center"
-					android:contentDescription="@string/contact"
+					android:contentDescription="@string/profile_image_delete"
 					app:circleColor="#FD3C00"/>
 
 				<TextView
@@ -117,7 +117,7 @@
 					android:layout_height="53dp"
 					android:src="@drawable/ic_keyboard_arrow_down_white_24dp"
 					android:scaleType="center"
-					android:contentDescription="@string/menu_add_attachment"
+					android:contentDescription="@string/cancel"
 					app:circleColor="?attr/close_icon_color"/>
 
 				<TextView android:layout_marginTop="10dp"

--- a/res/layout/contact_filter_toolbar.xml
+++ b/res/layout/contact_filter_toolbar.xml
@@ -45,6 +45,7 @@
                            android:visibility="gone"
                            android:focusable="true"
                            android:background="@drawable/circle_touch_highlight_background"
+                           android:contentDescription="@string/clear_search"
                            android:src="@drawable/ic_clear_white_24dp" />
 
             </org.thoughtcrime.securesms.components.AnimatingToggle>

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -52,7 +52,7 @@
                 android:layout_height="36dp"
                 android:layout_marginBottom="1dp"
                 android:cropToPadding="true"
-                android:contentDescription="@null" />
+                android:contentDescription="@string/pref_profile_photo" />
 
         </FrameLayout>
 

--- a/res/layout/conversation_list_activity.xml
+++ b/res/layout/conversation_list_activity.xml
@@ -48,7 +48,8 @@
                        android:layout_marginBottom="4dp"
                        android:layout_alignParentRight="true"
                        android:layout_alignParentEnd="true"
-                       android:layout_centerVertical="true"/>
+                       android:layout_centerVertical="true"
+                       android:contentDescription="@string/search"/>
 
         </RelativeLayout>
 

--- a/res/layout/conversation_list_item_view.xml
+++ b/res/layout/conversation_list_item_view.xml
@@ -20,7 +20,7 @@
         android:layout_centerVertical="true"
         android:cropToPadding="true"
         tools:src="@drawable/ic_contact_picture"
-        android:contentDescription="@string/pref_profile_photo"
+        android:importantForAccessibility="no"
         android:layout_marginLeft="12dp"
         android:layout_marginRight="12dp" />
 

--- a/res/layout/conversation_title_view.xml
+++ b/res/layout/conversation_title_view.xml
@@ -22,6 +22,7 @@
                android:layout_alignParentLeft="true"
                android:layout_alignParentStart="true"
                android:layout_centerVertical="true"
+               android:contentDescription="@string/back"
                android:visibility="visible"/>
 
     <org.thoughtcrime.securesms.components.AvatarImageView

--- a/res/layout/image_editor_hud.xml
+++ b/res/layout/image_editor_hud.xml
@@ -36,6 +36,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/undo"
                 android:src="@drawable/ic_undo_32" />
 
             <ImageView
@@ -44,6 +45,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/delete"
                 android:src="@drawable/ic_trash_filled_32" />
 
             <ImageView
@@ -52,6 +54,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/ImageEditorHud_add_text"
                 android:src="@drawable/ic_text_32" />
                 
             <ImageView
@@ -60,6 +63,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/ImageEditorHud_brush_marker"
                 android:src="@drawable/ic_brush_marker_32" />
 
             <ImageView
@@ -68,6 +72,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/ImageEditorHud_brush_highlight"
                 android:src="@drawable/ic_brush_highlight_32" />
 
             <ImageView
@@ -76,6 +81,7 @@
                 android:layout_height="44dp"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/ImageEditorHud_blur"
                 android:src="@drawable/ic_blur_on_white_24" />
 
             <ImageView
@@ -84,6 +90,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/emoji"
                 android:src="@drawable/ic_emoji_32" />
 
             <ImageView
@@ -92,6 +99,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/ImageEditorHud_crop"
                 android:src="@drawable/ic_crop_32" />
 
             <ImageView
@@ -100,6 +108,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/ImageEditorHud_flip"
                 android:src="@drawable/ic_flip_32" />
 
             <ImageView
@@ -108,6 +117,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/circle_universal_overlay"
                 android:padding="6dp"
+                android:contentDescription="@string/ImageEditorHud_rotate"
                 android:src="@drawable/ic_rotate_32" />
 
         </com.google.android.material.chip.ChipGroup>
@@ -128,6 +138,7 @@
             android:padding="6dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            android:contentDescription="@string/ok"
             android:src="@drawable/ic_check_white_24dp" />
 
         <ImageView
@@ -138,6 +149,7 @@
             android:padding="6dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            android:contentDescription="@string/save"
             android:background="@drawable/circle_universal_overlay"/>
 
         <org.thoughtcrime.securesms.scribbles.widget.VerticalSlideColorPicker

--- a/res/layout/media_view_edit_button.xml
+++ b/res/layout/media_view_edit_button.xml
@@ -5,4 +5,5 @@
            android:layout_gravity="bottom|right"
            android:layout_margin="8dp"
            android:src="@drawable/conversation_attachment_edit"
+           android:contentDescription="@string/global_menu_edit_desktop"
            android:visibility="gone"/>

--- a/res/layout/media_view_remove_button.xml
+++ b/res/layout/media_view_remove_button.xml
@@ -4,4 +4,5 @@
            android:layout_height="@dimen/media_bubble_remove_button_size"
            android:layout_gravity="top|right"
            android:src="@drawable/conversation_attachment_close_circle"
+           android:contentDescription="@string/cancel"
            android:visibility="gone"/>

--- a/res/layout/profile_create_activity.xml
+++ b/res/layout/profile_create_activity.xml
@@ -34,6 +34,7 @@
             <ImageView android:id="@+id/avatar"
                        android:layout_width="64dp"
                        android:layout_height="64dp"
+                       android:contentDescription="@string/pref_profile_photo"
                        android:transitionName="avatar"/>
 
             <com.google.android.material.textfield.TextInputLayout

--- a/res/layout/profile_preference_view.xml
+++ b/res/layout/profile_preference_view.xml
@@ -10,6 +10,7 @@
                android:layout_width="64dp"
                android:layout_height="64dp"
                android:layout_margin="16dp"
+               android:contentDescription="@string/pref_profile_info_headline"
                android:transitionName="avatar"/>
 
     <LinearLayout android:orientation="vertical"

--- a/res/layout/quick_camera_controls.xml
+++ b/res/layout/quick_camera_controls.xml
@@ -14,7 +14,8 @@
                  android:background="@drawable/quick_camera_shutter_ring"
                  android:src="@drawable/quick_shutter_button"
                  android:enabled="false"
-                 android:padding="20dp"/>
+                 android:padding="20dp"
+                 android:contentDescription="@string/camera_capture_description"/>
 
     <ImageButton android:id="@+id/fullscreen_button"
                  android:layout_width="wrap_content"
@@ -23,7 +24,8 @@
                  android:layout_alignParentRight="true"
                  android:background="@drawable/circle_touch_highlight_background"
                  android:src="@drawable/quick_camera_fullscreen"
-                 android:padding="20dp" />
+                 android:padding="20dp"
+                 android:contentDescription="@string/camera_fullscreen_toogle_description" />
 
     <ImageButton android:id="@+id/swap_camera_button"
                  android:layout_width="wrap_content"
@@ -35,6 +37,7 @@
                  android:enabled="false"
                  android:padding="20dp"
                  android:visibility="invisible"
-                 tools:visibility="visible" />
+                 tools:visibility="visible"
+                 android:contentDescription="@string/camera_change_description" />
 
 </RelativeLayout>

--- a/res/layout/quick_camera_controls.xml
+++ b/res/layout/quick_camera_controls.xml
@@ -15,7 +15,7 @@
                  android:src="@drawable/quick_shutter_button"
                  android:enabled="false"
                  android:padding="20dp"
-                 android:contentDescription="@string/camera_capture_description"/>
+                 android:contentDescription="@string/capture"/>
 
     <ImageButton android:id="@+id/fullscreen_button"
                  android:layout_width="wrap_content"
@@ -25,7 +25,7 @@
                  android:background="@drawable/circle_touch_highlight_background"
                  android:src="@drawable/quick_camera_fullscreen"
                  android:padding="20dp"
-                 android:contentDescription="@string/camera_fullscreen_toogle_description" />
+                 android:contentDescription="@string/toggle_fullscreen" />
 
     <ImageButton android:id="@+id/swap_camera_button"
                  android:layout_width="wrap_content"
@@ -38,6 +38,6 @@
                  android:padding="20dp"
                  android:visibility="invisible"
                  tools:visibility="visible"
-                 android:contentDescription="@string/camera_change_description" />
+                 android:contentDescription="@string/switch_camera" />
 
 </RelativeLayout>

--- a/res/layout/quote_view.xml
+++ b/res/layout/quote_view.xml
@@ -120,7 +120,8 @@
 			android:layout_gravity="center|end"
 			android:background="@drawable/dismiss_background"
 			android:src="@drawable/ic_close_white_18dp"
-			android:tint="?quote_dismiss_button_tint" />
+			android:tint="?quote_dismiss_button_tint"
+			android:contentDescription="@string/cancel" />
 	</LinearLayout>
 
 </merge>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -683,6 +683,13 @@
 
     <!-- ImageEditorHud -->
     <string name="ImageEditorHud_draw_anywhere_to_blur">Dibuja para difuminar</string>
+    <string name="ImageEditorHud_add_text">Añadir texto</string>
+    <string name="ImageEditorHud_blur">Difuminar</string>
+    <string name="ImageEditorHud_brush_marker">Marcador</string>
+    <string name="ImageEditorHud_brush_highlight">Pincel de resaltado</string>
+    <string name="ImageEditorHud_crop">Recortar</string>
+    <string name="ImageEditorHud_flip">Voltear</string>
+    <string name="ImageEditorHud_rotate">Rotar</string>
 
     <!-- dc_str_* resources -->
     <string name="encrypted_message">Mensaje cifrado</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -119,9 +119,9 @@
     <string name="contact">Contacto</string>
     <string name="verified_contact">Contacto verificado</string>
     <string name="camera">Cámara</string>
-    <string name="camera_capture_description">Capturar</string>
-    <string name="camera_change_description">Cambiar cámara</string>
-    <string name="camera_fullscreen_toogle_description">Alternar modo pantalla completa</string>
+    <string name="capture">Capturar</string>
+    <string name="switch_camera">Cambiar cámara</string>
+    <string name="toggle_fullscreen">Alternar modo pantalla completa</string>
     <string name="location">Ubicación</string>
     <string name="gallery">Galería</string>
     <string name="images_and_videos">Imágenes y videos</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -119,6 +119,9 @@
     <string name="contact">Contacto</string>
     <string name="verified_contact">Contacto verificado</string>
     <string name="camera">Cámara</string>
+    <string name="camera_capture_description">Capturar</string>
+    <string name="camera_change_description">Cambiar cámara</string>
+    <string name="camera_fullscreen_toogle_description">Alternar modo pantalla completa</string>
     <string name="location">Ubicación</string>
     <string name="gallery">Galería</string>
     <string name="images_and_videos">Imágenes y videos</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -4,6 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancelar</string>
+    <string name="clear_search">Borrar búsqueda</string>
     <string name="yes">Sí</string>
     <string name="no">No</string>
     <string name="select">Seleccionar</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -121,6 +121,9 @@
     <string name="contact">Contact</string>
     <string name="verified_contact">Verified contact</string>
     <string name="camera">Camera</string>
+    <string name="camera_capture_description">Capture</string>
+    <string name="camera_change_description">Change camera</string>
+    <string name="camera_fullscreen_toogle_description">Alternate full screen mode</string>
     <string name="location">Location</string>
     <string name="gallery">Gallery</string>
     <string name="images_and_videos">Images and videos</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -703,6 +703,13 @@
 
     <!-- ImageEditorHud -->
     <string name="ImageEditorHud_draw_anywhere_to_blur">Draw anywhere to blur</string>
+    <string name="ImageEditorHud_add_text">Add text</string>
+    <string name="ImageEditorHud_blur">Blur</string>
+    <string name="ImageEditorHud_brush_marker">Marker brush</string>
+    <string name="ImageEditorHud_brush_highlight">Highlight brush</string>
+    <string name="ImageEditorHud_crop">Crop</string>
+    <string name="ImageEditorHud_flip">Flip</string>
+    <string name="ImageEditorHud_rotate">Rotate</string>
 
     <!-- dc_str_* resources -->
     <string name="encrypted_message">Encrypted message</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -122,7 +122,7 @@
     <string name="verified_contact">Verified contact</string>
     <string name="camera">Camera</string>
     <string name="camera_capture_description">Capture</string>
-    <string name="camera_change_description">Change camera</string>
+    <string name="camera_change_description">Switch camera</string>
     <string name="camera_fullscreen_toogle_description">Toggle full screen mode</string>
     <string name="location">Location</string>
     <string name="gallery">Gallery</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -123,7 +123,7 @@
     <string name="camera">Camera</string>
     <string name="camera_capture_description">Capture</string>
     <string name="camera_change_description">Change camera</string>
-    <string name="camera_fullscreen_toogle_description">Alternate full screen mode</string>
+    <string name="camera_fullscreen_toogle_description">Toggle full screen mode</string>
     <string name="location">Location</string>
     <string name="gallery">Gallery</string>
     <string name="images_and_videos">Images and videos</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
+    <string name="clear_search">Clear search</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="select">Select</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -121,9 +121,9 @@
     <string name="contact">Contact</string>
     <string name="verified_contact">Verified contact</string>
     <string name="camera">Camera</string>
-    <string name="camera_capture_description">Capture</string>
-    <string name="camera_change_description">Switch camera</string>
-    <string name="camera_fullscreen_toogle_description">Toggle full screen mode</string>
+    <string name="capture">Capture</string>
+    <string name="switch_camera">Switch camera</string>
+    <string name="toggle_fullscreen">Toggle full screen mode</string>
     <string name="location">Location</string>
     <string name="gallery">Gallery</string>
     <string name="images_and_videos">Images and videos</string>

--- a/src/org/thoughtcrime/securesms/TransportOptions.java
+++ b/src/org/thoughtcrime/securesms/TransportOptions.java
@@ -95,7 +95,7 @@ public class TransportOptions {
     List<TransportOption> results = new LinkedList<>();
 
     results.add(new TransportOption(Type.NORMAL_MAIL, R.drawable.ic_send_sms_white_24dp,
-                                    context.getString(R.string.app_name),
+                                    context.getString(R.string.menu_send),
                                     context.getString(R.string.chat_input_placeholder)));
 
     return results;

--- a/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
+++ b/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.components;
 
+import android.content.Context;
 import android.util.Log;
 import android.view.View;
 import android.view.animation.Animation;
@@ -12,12 +13,14 @@ import org.thoughtcrime.securesms.R;
 public class DeliveryStatusView {
 
   private final ImageView deliveryIndicator;
+  private final Context   context;
   private static RotateAnimation prepareAnimation;
   private static RotateAnimation sendingAnimation;
   private boolean animated;
 
   public DeliveryStatusView(ImageView deliveryIndicator) {
     this.deliveryIndicator = deliveryIndicator;
+    this.context = deliveryIndicator.getContext();
   }
 
   private void animatePrepare()
@@ -66,30 +69,35 @@ public class DeliveryStatusView {
   public void setPreparing() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sending);
+    deliveryIndicator.setContentDescription(context.getString(R.string.a11y_delivery_status_sending));
     animatePrepare();
   }
 
   public void setPending() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sending);
+    deliveryIndicator.setContentDescription(context.getString(R.string.a11y_delivery_status_sending));
     animateSending();
   }
 
   public void setSent() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sent);
+    deliveryIndicator.setContentDescription(context.getString(R.string.a11y_delivery_status_delivered));
     clearAnimation();
   }
 
   public void setRead() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_read);
+    deliveryIndicator.setContentDescription(context.getString(R.string.a11y_delivery_status_read));
     clearAnimation();
   }
 
   public void setFailed() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_failed);
+    deliveryIndicator.setContentDescription(context.getString(R.string.a11y_delivery_status_invalid));
     clearAnimation();
   }
 

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiPageViewGridAdapter.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiPageViewGridAdapter.java
@@ -55,6 +55,7 @@ public class EmojiPageViewGridAdapter extends RecyclerView.Adapter<EmojiPageView
     if (drawable != null) {
       viewHolder.textView.setVisibility(View.GONE);
       viewHolder.imageView.setVisibility(View.VISIBLE);
+      viewHolder.imageView.setContentDescription(emoji.getValue());
 
       viewHolder.imageView.setImageDrawable(drawable);
     } else {


### PR DESCRIPTION
close #1901 

- [x] add label to "global search", "go back to chatlist", "cancel contact search", and a lot more of other unlabeled buttons
- [x] add labels to emojis in emoji selector
- [x] fix: when you press add attachment, the button to go back keeps the label of "add attachment" button
- [x] fix send button label
- [x] add labels to quick camera buttons
- [x] add labels to staged image and image editor
- [x] add labels for message status (sending, sent, read, failed) 
