### PR TITLE
profile: show tab containing 'status' for device chat

### DIFF
--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -223,7 +223,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       }
     }
 
-    if(!isGlobalProfile() && !isSelfProfile() && !chatIsDeviceTalk && !chatIsMailingList) {
+    if(!isGlobalProfile() && !isSelfProfile() && !chatIsMailingList) {
       tabs.add(TAB_SETTINGS);
     }
     tabs.add(TAB_GALLERY);
@@ -329,7 +329,9 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       int tabId = tabs.get(position);
       switch(tabId) {
         case TAB_SETTINGS:
-          if(isContactProfile()) {
+          if (chatIsDeviceTalk) {
+            return getString(R.string.profile);
+          } else if(isContactProfile()) {
             return getString(R.string.tab_contact);
           }
           else if (chatIsMailingList) {

--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -291,17 +291,24 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
       }
     }
     else if (sharedChats!=null && dcContact!=null) {
+      boolean chatIsDeviceTalk = dcChat != null && dcChat.isDeviceTalk();
+
       itemDataContact = dcContact;
-      itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_CHAT, context.getString(R.string.send_message)));
+      if (!chatIsDeviceTalk) {
+        itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_CHAT, context.getString(R.string.send_message)));
+      }
 
       itemDataStatusText = dcContact.getStatus();
       if (!itemDataStatusText.isEmpty()) {
         itemData.add(new ItemData(ItemData.TYPE_STATUS, 0, itemDataStatusText));
       }
+
       itemDataSharedChats = sharedChats;
-      int sharedChatsCnt = sharedChats.getCnt();
-      for (int i = 0; i < sharedChatsCnt; i++) {
-        itemData.add(new ItemData(ItemData.TYPE_SHARED_CHAT, 0, i));
+      if (!chatIsDeviceTalk) {
+        int sharedChatsCnt = sharedChats.getCnt();
+        for (int i = 0; i < sharedChatsCnt; i++) {
+          itemData.add(new ItemData(ItemData.TYPE_SHARED_CHAT, 0, i));
+        }
       }
     }
 


### PR DESCRIPTION
the device chat's status contains some useful information
since https://github.com/deltachat/deltachat-core-rust/pull/2613 -
unfortunately, the whole tab was hidden on android.

reminder for myself, again: things are never easy, esp. not the superficial changes ;)

ios and desktop should be fine in this regard.

<img width=320 src=https://user-images.githubusercontent.com/9800740/130292216-9ed10fd0-6dd0-45a2-91bf-e4624e478617.png>

