### PR TITLE
Fix back button not working in connectivity view sometimes

### DIFF
--- a/src/org/thoughtcrime/securesms/ConnectivityActivity.java
+++ b/src/org/thoughtcrime/securesms/ConnectivityActivity.java
@@ -15,6 +15,7 @@ public class ConnectivityActivity extends WebViewActivity implements DcEventCent
   @Override
   protected void onCreate(Bundle state, boolean ready) {
     super.onCreate(state, ready);
+    getSupportActionBar().setTitle(R.string.connectivity);
     refresh();
 
     DcHelper.getEventCenter(this).addObserver(DcContext.DC_EVENT_CONNECTIVITY_CHANGED, this);
@@ -33,8 +34,6 @@ public class ConnectivityActivity extends WebViewActivity implements DcEventCent
   }
 
   private void refresh() {
-    getSupportActionBar().setTitle(R.string.connectivity);
-
     String connectivityHtml = DcHelper.getContext(this).getConnectivityHtml();
     webView.loadDataWithBaseURL(null, connectivityHtml, "text/html", "utf-8", null);
   }
@@ -42,5 +41,12 @@ public class ConnectivityActivity extends WebViewActivity implements DcEventCent
   @Override
   public void handleEvent(@NonNull DcEvent event) {
     refresh();
+  }
+
+  @Override
+  public void onBackPressed() {
+    // If we did not override this function, the back button in the connectivity view would sometimes
+    // not work, probably because webView.canGoBack() in WebViewActivity.onBackPressed() wrongly returns true
+    finish();
   }
 }


### PR DESCRIPTION
I noticed that sometimes the system back button (the one in the lower
left) does not work in the connectivity view. The top bar back button
worked.

This should fix this.

Also, I moved `getSupportActionBar().setTitle(R.string.connectivity)` to onCreate(). It had been in refresh() so that the title could be set to "Connectivity | Connected", "Connectivity | Connecting" and so on. But as we decided not to do this, there is no reason for it to be in refresh().