### PR TITLE
use 'Updating…' instead of 'Getting new messages…'

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -415,10 +415,13 @@
 
     <!-- Connectivity -->
     <string name="connectivity">Connectivity</string>
+    <!-- Shown eg. in the title bar if the app is "Not connected"; as there is very few room, try to be as short as possible. -->
     <string name="connectivity_not_connected">Not connected</string>
-    <!-- Note that the three dots are a single character (…), not three (...) -->
+    <!-- Shown eg. in the title bar if the app is "Connecting"; as there is very few room, try to be as short as possible. Note that the three dots are a single character (…), not three (...) -->
     <string name="connectivity_connecting">Connecting…</string>
-    <string name="connectivity_getting_new_msgs">Getting new messages…</string>
+    <!-- Shown eg. in the title bar if the app is "Updating" (eg. getting new/old message, sync things); as there is very few room, try to be as short as possible. Note that the three dots are a single character (…), not three (...) -->
+    <string name="connectivity_updating">Updating…</string>
+    <!-- Shown eg. in the setting if the app is "Connected" -->
     <string name="connectivity_connected">Connected</string>
 
 

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -81,7 +81,7 @@ public class DcHelper {
       if (connectivity >= DcContext.DC_CONNECTIVITY_CONNECTED) {
           return context.getString(connectedString);
       } else if (connectivity >= DcContext.DC_CONNECTIVITY_WORKING) {
-          return context.getString(R.string.connectivity_getting_new_msgs);
+          return context.getString(R.string.connectivity_updating);
       } else if (connectivity >= DcContext.DC_CONNECTIVITY_CONNECTING) {
           return context.getString(R.string.connectivity_connecting);
       } else {


### PR DESCRIPTION
- 'Getting new messages…' is not always fitting,
  the messages may be old or they are not visible as messags at all
  (read receipts, setup-contact, sync).
  'Updating…' is better fitting here.

- 'Getting new messages…' is a bit too long and results in
  linebreaks on smaller devices.

closes #1983