### PR TITLE
Fix: When blocking a contact from the profile, update the chatlist

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -107,6 +107,7 @@ public class ConversationListFragment extends Fragment
 
     DcEventCenter eventCenter = DcHelper.getEventCenter(getActivity());
     eventCenter.addObserver(DcContext.DC_EVENT_CHAT_MODIFIED, this);
+    eventCenter.addObserver(DcContext.DC_EVENT_CONTACTS_CHANGED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_INCOMING_MSG, this);
     eventCenter.addObserver(DcContext.DC_EVENT_MSGS_CHANGED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_MSGS_NOTICED, this);


### PR DESCRIPTION
Steps to reproduce:

- Go to the profile of a contact
- Block the contact
- Press back twice

Expected behavior: The chat is not shown in the list anymore.
Actual behavior: The chat is shown in the list until the app is
restarted (or if you wait some time)