### PR TITLE
Clarify disappearing message hint

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="unarchive">Unarchive</string>
     <string name="mute">Mute</string>
     <string name="ephemeral_messages">Disappearing messages</string>
-    <string name="ephemeral_messages_hint">These settings apply to all participants using Delta Chat. However, they may copy, save and forward messages or use other e-mail clients.</string>
+    <string name="ephemeral_messages_hint">These settings apply to all participants in this group using Delta Chat. However, they may copy, save and forward messages or use other e-mail clients.</string>
     <string name="save">Save</string>
     <string name="chat">Chat</string>
     <string name="media">Media</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="unarchive">Unarchive</string>
     <string name="mute">Mute</string>
     <string name="ephemeral_messages">Disappearing messages</string>
-    <string name="ephemeral_messages_hint">These settings apply to all participants in this group using Delta Chat. However, they may copy, save and forward messages or use other e-mail clients.</string>
+    <string name="ephemeral_messages_hint">These settings apply to all chat members using Delta Chat. However, they may copy, save and forward messages or use other e-mail clients.</string>
     <string name="save">Save</string>
     <string name="chat">Chat</string>
     <string name="media">Media</string>


### PR DESCRIPTION
I got the user feedback that it's not clear that this setting only applies for this chat/group and is not a global setting like device/server deletion