### PR TITLE
do not download large messages automatically

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -638,6 +638,12 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcContext_getMsgHtml(JNIEnv *env, jobj
 }
 
 
+JNIEXPORT void Java_com_b44t_messenger_DcContext_downloadFullMsg(JNIEnv *env, jobject obj, jint msg_id)
+{
+    dc_download_full_msg(get_dc_context(env, obj), msg_id);
+}
+
+
 JNIEXPORT void Java_com_b44t_messenger_DcContext_deleteMsgs(JNIEnv *env, jobject obj, jintArray msg_ids)
 {
     int msg_ids_cnt = 0;
@@ -1386,6 +1392,12 @@ JNIEXPORT jint Java_com_b44t_messenger_DcMsg_getType(JNIEnv *env, jobject obj)
 JNIEXPORT jint Java_com_b44t_messenger_DcMsg_getState(JNIEnv *env, jobject obj)
 {
     return dc_msg_get_state(get_dc_msg(env, obj));
+}
+
+
+JNIEXPORT jint Java_com_b44t_messenger_DcMsg_getDownloadState(JNIEnv *env, jobject obj)
+{
+    return dc_msg_get_download_state(get_dc_msg(env, obj));
 }
 
 

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -158,7 +158,7 @@
                 tools:text="Mango pickle lorem ipsum"/>
 
             <Button
-                android:id="@+id/show_full_message"
+                android:id="@+id/msg_action_button"
                 android:visibility="gone"
                 style="@style/Signal.Text.Body"
                 android:layout_width="wrap_content"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -136,7 +136,7 @@
                 tools:text="Mango pickle lorem ipsum"/>
 
             <Button
-                android:id="@+id/show_full_message"
+                android:id="@+id/msg_action_button"
                 android:visibility="gone"
                 style="@style/Signal.Text.Body"
                 android:layout_width="wrap_content"

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -309,4 +309,22 @@
         <item>OAuth2</item>
     </string-array>
 
+    <string-array name="pref_download_limit_entries">
+        <item>@string/no_limit</item>
+        <item>40 KiB</item>
+        <item>160 KiB</item>
+        <item>640 KiB</item>
+        <item>5 MiB</item>
+        <item>25 MiB</item>
+    </string-array>
+
+    <string-array name="pref_download_limit_values">
+        <item>0</item>        <!-- No Limit -->
+        <item>40960</item>    <!--  40 KiB, fine for text -->
+        <item>163840</item>   <!-- 160 KiB, fine for most worse-quality image -->
+        <item>655360</item>   <!-- 640 KiB, fine for most balanced-quality images -->
+        <item>5242880</item>  <!--   5 MiB, fine for many files, music and videos -->
+        <item>26214400</item> <!--  25 MiB, fine for most things send by delta -->
+    </string-array>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="automatic">Automatic</string>
     <string name="strict">Strict</string>
     <string name="open">Open</string>
+    <string name="download">Download</string>
     <string name="open_attachment">Open Attachment</string>
     <string name="join">Join</string>
     <string name="rejoin">Rejoin</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -582,6 +582,12 @@
     <string name="pref_background_custom_image">Custom image</string>
     <string name="pref_background_custom_color">Custom color</string>
     <string name="export_aborted">Export aborted.</string>
+    <string name="auto_download_messages">Auto-Download Messages</string>
+    <!-- %1$s will be replaced by a human-readable number of bytes, eg. 32 KiB, 1 MiB -->
+    <string name="up_to_x">Up to %1$s</string>
+    <string name="up_to_x_most_worse_quality_images">Up to %1$s, most worse quality images</string>
+    <string name="up_to_x_most_balanced_quality_images">Up to %1$s, most balanced quality images</string>
+    <string name="no_limit">No limit</string>
     <string name="profile_image_select">Select Profile Image</string>
     <string name="select_your_new_profile_image">Select your new profile image</string>
     <string name="profile_image_delete">Delete Profile Image</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -589,6 +589,10 @@
     <string name="up_to_x_most_worse_quality_images">Up to %1$s, most worse quality images</string>
     <string name="up_to_x_most_balanced_quality_images">Up to %1$s, most balanced quality images</string>
     <string name="no_limit">No limit</string>
+    <!-- %1$s will be replaced by a human-readable number of bytes, eg. 32 KiB, 1 MiB. Resulting string eg. "1 MiB message" -->
+    <string name="n_bytes_message">%1$s message</string>
+    <!-- %1$s will be replaced by human-readable date and time -->
+    <string name="download_max_available_until">Download maximum available until %1$s</string>
     <string name="profile_image_select">Select Profile Image</string>
     <string name="select_your_new_profile_image">Select your new profile image</string>
     <string name="profile_image_delete">Delete Profile Image</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="strict">Strict</string>
     <string name="open">Open</string>
     <string name="download">Download</string>
+    <string name="downloading">Downloading…</string>
     <string name="open_attachment">Open Attachment</string>
     <string name="join">Join</string>
     <string name="rejoin">Rejoin</string>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -34,6 +34,12 @@
         android:entryValues="@array/pref_compression_values"
         android:defaultValue="0" />
 
+    <ListPreference
+        android:key="auto_download"
+        android:title="@string/auto_download_messages"
+        android:entries="@array/pref_download_limit_entries"
+        android:entryValues="@array/pref_download_limit_values"/>
+
     <PreferenceCategory android:title="@string/delete_old_messages">
         <ListPreference
             android:key="autodel_device"

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -183,6 +183,7 @@ public class DcContext {
     public DcMsg               getMsg               (int msg_id) { return new DcMsg(getMsgCPtr(msg_id)); }
     public native String       getMsgInfo           (int id);
     public native String       getMsgHtml           (int msg_id);
+    public native void         downloadFullMsg      (int msg_id);
     public native int          getFreshMsgCount     (int chat_id);
     public native int          estimateDeletionCount(boolean from_server, long seconds);
     public native void         deleteMsgs           (int msg_ids[]);

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -26,6 +26,11 @@ public class DcMsg {
     public final static int DC_STATE_OUT_DELIVERED = 26;
     public final static int DC_STATE_OUT_MDN_RCVD = 28;
 
+    public final static int DC_DOWNLOAD_DONE = 0;
+    public final static int DC_DOWNLOAD_AVAILABLE = 10;
+    public final static int DC_DOWNLOAD_FAILURE = 20;
+    public final static int DC_DOWNLOAD_IN_PROGRESS = 1000;
+
     public static final int DC_MSG_NO_ID = 0;
     public final static int DC_MSG_ID_MARKER1 = 1;
     public final static int DC_MSG_ID_DAYMARKER = 9;
@@ -90,6 +95,7 @@ public class DcMsg {
     public native boolean hasLocation        ();
     public native int     getType            ();
     public native int     getState           ();
+    public native int     getDownloadState   ();
     public native int     getChatId          ();
     public native int     getFromId          ();
     public native int     getWidth           (int def);

--- a/src/org/thoughtcrime/securesms/BindableConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BindableConversationItem.java
@@ -29,5 +29,6 @@ public interface BindableConversationItem extends Unbindable {
   interface EventListener {
     void onQuoteClicked(DcMsg messageRecord);
     void onShowFullClicked(DcMsg messageRecord);
+    void onDownloadClicked(DcMsg messageRecord);
   }
 }

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -828,6 +828,11 @@ public class ConversationFragment extends MessageSelectorFragment
         startActivity(intent);
         getActivity().overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
       }
+
+      @Override
+      public void onDownloadClicked(DcMsg messageRecord) {
+        dcContext.downloadFullMsg(messageRecord.getId());
+      }
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -101,7 +101,7 @@ public class ConversationItem extends BaseConversationItem
   private   AvatarImageView        contactPhoto;
   protected ViewGroup              contactPhotoHolder;
   private   ViewGroup              container;
-  private   Button                 showFullMessage;
+  private   Button                 msgActionButton;
 
   private @NonNull  Recipient                       conversationRecipient;
   private @NonNull  Stub<ConversationItemThumbnail> mediaThumbnailStub;
@@ -144,7 +144,7 @@ public class ConversationItem extends BaseConversationItem
     this.quoteView               =            findViewById(R.id.quote_view);
     this.container               =            findViewById(R.id.container);
     this.replyView               =            findViewById(R.id.reply_icon);
-    this.showFullMessage         =            findViewById(R.id.show_full_message);
+    this.msgActionButton         =            findViewById(R.id.msg_action_button);
 
     setOnClickListener(new ClickListener(null));
 
@@ -343,9 +343,21 @@ public class ConversationItem extends BaseConversationItem
       bodyText.setVisibility(View.VISIBLE);
     }
 
-    if (messageRecord.hasHtml()) {
-      showFullMessage.setVisibility(View.VISIBLE);
-      showFullMessage.setOnClickListener(view -> {
+    if (messageRecord.getDownloadState() != DcMsg.DC_DOWNLOAD_DONE) {
+      msgActionButton.setVisibility(View.VISIBLE);
+      msgActionButton.setText(R.string.download);
+      msgActionButton.setOnClickListener(view -> {
+        if (eventListener != null && batchSelected.isEmpty()) {
+          eventListener.onDownloadClicked(messageRecord);
+        } else {
+          passthroughClickListener.onClick(view);
+        }
+      });
+    }
+    else if (messageRecord.hasHtml()) {
+      msgActionButton.setVisibility(View.VISIBLE);
+      msgActionButton.setText(R.string.show_full_message);
+      msgActionButton.setOnClickListener(view -> {
         if (eventListener != null && batchSelected.isEmpty()) {
           eventListener.onShowFullClicked(messageRecord);
         } else {
@@ -353,7 +365,7 @@ public class ConversationItem extends BaseConversationItem
         }
       });
     } else {
-      showFullMessage.setVisibility(View.GONE);
+      msgActionButton.setVisibility(View.GONE);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -343,9 +343,17 @@ public class ConversationItem extends BaseConversationItem
       bodyText.setVisibility(View.VISIBLE);
     }
 
-    if (messageRecord.getDownloadState() != DcMsg.DC_DOWNLOAD_DONE) {
+    int downloadState = messageRecord.getDownloadState();
+    if (downloadState != DcMsg.DC_DOWNLOAD_DONE) {
       msgActionButton.setVisibility(View.VISIBLE);
-      msgActionButton.setText(R.string.download);
+      if (downloadState==DcMsg.DC_DOWNLOAD_IN_PROGRESS) {
+        msgActionButton.setEnabled(false);
+        msgActionButton.setText(R.string.downloading);
+      } else {
+        msgActionButton.setEnabled(true);
+        msgActionButton.setText(R.string.download);
+      }
+
       msgActionButton.setOnClickListener(view -> {
         if (eventListener != null && batchSelected.isEmpty()) {
           eventListener.onDownloadClicked(messageRecord);
@@ -356,6 +364,7 @@ public class ConversationItem extends BaseConversationItem
     }
     else if (messageRecord.hasHtml()) {
       msgActionButton.setVisibility(View.VISIBLE);
+      msgActionButton.setEnabled(true);
       msgActionButton.setText(R.string.show_full_message);
       msgActionButton.setOnClickListener(view -> {
         if (eventListener != null && batchSelected.isEmpty()) {

--- a/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -88,7 +88,11 @@ public class ConversationItemFooter extends LinearLayout {
   }
 
   private void presentDeliveryStatus(@NonNull DcMsg messageRecord) {
-    if      (!messageRecord.isOutgoing())  deliveryStatusView.setNone();
+    // isDownloading is temporary and should be checked first.
+    boolean isDownloading = messageRecord.getDownloadState() == DcMsg.DC_DOWNLOAD_IN_PROGRESS;
+
+         if (isDownloading)                deliveryStatusView.setDownloading();
+    else if (!messageRecord.isOutgoing())  deliveryStatusView.setNone();
     else if (messageRecord.isRemoteRead()) deliveryStatusView.setRead();
     else if (messageRecord.isDelivered())  deliveryStatusView.setSent();
     else if (messageRecord.isFailed())     deliveryStatusView.setFailed();

--- a/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
+++ b/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
@@ -66,6 +66,13 @@ public class DeliveryStatusView {
     deliveryIndicator.clearAnimation();
   }
 
+  public void setDownloading() {
+    deliveryIndicator.setVisibility(View.VISIBLE);
+    deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sending);
+    deliveryIndicator.setContentDescription(context.getString(R.string.one_moment));
+    animatePrepare();
+  }
+
   public void setPreparing() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sending);

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -166,6 +166,8 @@ public class DcHelper {
     dcContext.setStockTranslation(95, context.getString(R.string.systemmsg_ephemeral_timer_days));
     dcContext.setStockTranslation(96, context.getString(R.string.systemmsg_ephemeral_timer_weeks));
     dcContext.setStockTranslation(97, context.getString(R.string.forwarded));
+    dcContext.setStockTranslation(99, context.getString(R.string.n_bytes_message));
+    dcContext.setStockTranslation(100, context.getString(R.string.download_max_available_until));
   }
 
   public static File getImexDir() {


### PR DESCRIPTION
this pr allows to not download large messages automatically

- by default, all messages are downloaded automatically, at "Settings / Chats and Media" is an option to set a limit.

- if a message exceeding the limit is received then, the message is assigned to the correct chat. however, instead of the message, just a placeholder text is shown (that should probably be tweaked a bit)

- the "Download" button then replaces the message with the real content.

- the pr requires the core branch [`draft-dl-ffi2`](https://github.com/deltachat/deltachat-core-rust/pull/2631) to be checked out

- there are tons of ideas how a preview can be achieved, and how media types may be detected, however, all of that is out of scope of this pr ;)

so, for testing, things should be fine, however, there are some open questions in the core, if they're solved. as a first step, maybe we can just add a limit for nauta and try out things there, cc @adbenitez 

some impressions:

<img width=250 src=https://user-images.githubusercontent.com/9800740/131874713-5d0b83f1-2dd6-4d7b-9f07-1a0b7ae58472.png> <img width=250 src=https://user-images.githubusercontent.com/9800740/131874720-aa194477-edf9-496b-a2e6-1b9e272a1139.png> <img width=250 src=https://user-images.githubusercontent.com/9800740/131254929-3bcd2947-8a7a-4ba0-8266-426db4514347.png>


https://user-images.githubusercontent.com/9800740/131254310-626dbead-fa38-4fb0-aa82-d92b2ee62dcc.mov






