### PR TITLE
use the same emoji style everywhere across the app

### DIFF
--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -84,7 +84,7 @@
                 android:visibility="gone"
                 tools:visibility="visible">
 
-                <TextView
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/group_message_sender"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/res/layout/conversation_item_update.xml
+++ b/res/layout/conversation_item_update.xml
@@ -23,7 +23,7 @@
         android:orientation="vertical">
 
         <!--Links should be clickable, see https://github.com/deltachat/deltachat-android/issues/1546-->
-        <TextView
+        <org.thoughtcrime.securesms.components.emoji.EmojiTextView
             android:id="@+id/conversation_update_body"
             style="@style/Delta.Text.UpdateHeader"
             android:layout_width="wrap_content"

--- a/res/layout/conversation_item_videochat.xml
+++ b/res/layout/conversation_item_videochat.xml
@@ -65,7 +65,7 @@
 
         </LinearLayout>
 
-        <TextView
+        <org.thoughtcrime.securesms.components.emoji.EmojiTextView
             android:id="@+id/conversation_update_body"
             style="@style/Delta.Text.UpdateHeader"
             android:layout_width="wrap_content"

--- a/res/layout/message_details_view.xml
+++ b/res/layout/message_details_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+        android:id="@+id/details_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:paddingTop="15dp"
+        android:paddingBottom="8dp"
+        android:textIsSelectable="true"
+        android:autoLink="web|email"
+        style="@style/Signal.Text.Body"/>
+
+</ScrollView>

--- a/res/layout/profile_create_activity.xml
+++ b/res/layout/profile_create_activity.xml
@@ -42,7 +42,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="10dp">
 
-                <com.google.android.material.textfield.TextInputEditText
+                <org.thoughtcrime.securesms.components.emoji.EmojiEditText
                     android:id="@+id/name_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -60,7 +60,7 @@
         android:layout_marginRight="16dp"
         android:layout_marginTop="16dp">
 
-        <com.google.android.material.textfield.TextInputEditText
+        <org.thoughtcrime.securesms.components.emoji.EmojiEditText
             android:id="@+id/status_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/res/layout/single_line_input.xml
+++ b/res/layout/single_line_input.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <EditText
+    <org.thoughtcrime.securesms.components.emoji.EmojiEditText
         android:id="@+id/input_field"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/src/org/thoughtcrime/securesms/BaseConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BaseConversationItem.java
@@ -2,7 +2,6 @@ package org.thoughtcrime.securesms;
 
 import android.content.Context;
 import android.content.Intent;
-import android.text.util.Linkify;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -117,12 +116,6 @@ public abstract class BaseConversationItem extends LinearLayout
                 .setPositiveButton(R.string.ok, null)
                 .create();
         d.show();
-        try {
-          //noinspection ConstantConditions
-          Linkify.addLinks((TextView) d.findViewById(android.R.id.message), Linkify.WEB_URLS | Linkify.EMAIL_ADDRESSES);
-        } catch(NullPointerException e) {
-          e.printStackTrace();
-        }
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/BaseConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BaseConversationItem.java
@@ -107,8 +107,12 @@ public abstract class BaseConversationItem extends LinearLayout
       } else if (!shouldInterceptClicks(messageRecord) && parent != null) {
         parent.onClick(v);
       } else if (messageRecord.isFailed()) {
+        View view = View.inflate(context, R.layout.message_details_view, null);
+        TextView detailsText = view.findViewById(R.id.details_text);
+        detailsText.setText(messageRecord.getError());
+
         AlertDialog d = new AlertDialog.Builder(context)
-                .setMessage(messageRecord.getError())
+                .setView(view)
                 .setTitle(R.string.error)
                 .setPositiveButton(R.string.ok, null)
                 .create();

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -27,7 +27,6 @@ import androidx.annotation.NonNull;
 import androidx.loader.app.LoaderManager;
 
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.google.android.material.textfield.TextInputEditText;
 import com.soundcloud.android.crop.Crop;
 
 import org.thoughtcrime.securesms.components.AvatarSelector;
@@ -71,7 +70,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
   private ImageView              avatar;
   private EditText               name;
   private MediaKeyboard          emojiDrawer;
-  private TextInputEditText statusView;
+  private EditText               statusView;
   private View                   reveal;
 
   private boolean fromWelcome;

--- a/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -4,7 +4,6 @@ import android.Manifest;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.text.util.Linkify;
 import android.view.Menu;
 import android.view.View;
 import android.widget.EditText;
@@ -50,12 +49,6 @@ public abstract class MessageSelectorFragment
             .setPositiveButton(android.R.string.ok, null)
             .create();
     d.show();
-    try {
-      //noinspection ConstantConditions
-      Linkify.addLinks((TextView) d.findViewById(android.R.id.message), Linkify.WEB_URLS);
-    } catch(NullPointerException e) {
-      e.printStackTrace();
-    }
   }
 
   protected void handleDeleteMessages(final Set<DcMsg> messageRecords) {

--- a/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -6,6 +6,8 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.text.util.Linkify;
 import android.view.Menu;
+import android.view.View;
+import android.widget.EditText;
 import android.widget.TextView;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ActionMode;
@@ -39,9 +41,12 @@ public abstract class MessageSelectorFragment
   }
 
   protected void handleDisplayDetails(DcMsg dcMsg) {
-    String infoStr = dcContext.getMsgInfo(dcMsg.getId());
+    View view = View.inflate(getActivity(), R.layout.message_details_view, null);
+    TextView detailsText = view.findViewById(R.id.details_text);
+    detailsText.setText(dcContext.getMsgInfo(dcMsg.getId()));
+
     AlertDialog d = new AlertDialog.Builder(getActivity())
-            .setMessage(infoStr)
+            .setView(view)
             .setPositiveButton(android.R.string.ok, null)
             .create();
     d.show();


### PR DESCRIPTION
try to use the same emoji style everywhere, if user enables "use system emojis" the system emojis are used without issues, the situation was that with built-in emojis enabled they are mixed with system emojis in quite visible parts of the app like the sender name of incoming messages contrasting with quotes, emojis in message body, etc.