### PR TITLE
do not say, device-messages can be deleted from the server somehow

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -295,6 +295,10 @@
         <item quantity="one">Delete %d message here and on the server?</item>
         <item quantity="other">Delete %d messages here and on the server?</item>
     </plurals>
+    <plurals name="ask_delete_messages_simple">
+        <item quantity="one">Delete %d message?</item>
+        <item quantity="other">Delete %d messages?</item>
+    </plurals>
     <string name="ask_forward">Forward messages to %1$s?</string>
     <string name="ask_forward_multiple">Forward messages to %1$d chats?</string>
     <string name="ask_export_attachment">Exporting attachments will allow any other apps on your device to access them.\n\nContinue?</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -893,7 +893,7 @@ public class ConversationFragment extends MessageSelectorFragment
                     actionMode.finish();
                     return true;
                 case R.id.menu_context_delete_message:
-                    handleDeleteMessages(getListAdapter().getSelectedItems());
+                    handleDeleteMessages((int) chatId, getListAdapter().getSelectedItems());
                     return true;
                 case R.id.menu_context_share:
                     DcHelper.openForViewOrShare(getContext(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId(), Intent.ACTION_SEND);

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -53,6 +53,7 @@ import androidx.loader.content.Loader;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
+import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcMediaGalleryElement;
 import com.b44t.messenger.DcMsg;
@@ -342,17 +343,21 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
       return;
     }
 
+    DcMsg dcMsg = dcContext.getMsg(mediaItem.msgId);
+    DcChat dcChat = dcContext.getChat(dcMsg.getChatId());
+
+    String text = getResources().getQuantityString(
+      dcChat.isDeviceTalk()? R.plurals.ask_delete_messages_simple : R.plurals.ask_delete_messages,
+      1, 1);
+
     AlertDialog.Builder builder = new AlertDialog.Builder(this);
-    builder.setMessage(getResources().getQuantityString(R.plurals.ask_delete_messages, 1, 1));
+    builder.setMessage(text);
     builder.setCancelable(true);
 
     builder.setPositiveButton(R.string.delete, (dialogInterface, which) -> {
       new AsyncTask<Void, Void, Void>() {
         @Override
         protected Void doInBackground(Void... voids) {
-          if (mediaItem.msgId == DcMsg.DC_MSG_NO_ID) {
-            return null;
-          }
           dcContext.deleteMsgs(new int[]{mediaItem.msgId});
           return null;
         }

--- a/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ActionMode;
 import androidx.fragment.app.Fragment;
 
+import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcMsg;
 
@@ -52,11 +53,16 @@ public abstract class MessageSelectorFragment
     d.show();
   }
 
-  protected void handleDeleteMessages(final Set<DcMsg> messageRecords) {
+  protected void handleDeleteMessages(int chatId, final Set<DcMsg> messageRecords) {
     int messagesCount = messageRecords.size();
+    DcChat dcChat = DcHelper.getContext(getActivity()).getChat(chatId);
+
+    String text = getActivity().getResources().getQuantityString(
+      dcChat.isDeviceTalk()? R.plurals.ask_delete_messages_simple : R.plurals.ask_delete_messages,
+      messagesCount, messagesCount);
 
     new AlertDialog.Builder(getActivity())
-            .setMessage(getActivity().getResources().getQuantityString(R.plurals.ask_delete_messages, messagesCount, messagesCount))
+            .setMessage(text)
             .setCancelable(true)
             .setPositiveButton(R.string.delete, (dialog, which) -> {
                 int[] ids = DcMsg.msgSetToIds(messageRecords);

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -216,7 +216,7 @@ public class ProfileDocumentsFragment
           mode.finish();
           return true;
         case R.id.delete:
-          handleDeleteMessages(getListAdapter().getSelectedMedia());
+          handleDeleteMessages(chatId, getListAdapter().getSelectedMedia());
           mode.finish();
           return true;
         case R.id.share:

--- a/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
@@ -229,7 +229,7 @@ public class ProfileGalleryFragment
           mode.finish();
           return true;
         case R.id.delete:
-          handleDeleteMessages(getListAdapter().getSelectedMedia());
+          handleDeleteMessages(chatId, getListAdapter().getSelectedMedia());
           mode.finish();
           return true;
         case R.id.share:


### PR DESCRIPTION
it is a bit nitpicking and also a cornercase,
however, yes, it was not correct before.

another option would be to just strike the "... and on your server" which may lead to confusion also on other circumstances - eg. when auto-delete is set to "at once", there is nothing on the server. however, that may raise other issues, we added the "... and on your server" for some reasons, so, i would not change that without further investigations :) - therefore just this pr :)

closes #2058