### PR TITLE
Try adding benchmarks by following the instructions

### DIFF
--- a/androidTest/AndroidManifest.xml
+++ b/androidTest/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	package="com.b44t.messenger.androidtest">
+
+	<!-- Important: disable debuggable for accurate performance results -->
+	<application
+		android:debuggable="false"
+		tools:ignore="HardcodedDebugMode"
+		tools:replace="android:debuggable" />
+
+</manifest>

--- a/androidTest/com/b44t/messenger/HelloWorldEspressoTest.java
+++ b/androidTest/com/b44t/messenger/HelloWorldEspressoTest.java
@@ -1,5 +1,7 @@
 package com.b44t.messenger;
 
+import androidx.benchmark.BenchmarkState;
+import androidx.benchmark.junit4.BenchmarkRule;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
@@ -10,9 +12,10 @@ import org.junit.runner.RunWith;
 import org.thoughtcrime.securesms.ConversationListActivity;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -22,8 +25,21 @@ public class HelloWorldEspressoTest {
   public ActivityScenarioRule<ConversationListActivity> activityRule =
           new ActivityScenarioRule<>(ConversationListActivity.class);
 
+  @Rule
+  public BenchmarkRule benchmarkRule = new BenchmarkRule();
+
   @Test
   public void listGoesOverTheFold() {
-    onView(withText("Hello world!")).check(matches(isDisplayed()));
+    openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+    onView(withText("Switch Account")).perform(click());
+    onView(withText("Add Account")).perform(click());
+  }
+
+  @Test
+  public void benchmarkSomeWork() {
+    final BenchmarkState state = benchmarkRule.getState();
+    while (state.keepRunning()) {
+      //doSomeWork();
+    }
   }
 }

--- a/androidTest/com/b44t/messenger/HelloWorldEspressoTest.java
+++ b/androidTest/com/b44t/messenger/HelloWorldEspressoTest.java
@@ -1,0 +1,29 @@
+package com.b44t.messenger;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.thoughtcrime.securesms.ConversationListActivity;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class HelloWorldEspressoTest {
+
+  @Rule
+  public ActivityScenarioRule<ConversationListActivity> activityRule =
+          new ActivityScenarioRule<>(ConversationListActivity.class);
+
+  @Test
+  public void listGoesOverTheFold() {
+    onView(withText("Hello world!")).check(matches(isDisplayed()));
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,18 @@ repositories {
     jcenter()
 }
 
+ext {
+    buildToolsVersion = "30.0.2"
+    androidxAnnotationVersion = "1.1.0"
+    robolectricVersion = "4.5.1"
+    guavaVersion = "29.0-android"
+    extTruthVersion = '1.3.0-rc01'
+    coreVersion = "1.4.0"
+    extJUnitVersion = "1.1.3"
+    runnerVersion = "1.4.0"
+    espressoVersion = "3.4.0"
+}
+
 dependencies {
     implementation 'androidx.webkit:webkit:1.4.0'
     implementation 'androidx.multidex:multidex:2.0.1'
@@ -75,6 +87,12 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.1'
     testImplementation 'org.powermock:powermock-classloading-xstream:1.6.1'
 
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'com.android.support:support-annotations:24.0.0'
+
     androidTestImplementation ('org.assertj:assertj-core:1.7.1') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
@@ -111,6 +129,8 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
         }
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
@@ -197,8 +217,8 @@ android {
             assets.srcDirs = ['assets']
             jniLibs.srcDirs = ['libs']
         }
-        test {
-            java.srcDirs = ['test']
+        androidTest {
+            java.srcDirs = ['androidTest']
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'androidx.benchmark:benchmark-gradle-plugin:1.0.0'
     }
 }
 
@@ -25,18 +26,6 @@ repositories {
         name 'JitPack Github wrapper'
     }
     jcenter()
-}
-
-ext {
-    buildToolsVersion = "30.0.2"
-    androidxAnnotationVersion = "1.1.0"
-    robolectricVersion = "4.5.1"
-    guavaVersion = "29.0-android"
-    extTruthVersion = '1.3.0-rc01'
-    coreVersion = "1.4.0"
-    extJUnitVersion = "1.1.3"
-    runnerVersion = "1.4.0"
-    espressoVersion = "3.4.0"
 }
 
 dependencies {
@@ -92,6 +81,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'com.android.support:support-annotations:24.0.0'
+    androidTestImplementation "androidx.benchmark:benchmark-junit4:1.0.0"
 
     androidTestImplementation ('org.assertj:assertj-core:1.7.1') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
@@ -130,7 +120,10 @@ android {
             abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
         }
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
+
+        // Suppress these two errors as I didn't find a way to fix them yet
+        testInstrumentationRunnerArgument 'androidx.benchmark.suppressErrors', 'ACTIVITY-MISSING,DEBUGGABLE'
     }
 
     compileOptions {
@@ -218,6 +211,8 @@ android {
             jniLibs.srcDirs = ['libs']
         }
         androidTest {
+            manifest.srcFile 'AndroidManifest.xml'
+            manifest.srcFile 'androidTest/AndroidManifest.xml'
             java.srcDirs = ['androidTest']
         }
     }


### PR DESCRIPTION
Here I tried to add benchmarks by following https://developer.android.com/studio/profile/benchmark.

The test compiles and starts, but it fails because of some warnings that it was not compiled in release mode and run with the AndroidJUnitRunner instead of AndroidBenchmarkRunner.

I neither succeeded in suppressing the warnings nor in following the advice the warnings gave me. The instructions were actually pretty specific, but when I followed them, nothing changed.