### PR TITLE
allow withdrawing and reviving qr codes, add corresponding strings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -682,8 +682,8 @@
     <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to setup a contact with you.\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
     <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
     <string name="withdraw_qr_code">Withdraw QR code</string>
-    <string name="revive_verifycontact_explain">This QR code was withdrawn and was used to setup a contact with you. Currently the QR code is not functional.</string>
-    <string name="revive_verifygroup_explain">This QR code was withdrawn and was used to join the group \"%1$s\". Currently the QR code is not functional.</string>
+    <string name="revive_verifycontact_explain">This QR code could be scanned to setup a contact with you, but was withdrawn. Currently the QR code is not functional.</string>
+    <string name="revive_verifygroup_explain">This QR code could be scanned by others to join the group \"%1$s\", but was withdrawn. Currently the QR code is not functional.</string>
     <string name="revive_qr_code">Revive QR code</string>
     <string name="qrshow_title">QR invite code</string>
     <string name="qrshow_x_joining">%1$s joins.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -682,7 +682,7 @@
     <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to setup a contact with you.\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
     <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
     <string name="withdraw_qr_code">Withdraw QR code</string>
-    <string name="revive_verifycontact_explain">This QR code could be scanned to setup a contact with you, but was withdrawn. Currently the QR code is not functional.</string>
+    <string name="revive_verifycontact_explain">This QR code could be scanned by others to setup a contact with you, but was withdrawn. Currently the QR code is not functional.</string>
     <string name="revive_verifygroup_explain">This QR code could be scanned by others to join the group \"%1$s\", but was withdrawn. Currently the QR code is not functional.</string>
     <string name="revive_qr_code">Revive QR code</string>
     <string name="qrshow_title">QR invite code</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -679,6 +679,12 @@
     <string name="qrscan_contains_url">Scanned QR code URL:\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">Fingerprint</string>
     <string name="qrscan_x_verified_introduce_myself">%1$s verified, introduce myself…</string>
+    <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to setup a contact with you.\n\nIf you do not want that any longer, you can withdraw it. Withdrawn QR codes can be revived by scanning again.</string>
+    <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nIf you do not want that any longer, you can withdraw it. Withdrawn QR codes can be revived by scanning again.</string>
+    <string name="withdraw_qr_code">Withdraw QR code</string>
+    <string name="revive_verifycontact_explain">This QR code was withdrawn and was used to setup a contact with you. Currently the QR code it is not functional.</string>
+    <string name="revive_verifygroup_explain">This QR code was withdrawn and was used to join the group \"%1$s\". Currently the QR code it is not functional.</string>
+    <string name="revive_qr_code">Revive QR code</string>
     <string name="qrshow_title">QR invite code</string>
     <string name="qrshow_x_joining">%1$s joins.</string>
     <string name="qrshow_x_verified">%1$s verified.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -679,8 +679,8 @@
     <string name="qrscan_contains_url">Scanned QR code URL:\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">Fingerprint</string>
     <string name="qrscan_x_verified_introduce_myself">%1$s verified, introduce myself…</string>
-    <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to setup a contact with you.\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
-    <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
+    <string name="withdraw_verifycontact_explain">Prevent others from contacting you when scanning this QR code?\n\n(Can be undone by scanning it yourself afterwards.)</string>
+    <string name="withdraw_verifygroup_explain">Prevent others from joining your \"%1$s\" group when scanning this QR code?\n\n(Can be undone by scanning it yourself afterwards.)</string>
     <string name="withdraw_qr_code">Withdraw QR code</string>
     <string name="revive_verifycontact_explain">This QR code could be scanned by others to setup a contact with you, but was withdrawn. Currently the QR code is not functional.</string>
     <string name="revive_verifygroup_explain">This QR code could be scanned by others to join the group \"%1$s\", but was withdrawn. Currently the QR code is not functional.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -679,11 +679,11 @@
     <string name="qrscan_contains_url">Scanned QR code URL:\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">Fingerprint</string>
     <string name="qrscan_x_verified_introduce_myself">%1$s verified, introduce myself…</string>
-    <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to setup a contact with you.\n\nIf you do not want that any longer, you can withdraw it. Withdrawn QR codes can be revived by scanning again.</string>
-    <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nIf you do not want that any longer, you can withdraw it. Withdrawn QR codes can be revived by scanning again.</string>
+    <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to setup a contact with you.\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
+    <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nIf you do not want that any longer, you can withdraw it. You can revive it by scanning it again.</string>
     <string name="withdraw_qr_code">Withdraw QR code</string>
-    <string name="revive_verifycontact_explain">This QR code was withdrawn and was used to setup a contact with you. Currently the QR code it is not functional.</string>
-    <string name="revive_verifygroup_explain">This QR code was withdrawn and was used to join the group \"%1$s\". Currently the QR code it is not functional.</string>
+    <string name="revive_verifycontact_explain">This QR code was withdrawn and was used to setup a contact with you. Currently the QR code is not functional.</string>
+    <string name="revive_verifygroup_explain">This QR code was withdrawn and was used to join the group \"%1$s\". Currently the QR code is not functional.</string>
     <string name="revive_qr_code">Revive QR code</string>
     <string name="qrshow_title">QR invite code</string>
     <string name="qrshow_x_joining">%1$s joins.</string>

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -52,6 +52,10 @@ public class DcContext {
     public final static int DC_QR_TEXT              = 330;
     public final static int DC_QR_URL               = 332;
     public final static int DC_QR_ERROR             = 400;
+    public final static int DC_QR_WITHDRAW_VERIFYCONTACT = 500;
+    public final static int DC_QR_WITHDRAW_VERIFYGROUP   = 502;
+    public final static int DC_QR_REVIVE_VERIFYCONTACT   = 510;
+    public final static int DC_QR_REVIVE_VERIFYGROUP     = 512;
 
     public final static int DC_LP_AUTH_OAUTH2          =     0x2;
     public final static int DC_LP_AUTH_NORMAL          =     0x4;

--- a/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -89,6 +89,38 @@ public class QrCodeHandler implements DcEventCenter.DcEventDelegate {
                 builder.setCancelable(false);
                 break;
 
+            case DcContext.DC_QR_WITHDRAW_VERIFYCONTACT:
+                builder.setMessage(activity.getString(R.string.withdraw_verifycontact_explain));
+                builder.setPositiveButton(R.string.withdraw_qr_code, (dialog, which) -> {
+                    dcContext.setConfigFromQr(rawString);
+                });
+                builder.setNegativeButton(R.string.cancel, null);
+                break;
+
+            case DcContext.DC_QR_REVIVE_VERIFYCONTACT:
+                builder.setMessage(activity.getString(R.string.revive_verifycontact_explain));
+                builder.setPositiveButton(R.string.revive_qr_code, (dialog, which) -> {
+                    dcContext.setConfigFromQr(rawString);
+                });
+                builder.setNegativeButton(R.string.cancel, null);
+                break;
+
+            case DcContext.DC_QR_WITHDRAW_VERIFYGROUP:
+                builder.setMessage(activity.getString(R.string.withdraw_verifygroup_explain, qrParsed.getText1()));
+                builder.setPositiveButton(R.string.withdraw_qr_code, (dialog, which) -> {
+                    dcContext.setConfigFromQr(rawString);
+                });
+                builder.setNegativeButton(R.string.cancel, null);
+                break;
+
+            case DcContext.DC_QR_REVIVE_VERIFYGROUP:
+                builder.setMessage(activity.getString(R.string.revive_verifygroup_explain, qrParsed.getText1()));
+                builder.setPositiveButton(R.string.revive_qr_code, (dialog, which) -> {
+                    dcContext.setConfigFromQr(rawString);
+                });
+                builder.setNegativeButton(R.string.cancel, null);
+                break;
+
             default:
                 handleDefault(builder, rawString, qrParsed);
                 break;


### PR DESCRIPTION
the code-part of this pr is pretty simple, most work was already done in core at https://github.com/deltachat/deltachat-core-rust/pull/2512

what should be reviewed mainly is the wording of the 4 dialogs that appear when a user scans ones own qr codes:

**widthdraw/revive secure join qr codes:**

<img width=300 src=https://user-images.githubusercontent.com/9800740/123861316-505a9e00-d927-11eb-81fc-29f022b52c92.png> <img width=300 src=https://user-images.githubusercontent.com/9800740/123861307-4e90da80-d927-11eb-835a-ec48d209bdf4.png>

**widthdraw/revive group joins:**

<img width=300 src=https://user-images.githubusercontent.com/9800740/123863950-7cc3e980-d92a-11eb-9c36-1c780439ecaf.png> <img width=300 src=https://user-images.githubusercontent.com/9800740/123863941-7afa2600-d92a-11eb-8d89-f9b906841034.png>

closes #1962