### PR TITLE
allow to export all selected attachments

### DIFF
--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -30,7 +30,7 @@
         android:icon="?menu_forward_icon"
         app:showAsAction="always" />
 
-    <item android:title="@string/menu_export_attachment"
+    <item android:title="@string/menu_export_attachments"
         android:id="@+id/menu_context_save_attachment"
         android:visible="false"
         app:showAsAction="never" />

--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -17,7 +17,7 @@
         android:icon="@drawable/ic_share_white_24dp"
         app:showAsAction="ifRoom"/>
     <item android:id="@+id/save"
-          android:title="@string/menu_export_attachment"
+          android:title="@string/menu_export_attachments"
           app:showAsAction="never"/>
     <item android:id="@+id/media_preview__overview"
           android:title="@string/tab_gallery"

--- a/res/menu/profile_context.xml
+++ b/res/menu/profile_context.xml
@@ -20,6 +20,6 @@
         app:showAsAction="never"/>
 
     <item android:id="@+id/save"
-        android:title="@string/menu_export_attachment"
+        android:title="@string/menu_export_attachments"
         app:showAsAction="never"/>
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -195,6 +195,7 @@
     <string name="menu_mute">Mute Notifications</string>
     <string name="menu_unmute">Unmute</string>
     <string name="menu_export_attachment">Export Attachment</string>
+    <string name="menu_export_attachments">Export Attachments</string>
     <string name="menu_all_media">All Media</string>
     <!-- menu entry that opens eg. a gallery image or a document in the chat at the correct position -->
     <string name="show_in_chat">Show in Chat</string>
@@ -292,7 +293,7 @@
     </plurals>
     <string name="ask_forward">Forward messages to %1$s?</string>
     <string name="ask_forward_multiple">Forward messages to %1$d chats?</string>
-    <string name="ask_export_attachment">Export attachment? Exporting attachments will allow any other apps on your device to access them.\n\nContinue?</string>
+    <string name="ask_export_attachment">Exporting attachments will allow any other apps on your device to access them.\n\nContinue?</string>
     <string name="ask_block_contact">Block this contact? You will no longer receive messages from this contact.</string>
     <string name="ask_unblock_contact">Unblock this contact? You will once again be able to receive messages from this contact.</string>
     <string name="ask_delete_contacts">Delete contacts?\n\nContacts with ongoing chats and contacts from the system\'s address book cannot be deleted permanently.</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -317,7 +317,6 @@ public class ConversationFragment extends MessageSelectorFragment
         if (messageRecords.size() > 1) {
             menu.findItem(R.id.menu_context_details).setVisible(false);
             menu.findItem(R.id.menu_context_share).setVisible(false);
-            menu.findItem(R.id.menu_context_save_attachment).setVisible(false);
             menu.findItem(R.id.menu_context_reply).setVisible(false);
             menu.findItem(R.id.menu_context_reply_privately).setVisible(false);
         } else {
@@ -325,7 +324,6 @@ public class ConversationFragment extends MessageSelectorFragment
             DcChat chat = getListAdapter().getChat();
             menu.findItem(R.id.menu_context_details).setVisible(true);
             menu.findItem(R.id.menu_context_share).setVisible(messageRecord.hasFile());
-            menu.findItem(R.id.menu_context_save_attachment).setVisible(messageRecord.hasFile());
             boolean canReply = canReplyToMsg(messageRecord);
             menu.findItem(R.id.menu_context_reply).setVisible(chat.canSend() && canReply);
             boolean showReplyPrivately = chat.isGroup() && !messageRecord.isOutgoing() && canReply;
@@ -341,6 +339,16 @@ public class ConversationFragment extends MessageSelectorFragment
             }
         }
         menu.findItem(R.id.menu_context_forward).setVisible(canForward);
+
+        // if one of the selected items cannot be saved, disable saving.
+        boolean canSave = true;
+        for (DcMsg messageRecord : messageRecords) {
+            if (!messageRecord.hasFile()) {
+                canSave = false;
+                break;
+            }
+        }
+        menu.findItem(R.id.menu_context_save_attachment).setVisible(canSave);
     }
 
     static boolean canReplyToMsg(DcMsg dcMsg) {
@@ -894,7 +902,7 @@ public class ConversationFragment extends MessageSelectorFragment
                     actionMode.finish();
                     return true;
                 case R.id.menu_context_save_attachment:
-                    handleSaveAttachment(getSelectedMessageRecord(getListAdapter().getSelectedItems()));
+                    handleSaveAttachment(getListAdapter().getSelectedItems());
                     return true;
                 case R.id.menu_context_reply:
                     handleReplyMessage(getSelectedMessageRecord(getListAdapter().getSelectedItems()));

--- a/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -67,17 +67,22 @@ public abstract class MessageSelectorFragment
             .show();
   }
 
-  protected void handleSaveAttachment(final DcMsg message) {
+  protected void handleSaveAttachment(final Set<DcMsg> messageRecords) {
     SaveAttachmentTask.showWarningDialog(getContext(), (dialogInterface, i) -> {
         Permissions.with(getActivity())
                 .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
                 .ifNecessary()
                 .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
                 .onAllGranted(() -> {
-                    SaveAttachmentTask saveTask = new SaveAttachmentTask(getContext());
-                    SaveAttachmentTask.Attachment attachment = new SaveAttachmentTask.Attachment(
+                    SaveAttachmentTask.Attachment[] attachments = new SaveAttachmentTask.Attachment[messageRecords.size()];
+                    int index = 0;
+                    for (DcMsg message : messageRecords) {
+                        attachments[index] = new SaveAttachmentTask.Attachment(
                             Uri.fromFile(message.getFileAsFile()), message.getFilemime(), message.getDateReceived(), message.getFilename());
-                    saveTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, attachment);
+                        index++;
+                    }
+                    SaveAttachmentTask saveTask = new SaveAttachmentTask(getContext());
+                    saveTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, attachments);
                     if (actionMode != null) actionMode.finish();
                 })
                 .execute();

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -178,7 +178,6 @@ public class ProfileDocumentsFragment
     boolean singleSelection = messageRecords.size() == 1;
     menu.findItem(R.id.details).setVisible(singleSelection);
     menu.findItem(R.id.show_in_chat).setVisible(singleSelection);
-    menu.findItem(R.id.save).setVisible(singleSelection);
     menu.findItem(R.id.share).setVisible(singleSelection);
   }
 
@@ -227,7 +226,7 @@ public class ProfileDocumentsFragment
           handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
           return true;
         case R.id.save:
-          handleSaveAttachment(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+          handleSaveAttachment(getListAdapter().getSelectedMedia());
           return true;
       }
       return false;

--- a/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
@@ -191,7 +191,6 @@ public class ProfileGalleryFragment
     boolean singleSelection = messageRecords.size() == 1;
     menu.findItem(R.id.details).setVisible(singleSelection);
     menu.findItem(R.id.show_in_chat).setVisible(singleSelection);
-    menu.findItem(R.id.save).setVisible(singleSelection);
     menu.findItem(R.id.share).setVisible(singleSelection);
   }
 
@@ -240,7 +239,7 @@ public class ProfileGalleryFragment
           handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
           return true;
         case R.id.save:
-          handleSaveAttachment(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+          handleSaveAttachment(getListAdapter().getSelectedMedia());
           return true;
       }
       return false;


### PR DESCRIPTION
when selecting multiple messages that contain attachments, for example documents in the "Documents" tab, it was not possible to export all the selected attachments at the same time, user had to select & export one by one, this PR fixes this, allowing to export all selected messages if all of them have attachments