### PR TITLE
Fix: When returning to chat after blocking it, hide request buttons

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -272,8 +272,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } else if (isSharing(this)) {
       handleSharing();
     }
-
-    initializeContactRequest();
   }
 
   @Override
@@ -300,7 +298,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         initializeDraft();
       }
     });
-    initializeContactRequest();
 
     if (fragment != null) {
       fragment.onNewIntent();
@@ -968,6 +965,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
 
     setComposePanelVisibility();
+    initializeContactRequest();
   }
 
   private void setComposePanelVisibility() {
@@ -1552,9 +1550,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       titleView.setTitle(glideRequests, dcChat);
       initializeSecurity(isSecureText, isDefaultSms);
       setComposePanelVisibility();
-    }
-
-    if (eventId == DcContext.DC_EVENT_CHAT_MODIFIED && event.getData1Int() == chatId) {
       initializeContactRequest();
     }
   }


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to a contact request
- Go to the profile
- Block the contact
- Press back

Expected behavior: Only the compose panel is shown, not the request
buttons.
Actual behavior: Both the panel and the request buttons are shown
because the panel visibility is updated, but not the request button's.

I fixed this by always calling `initializeContactRequest()` after
`setComposePanelVisibility()`.