### PR TITLE
notify quote-mentions in muted groups

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -311,8 +311,11 @@ public class NotificationCenter {
         Util.runOnAnyBackgroundThread(() -> {
 
             DcChat dcChat = dcContext.getChat(chatId);
+            DcMsg dcMsg = dcContext.getMsg(msgId);
+            DcMsg quotedMsg = dcMsg.getQuotedMsg();
+            boolean isGroupMention = quotedMsg != null && dcChat.isGroup() && quotedMsg.isOutgoing();
 
-            if (!Prefs.isNotificationsEnabled(context) || dcChat.isMuted()) {
+            if (!Prefs.isNotificationsEnabled(context) || (!isGroupMention &&  dcChat.isMuted())) {
                 return;
             }
 
@@ -328,7 +331,6 @@ public class NotificationCenter {
             // get notification text as a single line
             NotificationPrivacyPreference privacy = Prefs.getNotificationPrivacy(context);
 
-            DcMsg dcMsg = dcContext.getMsg(msgId);
             String line = privacy.isDisplayMessage()? dcMsg.getSummarytext(2000) : context.getString(R.string.notify_new_message);
             if (dcChat.isGroup() && privacy.isDisplayContact()) {
                 line = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId()), false) + ": " + line;


### PR DESCRIPTION
if group is muted, it would still be nice to get notifications when our messages are quoted, I added no extra setting for this as I think in general it would be a desired behavior and you can set notification sound of the chat to "silence" or temporally leave the group if you for don't want any interaction.

Without this feature, in a muted noise chat, you would miss mentions if you get like +100 messages and you don't skim over all of them to see if you got mentioned, etc. with this you will get a notification for the mention and then you can jump to the message directly.

related feature request: https://support.delta.chat/t/get-notified-when-your-message-is-quoted/1241

cc @link2xt 