### PR TITLE
Fix: When searching, entering an archived chat, and going back, go back to search

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -156,6 +156,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private static final String TAG = ConversationActivity.class.getSimpleName();
 
   public static final String CHAT_ID_EXTRA           = "chat_id";
+  public static final String FROM_ARCHIVED_CHATS_EXTRA = "from_archived";
   public static final String TEXT_EXTRA              = "draft_text";
   public static final String STARTING_POSITION_EXTRA = "starting_position";
 
@@ -616,7 +617,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       return;
     }
 
-    Intent intent = new Intent(this, (isArchived() ? ConversationListArchiveActivity.class : ConversationListActivity.class));
+    boolean archived = getIntent().getBooleanExtra(FROM_ARCHIVED_CHATS_EXTRA, false);
+    Intent intent = new Intent(this, (archived ? ConversationListArchiveActivity.class : ConversationListActivity.class));
     intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
     if (extras != null) intent.putExtras(extras);
     startActivity(intent);

--- a/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
@@ -8,6 +8,7 @@ import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
+import static org.thoughtcrime.securesms.ConversationActivity.FROM_ARCHIVED_CHATS_EXTRA;
 import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
@@ -71,6 +72,7 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
   public void onCreateConversation(int chatId) {
     Intent intent = new Intent(this, ConversationActivity.class);
     intent.putExtra(CHAT_ID_EXTRA, chatId);
+    intent.putExtra(FROM_ARCHIVED_CHATS_EXTRA, true);
     if (isRelayingMessageContent(this)) {
       acquireRelayMessageContent(this, intent);
       startActivityForResult(intent, REQUEST_RELAY);


### PR DESCRIPTION
Steps to reproduce the bug:
- Search and select an archived chat
- Press back

Expected: Go back to the search activity.
Actual: Go to the Archived chats list activity. The user has to press
"back" again to get to the search.