### PR TITLE
Remove RequiresApi(19) annotation on ScribbleActivity

### DIFF
--- a/src/org/thoughtcrime/securesms/scribbles/ScribbleActivity.java
+++ b/src/org/thoughtcrime/securesms/scribbles/ScribbleActivity.java
@@ -1,12 +1,10 @@
 package org.thoughtcrime.securesms.scribbles;
 
 import android.os.Bundle;
-import androidx.annotation.RequiresApi;
 
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity;
 import org.thoughtcrime.securesms.R;
 
-@RequiresApi(19)
 public class ScribbleActivity extends PassphraseRequiredActionBarActivity {
   public static final int SCRIBBLE_REQUEST_CODE       = 31424;
   ImageEditorFragment imageEditorFragment;


### PR DESCRIPTION
These annotations don't actually have an effect, but they lead to an
error (not a warning) being shown in Android Studio. It still compiles
fine, though.

The line `case ScribbleActivity.SCRIBBLE_REQUEST_CODE:` in
ConversationActivity was therefore shown as an error all the time, which
was really annoying.

The alternative would be to suppress the error in ConversationActivity.