### PR TITLE
handle URLs starting with OPENPGP4FPR and other case variants

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -122,6 +122,7 @@
             <category android:name="android.intent.category.DEFAULT"/>
             <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="openpgp4fpr" />
+            <data android:scheme="OPENPGP4FPR" />
         </intent-filter>
 
         <meta-data android:name="com.sec.minimode.icon.portrait.normal"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -121,8 +121,12 @@
             <action android:name="android.intent.action.VIEW"/>
             <category android:name="android.intent.category.DEFAULT"/>
             <category android:name="android.intent.category.BROWSABLE"/>
+            <!-- Android's scheme matcher is case-sensitive, so include most likely variations -->
             <data android:scheme="openpgp4fpr" />
             <data android:scheme="OPENPGP4FPR" />
+            <data android:scheme="OpenPGP4FPR" />
+            <data android:scheme="OpenPGP4Fpr" />
+            <data android:scheme="OpenPGP4fpr" />
         </intent-filter>
 
         <meta-data android:name="com.sec.minimode.icon.portrait.normal"


### PR DESCRIPTION
for some reason, URLs starting with "OPENPGP4FPR:" are not handled if the custom schema is not specified also in upper case.

in DeltaLab there is markdown support so extracting QR data and creating a nice invitation link is a possibility, also bots might offer this kind of link in html messages taking the QR data provided by core which is in upper case, and it would be nice if it works in upper case 