### PR TITLE
Fix SELinux build issue with `:z` suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) . -t deltachat-an
 
 Then, run the image:
 ```
-podman run --userns=keep-id -it --name deltachat -v $(pwd):/home/app -w /home/app localhost/deltachat-android
+podman run --userns=keep-id -it --name deltachat -v $(pwd):/home/app:z -w /home/app localhost/deltachat-android
 ```
 or
 ```
-docker run -it --name deltachat -v $(pwd):/home/app -w /home/app localhost/deltachat-android
+docker run -it --name deltachat -v $(pwd):/home/app:z -w /home/app localhost/deltachat-android
 ```
 
 You can leave the container with Ctrl+D or by typing `exit` and re-enter it with 


### PR DESCRIPTION
Podman and docker require the `:z` suffix if running on system where SELinux is enabled (like
Fedora 34). See the following links for more information:

 - https://bugzilla.redhat.com/show_bug.cgi?id=1984457
 - https://unix.stackexchange.com/questions/651198/podman-volume-mounts-when-to-use-the-z-or-z-suffix
 - https://stackoverflow.com/questions/35218194/what-is-z-flag-in-docker-containers-volumes-from-option

Fixes #1981 