### PR TITLE
Fix "Can't edit shared image"

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -429,6 +429,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       break;
     case ScribbleActivity.SCRIBBLE_REQUEST_CODE:
       setMedia(data.getData(), MediaType.IMAGE);
+      doReinitializeDraft = false;
       break;
     case SMS_DEFAULT:
       initializeSecurity(isSecureText, isDefaultSms);


### PR DESCRIPTION
Fix #2032

The problem was that after returning from the image editor, `doReinitializeDraft` was true and therefore we the draft was reinitialized to the originally shared, unedited image.

This was introduced in https://github.com/deltachat/deltachat-android/pull/1770. I im pretty sure that what I changed this time is fine, but I also was sure when implementing #1770…. We had so many regressions in the past in this area that we should thoroughly test this change before merging (and I'm really looking forward to UI tests in this area).

I extended
https://github.com/deltachat/interface/blob/master/user-testing/mailto-links.md
a bit; before merging this PR we should test that everything there still
works.