### PR TITLE
broadcasts android ui

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -527,12 +527,9 @@ JNIEXPORT jint Java_com_b44t_messenger_DcContext_createGroupChat(JNIEnv *env, jo
 }
 
 
-JNIEXPORT jint Java_com_b44t_messenger_DcContext_createBroadcastList(JNIEnv *env, jobject obj, jstring name)
+JNIEXPORT jint Java_com_b44t_messenger_DcContext_createBroadcastList(JNIEnv *env, jobject obj)
 {
-    CHAR_REF(name);
-        jint ret = (jint)dc_create_broadcast_list(get_dc_context(env, obj), namePtr);
-    CHAR_UNREF(name);
-    return ret;
+    return (jint)dc_create_broadcast_list(get_dc_context(env, obj));
 }
 
 

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -527,6 +527,15 @@ JNIEXPORT jint Java_com_b44t_messenger_DcContext_createGroupChat(JNIEnv *env, jo
 }
 
 
+JNIEXPORT jint Java_com_b44t_messenger_DcContext_createBroadcastList(JNIEnv *env, jobject obj, jstring name)
+{
+    CHAR_REF(name);
+        jint ret = (jint)dc_create_broadcast_list(get_dc_context(env, obj), namePtr);
+    CHAR_UNREF(name);
+    return ret;
+}
+
+
 JNIEXPORT jboolean Java_com_b44t_messenger_DcContext_isContactInChat(JNIEnv *env, jobject obj, jint chat_id, jint contact_id)
 {
     return (jboolean)dc_is_contact_in_chat(get_dc_context(env, obj), chat_id, contact_id);

--- a/res/layout/group_create_activity.xml
+++ b/res/layout/group_create_activity.xml
@@ -7,6 +7,7 @@
               android:orientation="vertical">
 
     <LinearLayout
+        android:id="@+id/group_image_holder"
         android:layout_width="fill_parent"
         android:layout_height="106dp"
         android:paddingStart="14dp"
@@ -41,8 +42,9 @@
         android:gravity="start"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginTop="4dp"
-        android:layout_marginBottom="4dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:textSize="18sp"
         android:text="@string/verified_group_explain" />
 
     <LinearLayout

--- a/res/menu/profile_common.xml
+++ b/res/menu/profile_common.xml
@@ -2,7 +2,7 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item android:title="@string/menu_edit_name"
+    <item android:title="@string/global_menu_edit_desktop"
           android:id="@+id/edit_name"
           app:showAsAction="never"/>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -109,6 +109,10 @@
         <item quantity="one">%d member</item>
         <item quantity="other">%d members</item>
     </plurals>
+    <plurals name="n_recipients">
+        <item quantity="one">%d recipient</item>
+        <item quantity="other">%d recipients</item>
+    </plurals>
 
     <string name="self">Me</string>
     <string name="draft">Draft</string>
@@ -311,6 +315,8 @@
     <string name="ask_delete_value">Delete %s?</string>
     <!-- Translators: %1$s will be replaces by a comma separated list of names -->
     <string name="ask_remove_members">Remove %1$s from group?</string>
+    <!-- Translators: %1$s will be replaces by a comma separated list of names -->
+    <string name="ask_remove_recipients">Remove %1$s from broadcast list?</string>
     <string name="open_url_confirmation">Do you want to open this link?</string>
 
 
@@ -339,6 +345,7 @@
         <item quantity="other">%d new messages</item>
     </plurals>
     <string name="chat_no_messages_hint">Send message to %1$s:\n\n• It is okay if %2$s does not use Delta Chat.\n\n• Delivering the first message may take a while and may be unencrypted.</string>
+    <string name="chat_new_broadcast_hint">In a broadcast list, others will receive messages in their one to one chats with you.\n\nThe recipients will not be directly aware of each other.</string>
     <string name="chat_new_group_hint">Compose the first message, allowing others to reply within this group.\n\n• It is okay if not all members use Delta Chat.\n\n• Delivering the first message may take a while.</string>
     <string name="chat_record_slide_to_cancel">Slide to cancel</string>
     <string name="chat_record_explain">Tap and hold to record a voice message, release to send</string>
@@ -424,6 +431,9 @@
     <string name="tab_docs_empty_hint">Documents, music and other files shared in this chat will be displayed here.</string>
     <string name="media_preview">Media Preview</string>
     <string name="send_message">Send Message</string>
+    <string name="broadcast_list">Broadcast List</string>
+    <string name="new_broadcast_list">New Broadcast List</string>
+    <string name="add_recipients">Add Recipients</string>
 
 
     <!-- Connectivity -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -173,6 +173,10 @@
     <string name="menu_new_chat">New Chat</string>
     <string name="menu_new_group">New Group</string>
     <string name="menu_new_verified_group">New Verified Group</string>
+    <!-- consider keeping the term "broadcast"; check how these lists are called eg. on whatsapp in the destination language -->
+    <string name="broadcast_list">Broadcast List</string>
+    <string name="new_broadcast_list">New Broadcast List</string>
+    <string name="add_recipients">Add Recipients</string>
     <string name="menu_send">Send</string>
     <string name="menu_toggle_keyboard">Toggle Emoji Keyboard</string>
     <string name="menu_edit_group">Edit Group</string>
@@ -316,7 +320,7 @@
     <!-- Translators: %1$s will be replaces by a comma separated list of names -->
     <string name="ask_remove_members">Remove %1$s from group?</string>
     <!-- Translators: %1$s will be replaced by a comma separated list of names -->
-    <string name="ask_remove_recipients">Remove %1$s from broadcast list?</string>
+    <string name="ask_remove_from_broadcast">Remove %1$s from broadcast list?</string>
     <string name="open_url_confirmation">Do you want to open this link?</string>
 
 
@@ -431,9 +435,6 @@
     <string name="tab_docs_empty_hint">Documents, music and other files shared in this chat will be displayed here.</string>
     <string name="media_preview">Media Preview</string>
     <string name="send_message">Send Message</string>
-    <string name="broadcast_list">Broadcast List</string>
-    <string name="new_broadcast_list">New Broadcast List</string>
-    <string name="add_recipients">Add Recipients</string>
 
 
     <!-- Connectivity -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -345,7 +345,7 @@
         <item quantity="other">%d new messages</item>
     </plurals>
     <string name="chat_no_messages_hint">Send message to %1$s:\n\n• It is okay if %2$s does not use Delta Chat.\n\n• Delivering the first message may take a while and may be unencrypted.</string>
-    <string name="chat_new_broadcast_hint">In a broadcast list, others will receive messages in their one to one chats with you.\n\nThe recipients will not be directly aware of each other.</string>
+    <string name="chat_new_broadcast_hint">In a broadcast list, others will receive messages in their private chats with you.\n\nThe recipients will not be aware of each other.</string>
     <string name="chat_new_group_hint">Compose the first message, allowing others to reply within this group.\n\n• It is okay if not all members use Delta Chat.\n\n• Delivering the first message may take a while.</string>
     <string name="chat_record_slide_to_cancel">Slide to cancel</string>
     <string name="chat_record_explain">Tap and hold to record a voice message, release to send</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -315,7 +315,7 @@
     <string name="ask_delete_value">Delete %s?</string>
     <!-- Translators: %1$s will be replaces by a comma separated list of names -->
     <string name="ask_remove_members">Remove %1$s from group?</string>
-    <!-- Translators: %1$s will be replaces by a comma separated list of names -->
+    <!-- Translators: %1$s will be replaced by a comma separated list of names -->
     <string name="ask_remove_recipients">Remove %1$s from broadcast list?</string>
     <string name="open_url_confirmation">Do you want to open this link?</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="menu_new_verified_group">New Verified Group</string>
     <!-- consider keeping the term "broadcast"; check how these lists are called eg. on whatsapp in the destination language -->
     <string name="broadcast_list">Broadcast List</string>
+    <string name="broadcast_lists">Broadcast Lists</string>
     <string name="new_broadcast_list">New Broadcast List</string>
     <string name="add_recipients">Add Recipients</string>
     <string name="menu_send">Send</string>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -68,6 +68,11 @@
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"
+            android:key="pref_new_broadcast_list"
+            android:title="@string/new_broadcast_list"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
             android:key="pref_location_streaming_enabled"
             android:title="@string/pref_on_demand_location_streaming"/>
 

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -69,7 +69,7 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="pref_new_broadcast_list"
-            android:title="@string/new_broadcast_list"/>
+            android:title="@string/broadcast_lists"/>
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"

--- a/src/com/b44t/messenger/DcChat.java
+++ b/src/com/b44t/messenger/DcChat.java
@@ -6,6 +6,7 @@ public class DcChat {
     public static final int DC_CHAT_TYPE_SINGLE      = 100;
     public static final int DC_CHAT_TYPE_GROUP       = 120;
     public static final int DC_CHAT_TYPE_MAILINGLIST = 140;
+    public static final int DC_CHAT_TYPE_BROADCAST   = 160;
 
     public static final int DC_CHAT_NO_CHAT          = 0;
     public final static int DC_CHAT_ID_ARCHIVED_LINK = 6;

--- a/src/com/b44t/messenger/DcChat.java
+++ b/src/com/b44t/messenger/DcChat.java
@@ -49,11 +49,15 @@ public class DcChat {
       // isMultiUser() might fit better,
       // however, would result in lots of code changes, so we leave this as is for now.
       int type = getType();
-      return type == DC_CHAT_TYPE_GROUP || type == DC_CHAT_TYPE_MAILINGLIST;
+      return type == DC_CHAT_TYPE_GROUP || type == DC_CHAT_TYPE_MAILINGLIST || type == DC_CHAT_TYPE_BROADCAST;
     }
 
     public boolean isMailingList() {
         return getType() == DC_CHAT_TYPE_MAILINGLIST;
+    }
+
+    public boolean isBroadcast() {
+      return getType() == DC_CHAT_TYPE_BROADCAST;
     }
 
     public boolean canVideochat() {

--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -11,6 +11,7 @@ public class DcContact {
     public final static int DC_CONTACT_ID_NEW_VERIFIED_GROUP = -3; //      - " -
     public final static int DC_CONTACT_ID_ADD_MEMBER         = -4; //      - " -
     public final static int DC_CONTACT_ID_QR_INVITE          = -5; //      - " -
+    public final static int DC_CONTACT_ID_NEW_BROADCAST_LIST = -6; //      - " -
 
     public DcContact(long contactCPtr) {
         this.contactCPtr = contactCPtr;

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -161,6 +161,7 @@ public class DcContext {
     public native int          getChatIdByContactId (int contact_id);
     public native int          createChatByContactId(int contact_id);
     public native int          createGroupChat      (boolean verified, String name);
+    public native int          createBroadcastList  (String name);
     public native boolean      isContactInChat      (int chat_id, int contact_id);
     public native int          addContactToChat     (int chat_id, int contact_id);
     public native int          removeContactFromChat(int chat_id, int contact_id);

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -161,7 +161,7 @@ public class DcContext {
     public native int          getChatIdByContactId (int contact_id);
     public native int          createChatByContactId(int contact_id);
     public native int          createGroupChat      (boolean verified, String name);
-    public native int          createBroadcastList  (String name);
+    public native int          createBroadcastList  ();
     public native boolean      isContactInChat      (int chat_id, int contact_id);
     public native int          addContactToChat     (int chat_id, int contact_id);
     public native int          removeContactFromChat(int chat_id, int contact_id);

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -458,7 +458,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     inflater.inflate(R.menu.conversation, menu);
 
-    if (dcChat.isSelfTalk()) {
+    if (dcChat.isSelfTalk() || dcChat.isBroadcast()) {
       menu.findItem(R.id.menu_mute_notifications).setVisible(false);
     } else if(dcChat.isMuted()) {
       menu.findItem(R.id.menu_mute_notifications).setTitle(R.string.menu_unmute);
@@ -472,12 +472,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       menu.findItem(R.id.menu_videochat_invite).setVisible(false);
     }
 
-    if (!dcChat.canSend()) {
+    if (!dcChat.canSend() || dcChat.isBroadcast()) {
       menu.findItem(R.id.menu_ephemeral_messages).setVisible(false);
     }
 
     if (isGroupConversation()) {
-      if (dcChat.canSend()) { // If you can't send, then you can't leave the group
+      if (dcChat.canSend() && !dcChat.isBroadcast()) {
         inflater.inflate(R.menu.conversation_push_group_options, menu);
       }
     }

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -175,7 +175,9 @@ public class ConversationFragment extends MessageSelectorFragment
     private void setNoMessageText() {
         DcChat dcChat = getListAdapter().getChat();
         if(dcChat.isGroup()){
-            if(dcContext.getChat((int) chatId).isUnpromoted()) {
+            if (dcChat.isBroadcast()) {
+              noMessageTextView.setText(R.string.chat_new_broadcast_hint);
+            } else if (dcChat.isUnpromoted()) {
                 noMessageTextView.setText(R.string.chat_new_group_hint);
             }
             else {

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -72,6 +72,8 @@ public class ConversationTitleView extends RelativeLayout {
     int[] chatContacts = dcContext.getChatContacts(chatId);
     if (dcChat.isMailingList()) {
       subtitleStr = context.getString(R.string.mailing_list);
+    } else if (dcChat.isBroadcast()) {
+      subtitleStr = context.getResources().getQuantityString(R.plurals.n_recipients, chatContacts.length, chatContacts.length);
     } else if( dcChat.isGroup() ) {
       subtitleStr = context.getResources().getQuantityString(R.plurals.n_members, chatContacts.length, chatContacts.length);
     } else if( chatContacts.length>=1 ) {

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -15,12 +15,14 @@ import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.loader.app.LoaderManager;
 
+import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
@@ -62,6 +64,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
 
   public static final String EDIT_GROUP_CHAT_ID = "edit_group_chat_id";
   public static final String GROUP_CREATE_VERIFIED_EXTRA  = "group_create_verified";
+  public static final String CREATE_BROADCAST  = "group_create_broadcast";
 
   private final DynamicTheme    dynamicTheme    = new DynamicTheme();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -73,6 +76,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   private DcContext dcContext;
 
   private boolean verified;
+  private boolean      broadcast;
   private EditText     groupName;
   private ListView     lv;
   private ImageView    avatar;
@@ -95,6 +99,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     setContentView(R.layout.group_create_activity);
     //noinspection ConstantConditions
     verified = getIntent().getBooleanExtra(GROUP_CREATE_VERIFIED_EXTRA, false);
+    broadcast = getIntent().getBooleanExtra(CREATE_BROADCAST, false);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     getSupportActionBar().setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
 
@@ -106,6 +111,8 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     // so always check isEdit()
     if(groupChatId !=0) {
       isEdit = true;
+      DcChat dcChat = dcContext.getChat(groupChatId);
+      broadcast = dcChat.isBroadcast();
     }
 
     initializeExistingGroup();
@@ -137,7 +144,10 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
 
     String title;
     if(isEdit()) {
-      title = getString(R.string.menu_group_name_and_image);
+      title = getString(R.string.global_menu_edit_desktop);
+    }
+    else if(broadcast) {
+      title = getString(R.string.new_broadcast_list);
     }
     else if(verified) {
       title = getString(R.string.menu_new_verified_group);
@@ -203,12 +213,16 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void initializeResources() {
-    lv           = ViewUtil.findById(this, R.id.selected_contacts_list);
-    avatar       = ViewUtil.findById(this, R.id.avatar);
-    groupName    = ViewUtil.findById(this, R.id.group_name);
+    lv                  = ViewUtil.findById(this, R.id.selected_contacts_list);
+    avatar              = ViewUtil.findById(this, R.id.avatar);
+    groupName           = ViewUtil.findById(this, R.id.group_name);
+    TextView groupHints = ViewUtil.findById(this, R.id.group_hints);
+
     List<Recipient> initList = new LinkedList<>();
-    DcContact self = dcContext.getContact(DC_CONTACT_ID_SELF);
-    initList.add(new Recipient(this, self));
+    if (!broadcast) {
+      DcContact self = dcContext.getContact(DC_CONTACT_ID_SELF);
+      initList.add(new Recipient(this, self));
+    }
     SelectedRecipientsAdapter adapter = new SelectedRecipientsAdapter(this, initList);
     adapter.setOnRecipientDeletedListener(this);
     lv.setAdapter(adapter);
@@ -217,8 +231,17 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     ViewUtil.findById(this, R.id.verify_button).setOnClickListener(new ShowQrButtonListener());
     initializeAvatarView();
 
-    if (!verified) {
-      ViewUtil.findById(this, R.id.group_hints).setVisibility(View.GONE);
+    if (broadcast) {
+      ViewUtil.findById(this, R.id.group_image_holder).setVisibility(isEdit()? View.VISIBLE : View.GONE);
+      avatar.setVisibility(View.GONE);
+      groupName.setVisibility(isEdit()? View.VISIBLE : View.GONE);
+      groupName.setHint(R.string.name_desktop);
+      groupHints.setText(R.string.chat_new_broadcast_hint);
+      groupHints.setVisibility(isEdit()? View.GONE : View.VISIBLE);
+      ViewUtil.findById(this, R.id.verify_button).setVisibility(View.INVISIBLE);
+      ((TextView)ViewUtil.findById(this, R.id.add_member_button)).setText(R.string.add_recipients);
+    } else if (!verified) {
+      groupHints.setVisibility(View.GONE);
     }
 
     if(isEdit()) {
@@ -307,9 +330,16 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
 
   private void groupCreateInDb() {
     String groupName = getGroupName();
-    if (showGroupNameEmptyToast(groupName)) return;
 
-    groupChatId = dcContext.createGroupChat(verified, groupName);
+    if (broadcast) {
+      if (groupName == null) {
+        groupName = getString(R.string.broadcast_list);
+      }
+      groupChatId = dcContext.createBroadcastList(groupName);
+    } else {
+      if (showGroupNameEmptyToast(groupName)) return;
+      groupChatId = dcContext.createGroupChat(verified, groupName);
+    }
 
     Set<Recipient> recipients = getAdapter().getRecipients();
     for (Recipient recipient : recipients) {

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -329,14 +329,10 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void groupCreateInDb() {
-    String groupName = getGroupName();
-
     if (broadcast) {
-      if (groupName == null) {
-        groupName = getString(R.string.broadcast_list);
-      }
-      groupChatId = dcContext.createBroadcastList(groupName);
+      groupChatId = dcContext.createBroadcastList();
     } else {
+      String groupName = getGroupName();
       if (showGroupNameEmptyToast(groupName)) return;
       groupChatId = dcContext.createGroupChat(verified, groupName);
     }

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -143,6 +143,11 @@ public class NewConversationActivity extends ContactSelectionActivity {
       intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, specialId == DcContact.DC_CONTACT_ID_NEW_VERIFIED_GROUP);
       startActivity(intent);
       finish();
+    } else if(specialId == DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST) {
+      Intent intent = new Intent(this, GroupCreateActivity.class);
+      intent.putExtra(GroupCreateActivity.CREATE_BROADCAST, true);
+      startActivity(intent);
+      finish();
     }
     else {
       if(!dcContext.mayBeValidAddr(addr)) {

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -70,6 +70,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   private boolean              chatIsGroup;
   private boolean              chatIsDeviceTalk;
   private boolean              chatIsMailingList;
+  private boolean              chatIsBroadcast;
   private int                  contactId;
   private boolean              fromChat;
 
@@ -127,6 +128,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   public boolean onCreateOptionsMenu(Menu menu) {
     if (!isSelfProfile()) {
       getMenuInflater().inflate(R.menu.profile_common, menu);
+      boolean canReceive = true;
 
       if (chatId != 0) {
         if (chatIsDeviceTalk) {
@@ -134,10 +136,16 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
           menu.findItem(R.id.show_encr_info).setVisible(false);
           menu.findItem(R.id.copy_addr_to_clipboard).setVisible(false);
         } else if (chatIsGroup) {
-          menu.findItem(R.id.edit_name).setTitle(R.string.menu_group_name_and_image);
+          if (chatIsBroadcast) {
+            canReceive = false;
+          }
           menu.findItem(R.id.copy_addr_to_clipboard).setVisible(false);
         }
       } else {
+        canReceive = false;
+      }
+
+      if (!canReceive) {
         menu.findItem(R.id.menu_mute_notifications).setVisible(false);
         menu.findItem(R.id.menu_sound).setVisible(false);
         menu.findItem(R.id.menu_vibrate).setVisible(false);
@@ -207,6 +215,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     chatIsGroup      = false;
     chatIsDeviceTalk = false;
     chatIsMailingList= false;
+    chatIsBroadcast  = false;
     fromChat         = getIntent().getBooleanExtra(FROM_CHAT, false);
 
     if (contactId!=0) {
@@ -217,6 +226,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       chatIsGroup = dcChat.isGroup();
       chatIsDeviceTalk = dcChat.isDeviceTalk();
       chatIsMailingList = dcChat.isMailingList();
+      chatIsBroadcast = dcChat.isBroadcast();
       if(!chatIsGroup) {
         final int[] members = dcContext.getChatContacts(chatId);
         contactId = members.length>=1? members[0] : 0;
@@ -333,6 +343,9 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
             return getString(R.string.profile);
           } else if(isContactProfile()) {
             return getString(R.string.tab_contact);
+          }
+          else if (chatIsBroadcast) {
+            return getString(R.string.broadcast_list);
           }
           else if (chatIsMailingList) {
             return getString(R.string.mailing_list);

--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -43,6 +43,7 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
   private DcContact                           itemDataContact;
   private String                              itemDataStatusText;
   private boolean                             isMailingList;
+  private boolean                             isBroadcast;
   private final Set<Integer>                  selectedMembers;
 
   private final LayoutInflater                layoutInflater;
@@ -146,7 +147,11 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
       String addr = null;
 
       if (contactId == DcContact.DC_CONTACT_ID_ADD_MEMBER) {
-        name = context.getString(R.string.group_add_members);
+        if (isBroadcast) {
+          name = context.getString(R.string.add_recipients);
+        } else {
+          name = context.getString(R.string.group_add_members);
+        }
       }
       else if (contactId == DcContact.DC_CONTACT_ID_QR_INVITE) {
         name = context.getString(R.string.qrshow_title);
@@ -219,6 +224,8 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
       case ItemData.TYPE_MEMBER:
         if (isMailingList) {
           txt = context.getString(R.string.contacts_headline);
+        } else if (isBroadcast) {
+          txt = context.getResources().getQuantityString(R.plurals.n_recipients, (int) itemDataMemberCount, (int) itemDataMemberCount);
         } else {
           txt = context.getResources().getQuantityString(R.plurals.n_members, (int) itemDataMemberCount, (int) itemDataMemberCount);
         }
@@ -277,15 +284,23 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
     itemDataContact = null;
     itemDataStatusText = "";
     isMailingList = false;
+    isBroadcast = false;
 
     if (memberList!=null) {
       itemDataMemberCount = memberList.length;
+      if (dcChat.isBroadcast()) {
+        isBroadcast = true;
+      }
+
       if (dcChat.isMailingList()) {
         isMailingList = true;
       } else {
         itemData.add(new ItemData(ItemData.TYPE_MEMBER, DcContact.DC_CONTACT_ID_ADD_MEMBER, 0));
-        itemData.add(new ItemData(ItemData.TYPE_MEMBER, DcContact.DC_CONTACT_ID_QR_INVITE, 0));
+        if (!isBroadcast) {
+          itemData.add(new ItemData(ItemData.TYPE_MEMBER, DcContact.DC_CONTACT_ID_QR_INVITE, 0));
+        }
       }
+
       for (int value : memberList) {
         itemData.add(new ItemData(ItemData.TYPE_MEMBER, value, 0));
       }

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -290,7 +290,7 @@ public class ProfileSettingsFragment extends Fragment
                 mode.finish();
               })
               .setNegativeButton(android.R.string.cancel, null)
-              .setMessage(getString(dcChat.isBroadcast()? R.string.ask_remove_recipients : R.string.ask_remove_members, readableToDelList))
+              .setMessage(getString(dcChat.isBroadcast()? R.string.ask_remove_from_broadcast : R.string.ask_remove_members, readableToDelList))
               .show();
           return true;
       }

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -281,6 +281,7 @@ public class ProfileSettingsFragment extends Fragment
             }
             readableToDelList.append(dcContext.getContact(toDelId).getDisplayName());
           }
+          DcChat dcChat = dcContext.getChat(chatId);
           new AlertDialog.Builder(getContext())
               .setPositiveButton(android.R.string.ok, (dialog, which) -> {
                 for (Integer toDelId : toDelIds) {
@@ -289,7 +290,7 @@ public class ProfileSettingsFragment extends Fragment
                 mode.finish();
               })
               .setNegativeButton(android.R.string.cancel, null)
-              .setMessage(getString(R.string.ask_remove_members, readableToDelList))
+              .setMessage(getString(dcChat.isBroadcast()? R.string.ask_remove_recipients : R.string.ask_remove_members, readableToDelList))
               .show();
           return true;
       }

--- a/src/org/thoughtcrime/securesms/connect/DcContactsLoader.java
+++ b/src/org/thoughtcrime/securesms/connect/DcContactsLoader.java
@@ -45,10 +45,11 @@ public class DcContactsLoader extends AsyncLoader<DcContactsLoader.Ret> {
         }
         else if(addCreateGroupLinks) {
             // add "new group" and "new verified group" links
-            final int additional_items = 2; // if someone knows an easier way to prepend sth. to int[] please pr :)
+            final int additional_items = 3; // if someone knows an easier way to prepend sth. to int[] please pr :)
             int all_ids[] = new int[contact_ids.length+additional_items];
             all_ids[0] = DcContact.DC_CONTACT_ID_NEW_GROUP;
             all_ids[1] = DcContact.DC_CONTACT_ID_NEW_VERIFIED_GROUP;
+            all_ids[2] = DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST;
             for(int i=0; i<contact_ids.length; i++) {
                 all_ids[i+additional_items] = contact_ids[i];
             }

--- a/src/org/thoughtcrime/securesms/connect/DcContactsLoader.java
+++ b/src/org/thoughtcrime/securesms/connect/DcContactsLoader.java
@@ -7,6 +7,7 @@ import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.util.AsyncLoader;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 public class DcContactsLoader extends AsyncLoader<DcContactsLoader.Ret> {
@@ -45,11 +46,14 @@ public class DcContactsLoader extends AsyncLoader<DcContactsLoader.Ret> {
         }
         else if(addCreateGroupLinks) {
             // add "new group" and "new verified group" links
-            final int additional_items = 3; // if someone knows an easier way to prepend sth. to int[] please pr :)
+            final boolean broadcasts_enabled = Prefs.isNewBroadcastListAvailable(getContext());
+            final int additional_items = 2 + (broadcasts_enabled? 1 : 0); // if someone knows an easier way to prepend sth. to int[] please pr :)
             int all_ids[] = new int[contact_ids.length+additional_items];
             all_ids[0] = DcContact.DC_CONTACT_ID_NEW_GROUP;
             all_ids[1] = DcContact.DC_CONTACT_ID_NEW_VERIFIED_GROUP;
-            all_ids[2] = DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST;
+            if (broadcasts_enabled) {
+              all_ids[2] = DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST;
+            }
             for(int i=0; i<contact_ids.length; i++) {
                 all_ids[i+additional_items] = contact_ids[i];
             }

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -186,6 +186,7 @@ public class DcHelper {
     dcContext.setStockTranslation(112, context.getString(R.string.error_x));
     dcContext.setStockTranslation(113, context.getString(R.string.not_supported_by_provider));
     dcContext.setStockTranslation(114, context.getString(R.string.messages));
+    dcContext.setStockTranslation(116, context.getString(R.string.broadcast_list));
   }
 
   public static File getImexDir() {

--- a/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
@@ -297,6 +297,8 @@ public class ContactSelectionListAdapter extends RecyclerView.Adapter
       name = context.getString(R.string.menu_new_group);
     } else if (id == DcContact.DC_CONTACT_ID_NEW_VERIFIED_GROUP) {
       name = context.getString(R.string.menu_new_verified_group);
+    } else if (id == DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST) {
+      name = context.getString(R.string.new_broadcast_list);
     } else {
       dcContact = getContact(i);
       name = dcContact.getDisplayName();

--- a/src/org/thoughtcrime/securesms/contacts/ContactSelectionListItem.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactSelectionListItem.java
@@ -65,6 +65,7 @@ public class ContactSelectionListItem extends LinearLayout implements RecipientM
     this.number        = number;
 
     if (specialId==DcContact.DC_CONTACT_ID_NEW_CONTACT || specialId==DcContact.DC_CONTACT_ID_NEW_GROUP || specialId==DcContact.DC_CONTACT_ID_NEW_VERIFIED_GROUP
+     || specialId==DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST
      || specialId==DcContact.DC_CONTACT_ID_ADD_MEMBER || specialId==DcContact.DC_CONTACT_ID_QR_INVITE) {
       this.recipient = null;
     }

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -112,9 +112,9 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       if ((Boolean)newValue) {
         new AlertDialog.Builder(getActivity())
           .setTitle("Thanks for trying out \"Broadcast Lists\"!")
-          .setMessage("\uD83E\uDDEA You can now create new \"Broadcast Lists\" from the \"New Chat\" dialog\n\n"
-            + "\uD83E\uDDEA In case you are using more than one device, broadcast lists are currently not synced between them\n\n"
-            + "\uD83E\uDDEA If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\"")
+          .setMessage("• You can now create new \"Broadcast Lists\" from the \"New Chat\" dialog\n\n"
+            + "• In case you are using more than one device, broadcast lists are currently not synced between them\n\n"
+            + "• If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\"")
           .setCancelable(false)
           .setPositiveButton(R.string.ok, null)
           .show();
@@ -127,8 +127,8 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       if ((Boolean)newValue) {
         new AlertDialog.Builder(getActivity())
           .setTitle("Thanks for trying out \"Location Streaming\"!")
-          .setMessage("\uD83E\uDDEA You will find a corresponding option in the attach menu (the paper clip) of each chat now\n\n"
-            + "\uD83E\uDDEA If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\"")
+          .setMessage("• You will find a corresponding option in the attach menu (the paper clip) of each chat now\n\n"
+            + "• If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\"")
           .setCancelable(false)
           .setPositiveButton(R.string.ok, null)
           .show();

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -106,6 +106,35 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     Preference webrtcInstance = this.findPreference("pref_webrtc_instance");
     webrtcInstance.setOnPreferenceClickListener(new WebrtcInstanceListener());
     updateWebrtcSummary();
+
+    Preference newBroadcastList = this.findPreference("pref_new_broadcast_list");
+    newBroadcastList.setOnPreferenceChangeListener((preference, newValue) -> {
+      if ((Boolean)newValue) {
+        new AlertDialog.Builder(getActivity())
+          .setTitle("Thanks for trying out \"Broadcast Lists\"!")
+          .setMessage("\uD83E\uDDEA You can now create new \"Broadcast Lists\" from the \"New Chat\" dialog\n\n"
+            + "\uD83E\uDDEA In case you are using more than one device, broadcast lists are currently not synced between them\n\n"
+            + "\uD83E\uDDEA If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\"")
+          .setCancelable(false)
+          .setPositiveButton(R.string.ok, null)
+          .show();
+      }
+      return true;
+    });
+
+    Preference locationStreamingEnabled = this.findPreference("pref_location_streaming_enabled");
+    locationStreamingEnabled.setOnPreferenceChangeListener((preference, newValue) -> {
+      if ((Boolean)newValue) {
+        new AlertDialog.Builder(getActivity())
+          .setTitle("Thanks for trying out \"Location Streaming\"!")
+          .setMessage("\uD83E\uDDEA You will find a corresponding option in the attach menu (the paper clip) of each chat now\n\n"
+            + "\uD83E\uDDEA If you want to quit the experimental feature, you can disable it at \"Settings / Advanced\"")
+          .setCancelable(false)
+          .setPositiveButton(R.string.ok, null)
+          .show();
+      }
+      return true;
+    });
   }
 
   private boolean handleImapCheck(Preference preference, Object newValue, String dc_config_name) {

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -178,6 +178,10 @@ public class Prefs {
     }
   }
 
+  public static boolean isNewBroadcastListAvailable(Context context) {
+    return getBooleanPreference(context, "pref_new_broadcast_list", false);
+  }
+
   // ringtone
 
   public static @NonNull Uri getNotificationRingtone(Context context) {


### PR DESCRIPTION
**requires https://github.com/deltachat/deltachat-core-rust/pull/2707 to be merged first.** you'll also find much more background information there.

<img width="260" alt="Screen Shot 2021-09-27 at 10 52 08" src="https://user-images.githubusercontent.com/9800740/134877614-b2a949f8-f052-4c82-ab77-9a14a56b9df9.png"> <img width="260" alt="Screen Shot 2021-09-27 at 10 58 41" src="https://user-images.githubusercontent.com/9800740/134877597-aee846b5-9a19-413f-bea3-2cdea0da8402.png">  <img width="260" alt="Screen Shot 2021-09-27 at 10 54 45" src="https://user-images.githubusercontent.com/9800740/134877608-9ded0421-4382-4e45-88c7-eeddfdb93d33.png"> 


~~"profile" and "create" needs to get removed some more options, eg. qr-invite, mute, sound, disappearing-messages and much more does not make sense as nothing can be retrieved. also some more strings need adaption and a little help-text in the broadcast creation screen is also missing.~~ EDIT: done so far.

nb: we should really make the group-creation member/recipient list nicer, they lack the icons, in profile/edit this is much better). [this is an old issue](https://github.com/deltachat/deltachat-android/issues/456), however, and not related to this pr.