### PR TITLE
prepare 1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Delta Chat Android Changelog
 
+## v1.22.1
+2021-08
+
+* update translations
+
+
 ## v1.22.0
 2021-08
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ android {
     }
 
     defaultConfig {
-        versionCode 612
-        versionName "1.22.0"
+        versionCode 613
+        versionName "1.22.1"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
1.22.1 just pulls in new translations - thanks for 9 quick translations of the device message, each for android and ios! - and will hopefully and finally go to the stores then.

