### PR TITLE
consider multi-device usage on withdraw/revive QR code wordings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -687,12 +687,14 @@
     <string name="qrscan_contains_url">Scanned QR code URL:\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">Fingerprint</string>
     <string name="qrscan_x_verified_introduce_myself">%1$s verified, introduce myself…</string>
-    <string name="withdraw_verifycontact_explain">Prevent others from contacting you when scanning this QR code?\n\n(Can be undone by scanning it yourself afterwards.)</string>
-    <string name="withdraw_verifygroup_explain">Prevent others from joining your \"%1$s\" group when scanning this QR code?\n\n(Can be undone by scanning it yourself afterwards.)</string>
-    <string name="withdraw_qr_code">Withdraw QR code</string>
-    <string name="revive_verifycontact_explain">This QR code could be scanned by others to setup a contact with you, but was withdrawn. Currently the QR code is not functional.</string>
-    <string name="revive_verifygroup_explain">This QR code could be scanned by others to join the group \"%1$s\", but was withdrawn. Currently the QR code is not functional.</string>
-    <string name="revive_qr_code">Revive QR code</string>
+    <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to contact you.\n\nYou can deactivate the QR code here and reactivate it by scanning it again.</string>
+    <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nYou can deactivate the QR code here and reactivate it by scanning it again.</string>
+    <string name="withdraw_qr_code">Deactivate QR code</string>
+    <!-- "could" in the meaning of "possible at some point in the past, but no longer possible today" -->
+    <string name="revive_verifycontact_explain">This QR code could be scanned by others to setup a contact with you.\n\nThe QR code is not active on this device.</string>
+    <!-- "could" in the meaning of "possible at some point in the past, but no longer possible today" -->
+    <string name="revive_verifygroup_explain">This QR code could be scanned by others to join the group \"%1$s\".\n\nThe QR code is not active on this device.</string>
+    <string name="revive_qr_code">Activate QR code</string>
     <string name="qrshow_title">QR invite code</string>
     <string name="qrshow_x_joining">%1$s joins.</string>
     <string name="qrshow_x_verified">%1$s verified.</string>


### PR DESCRIPTION
in a multi-device-setup,
if deviceB scans ones own setup-contact QR code shown on deviceA,
it is misleading to say that the QR code was withdrawn
and can be revived.
actually, the QR code was never withdrawn by the user.

this is fixed by this pr.
(at some point, we want to sync QR codes across devices,
but even then, there may be siutuations where things are not in sync)

moreover,
the wording is more explicit about what is usually done with the qr code;
this is esp. helpful, when scanning a printed QR code without much context.
i am not fixed to the rewording, but i'd like to have a similar wording on deactivate/activate.

finally, i removed the "your group" wording; we do not use that anywhere else
and a groups does not have an owner (one may imply that by reading "your group")