### PR TITLE
tweak 'Archived Chats' and  'Requests'

### DIFF
--- a/res/layout/conversation_list_fragment.xml
+++ b/res/layout/conversation_list_fragment.xml
@@ -26,7 +26,8 @@
                   android:visibility="gone"
                   tools:visibility="visible">
 
-        <TextView android:text="@string/chat_no_chats_yet_title"
+        <TextView android:id="@+id/empty_title"
+                  android:text="@string/chat_no_chats_yet_title"
                   android:textSize="20sp"
                   android:padding="16dp"
                   android:gravity="center"
@@ -34,7 +35,8 @@
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"/>
 
-        <TextView android:text="@string/chat_no_chats_yet_hint"
+        <TextView android:id="@+id/empty_subtitle"
+                  android:text="@string/chat_no_chats_yet_hint"
                   android:textSize="16sp"
                   android:paddingLeft="16dp"
                   android:paddingTop="16dp"

--- a/res/menu/text_secure_normal.xml
+++ b/res/menu/text_secure_normal.xml
@@ -10,6 +10,9 @@
     <item android:title="@string/menu_new_chat"
           android:id="@+id/menu_new_chat" />
 
+    <item android:title="@string/chat_archived_chats_title"
+        android:id="@+id/menu_archived_chats" />
+
     <item android:title="@string/menu_show_global_map"
         android:id="@+id/menu_global_map"
         android:visible="false"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -342,6 +342,7 @@
     <string name="chat_request_label">Request</string>
     <string name="chat_no_messages">No messages.</string>
     <string name="chat_self_talk_subtitle">Messages I sent to myself</string>
+    <string name="archive_empty_hint">If you archive chats, they will be shown here.</string>
     <string name="saved_messages">Saved Messages</string>
     <string name="saved_messages_explain">• Forward messages here for easy access\n\n• Take notes or voice memos\n\n• Attach media to save them</string>
     <!-- this "Saved" should match the "Saved" from "Saved messages" -->

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -225,6 +225,9 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       case R.id.menu_new_chat:
         createChat();
         return true;
+      case R.id.menu_archived_chats:
+        onSwitchToArchive();
+        return true;
       case R.id.menu_settings:
         startActivity(new Intent(this, ApplicationPreferencesActivity.class));
         return true;

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -133,8 +133,15 @@ public class ConversationListFragment extends Fragment
     emptyState   = ViewUtil.findById(view, R.id.empty_state);
     emptySearch  = ViewUtil.findById(view, R.id.empty_search);
 
-    if (archive) fab.setVisibility(View.GONE);
-    else         fab.setVisibility(View.VISIBLE);
+    if (archive) {
+      fab.setVisibility(View.GONE);
+      TextView emptyTitle = ViewUtil.findById(view, R.id.empty_title);
+      TextView emptySubtitle = ViewUtil.findById(view, R.id.empty_subtitle);
+      emptyTitle.setText(R.string.archive_empty_hint);
+      emptySubtitle.setVisibility(View.GONE);
+    } else {
+      fab.setVisibility(View.VISIBLE);
+    }
 
     list.setHasFixedSize(true);
     list.setLayoutManager(new LinearLayoutManager(getActivity()));
@@ -383,7 +390,7 @@ public class ConversationListFragment extends Fragment
     }
     DcChatlist chatlist = DcHelper.getContext(getContext()).getChatlist(listflags, queryFilter.isEmpty() ? null : queryFilter, 0);
 
-    if (chatlist.getCnt() <= 0 && TextUtils.isEmpty(queryFilter) && !archive) {
+    if (chatlist.getCnt() <= 0 && TextUtils.isEmpty(queryFilter)) {
       list.setVisibility(View.INVISIBLE);
       emptyState.setVisibility(View.VISIBLE);
       emptySearch.setVisibility(View.INVISIBLE);

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -245,7 +245,11 @@ public class ConversationListItem extends RelativeLayout
     if (visibility==DcChat.DC_CHAT_VISIBILITY_ARCHIVED)
     {
       badgeView.setVisibility(View.VISIBLE);
-      badgeView.setText(R.string.chat_archived_label);
+      if (isContactRequest) {
+        badgeView.setText(getContext().getString(R.string.chat_archived_label) + "  " + getContext().getString(R.string.chat_request_label));
+      } else {
+        badgeView.setText(R.string.chat_archived_label);
+      }
       deliveryStatusIndicator.setNone();
       unreadIndicator.setVisibility(View.GONE);
     }

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -133,7 +133,8 @@ public class ConversationListItem extends RelativeLayout
     this.glideRequests    = glideRequests;
 
     int state       = dcSummary.getState();
-    int unreadCount = (state==DcMsg.DC_STATE_IN_FRESH || state==DcMsg.DC_STATE_IN_NOTICED)? thread.getUnreadCount() : 0;
+    int unreadCount = ((state==DcMsg.DC_STATE_IN_FRESH || state==DcMsg.DC_STATE_IN_NOTICED) && !thread.isContactRequest())?
+                        thread.getUnreadCount() : 0;
 
     if (highlightSubstring != null) {
       this.fromView.setText(getHighlightedSpan(locale, recipient.getName(), highlightSubstring));


### PR DESCRIPTION
- [x] add "Archived Chats" menu entry the place where the 'Contact Requests' were before -
that way, ppl may find existing contact requests easier.  
moreover, it is now possible to access 'Archived Chats'
without endless scrolling ;)
- [x] add a hint as "If you archive chats, they will be shown here." in case there are no archived chats (also before, the list could be empty, however, typically, the activity was not opened then)
- [x] allow "Archived" and "Request" label in combination (maybe one can do two badge views at some point, in another pr, however, for now, this is good enough; it is not so much in focus anyway.
- [x] do not show requests in bold

targets some points of #1990 - the other points require some more playing around and can be done in another pr.