### PR TITLE
Hide unnecessary controls if you can't send

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -478,7 +478,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
 
     if (isGroupConversation()) {
-      if (!dcChat.isMailingList()) { // Leaving mailing lists is currently not supported
+      if (dcChat.canSend()) { // If you can't send, then you can't leave the group
         inflater.inflate(R.menu.conversation_push_group_options, menu);
       }
     }
@@ -965,13 +965,15 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       conversationContainer.setClipToPadding(true);
     }
 
-    if (!dcChat.canSend()) {
-      composePanel.setVisibility(View.GONE);
-    }
+    setComposePanelVisibility();
 
     if (chatId == DcChat.DC_CHAT_ID_DEADDROP) {
       titleView.hideAvatar();
     }
+  }
+
+  private void setComposePanelVisibility() {
+    composePanel.setVisibility(dcChat.canSend() ? View.VISIBLE : View.GONE);
   }
 
   //////// Helper Methods
@@ -1551,6 +1553,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       dcChat = dcContext.getChat(chatId);
       titleView.setTitle(glideRequests, dcChat);
       initializeSecurity(isSecureText, isDefaultSms);
+      setComposePanelVisibility();
     }
   }
 


### PR DESCRIPTION
Companion for https://github.com/deltachat/deltachat-core-rust/pull/2479, should be merged before to make sure that the compose panel is hidden immediately when the user leaves a group.

- Imediately hide the compose panel when you left the group and
EVENT_CHAT_CHANGED was sent
- Hide the "Leave" button if you are not a member of a group. I solved
this by checking `canSend()`; I could also have checked
`dc_is_contact_in_chat(CONTACT_ID_SELF)`, but this would be more
complexity for now.

  When we add the possibility to leave mailing lists, the core will have
  to explicitly tell the UI whether it's possible to leave a chat, but
  that's not for now.