### PR TITLE
refine wording of remaining screenlock

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -663,10 +663,7 @@
     <string name="systemmsg_chat_protection_disabled">Chat protection disabled.</string>
     <string name="systemmsg_chat_protection_enabled">Chat protection enabled.</string>
 
-    <!-- screen lock -->
-    <string name="screenlock_unlock_title">Unlock Delta Chat</string>
-    <string name="screenlock_unlock_description">Please enter your system defined secret to unlock Delta Chat.</string>
-    <string name="screenlock_authentication_failed">Authentication failed.</string>
+    <string name="enter_system_secret_to_continue">Please enter your system defined secret to continue.</string>
 
     <!-- qr code stuff -->
     <string name="qr_code">QR code</string>

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -155,8 +155,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     super.onActivityResult(requestCode, resultCode, data);
       if (resultCode == RESULT_OK && requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS) {
           exportKeys();
-      } else {
-        Toast.makeText(getActivity(), R.string.screenlock_authentication_failed, Toast.LENGTH_SHORT).show();
       }
   }
 
@@ -294,7 +292,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   private class ManageKeysListener implements Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS);
+      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_manage_keys), REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS);
       if (!result) {
         exportKeys();
       }

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -110,8 +110,6 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     super.onActivityResult(requestCode, resultCode, data);
     if (resultCode == RESULT_OK && requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP) {
       performBackup();
-    } else {
-      Toast.makeText(getActivity(), R.string.screenlock_authentication_failed, Toast.LENGTH_SHORT).show();
     }
   }
 
@@ -211,7 +209,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   private class BackupListener implements Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP);
+      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_backup), REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP);
       if (!result) {
         performBackup();
       }

--- a/src/org/thoughtcrime/securesms/util/ScreenLockUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ScreenLockUtil.java
@@ -11,11 +11,11 @@ public class ScreenLockUtil {
 
     public static final int REQUEST_CODE_CONFIRM_CREDENTIALS = 1001;
 
-    public static boolean applyScreenLock(Activity activity, int requestCode) {
+    public static boolean applyScreenLock(Activity activity, String title, int requestCode) {
         KeyguardManager keyguardManager = (KeyguardManager) activity.getSystemService(Context.KEYGUARD_SERVICE);
         Intent intent;
         if (keyguardManager != null && isScreenLockAvailable()) {
-            intent = keyguardManager.createConfirmDeviceCredentialIntent(activity.getString(R.string.screenlock_unlock_title), activity.getString(R.string.screenlock_unlock_description));
+            intent = keyguardManager.createConfirmDeviceCredentialIntent(title, activity.getString(R.string.enter_system_secret_to_continue));
             if (intent != null) {
                 activity.startActivityForResult(intent, requestCode);
                 return true;


### PR DESCRIPTION
successor of #1942 

we keep using the screenlock for "Backup" and "Manage keys";
these dialog always used the wording of the "global" screenlock,
sth. as "Please Unlock Delta Chat", however, that wording was always wrong
as Delta Chat itself is not locked in these situations.

this pr sets the title to the selected action
and just says "Please enter system secret to continue."

moreover, the toasts on canceling the action are removed,
they do not make much sense here,
there was a user action just before, so that is pretty clear anyway.