### PR TITLE
Fix shared image being set as draft repeatedly

### DIFF
--- a/androidTest/com/b44t/messenger/SharingTest.java
+++ b/androidTest/com/b44t/messenger/SharingTest.java
@@ -2,6 +2,7 @@ package com.b44t.messenger;
 
 import android.content.ComponentName;
 import android.content.Intent;
+import android.net.Uri;
 
 import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
@@ -9,17 +10,23 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.ShareActivity;
 import org.thoughtcrime.securesms.connect.DcHelper;
 
+import java.io.File;
+
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -33,17 +40,22 @@ public class SharingTest {
   // PLEASE BACKUP YOUR ACCOUNT BEFORE RUNNING THIS!
   // ==============================================================================================
 
+  @SuppressWarnings("unused")
   private final static String TAG = SharingTest.class.getSimpleName();
+  private static int createdGroupId;
 
   @Rule
   public ActivityScenarioRule<ConversationListActivity> activityRule = TestUtils.getOfflineActivityRule();
 
+  @Before
+  public void createGroup() {
+    activityRule.getScenario().onActivity(a -> {
+      createdGroupId = DcHelper.getContext(a).createGroupChat(false, "group");
+    });
+  }
+
   @Test
   public void testNormalSharing() {
-    activityRule.getScenario().onActivity(a -> {
-      DcHelper.getContext(a).createGroupChat(false, "group");
-    });
-
     Intent i = new Intent(Intent.ACTION_SEND);
     i.putExtra(Intent.EXTRA_TEXT, "Hello!");
     i.setComponent(new ComponentName(getInstrumentation().getTargetContext().getApplicationContext(), ShareActivity.class));
@@ -53,6 +65,50 @@ public class SharingTest {
 
     onView(withHint(R.string.chat_input_placeholder)).check(matches(withText("Hello!")));
     TestUtils.pressSend();
+  }
+
+  /**
+   * Test direct sharing from a screenshot.
+   * Also, this is the regression test for https://github.com/deltachat/deltachat-android/issues/2040
+   * where network changes during sharing lead to
+   */
+  @Test
+  public void testShareFromScreenshot() {
+    DcContext dcContext = DcHelper.getContext(getInstrumentation().getTargetContext());
+    String[] files = new File(dcContext.getBlobdir()).list();
+    String pngImage = null;
+    assert files != null;
+    for (String file : files) {
+      if (file.endsWith(".png")) {
+        pngImage = file;
+      }
+    }
+    Uri uri = Uri.parse("content://" + BuildConfig.APPLICATION_ID + ".attachments/" + Uri.encode(pngImage));
+    DcHelper.sharedFiles.put("/" + pngImage, 1);
+
+    Intent i = new Intent(Intent.ACTION_SEND);
+    i.setType("image/png");
+    i.putExtra(Intent.EXTRA_SUBJECT, "Screenshot (Sep 27, 2021 00:00:00");
+    i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+            | Intent.FLAG_ACTIVITY_FORWARD_RESULT
+            | Intent.FLAG_ACTIVITY_PREVIOUS_IS_TOP
+            | Intent.FLAG_RECEIVER_FOREGROUND
+            | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    i.putExtra(Intent.EXTRA_STREAM, uri);
+    i.putExtra(ShareActivity.EXTRA_CHAT_ID, createdGroupId);
+    i.setComponent(new ComponentName(getInstrumentation().getTargetContext().getApplicationContext(), ShareActivity.class));
+    activityRule.getScenario().onActivity(a -> a.startActivity(i));
+
+    TestUtils.waitForView(withId(R.id.send_button), 10000, 50);
+
+    dcContext.maybeNetwork();
+    dcContext.maybeNetwork();
+    dcContext.maybeNetwork();
+
+    onView(withId(R.id.send_button)).perform(click());
+    pressBack();
+
+    onView(withId(R.id.fab)).check(matches(isClickable()));
   }
 
   // TODO test other things from https://github.com/deltachat/interface/blob/master/user-testing/mailto-links.md

--- a/androidTest/com/b44t/messenger/TestUtils.java
+++ b/androidTest/com/b44t/messenger/TestUtils.java
@@ -27,7 +27,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
-class TestUtils {
+public class TestUtils {
   private static int createdAccountId = 0;
   private static boolean resetEnterSends = false;
 
@@ -58,7 +58,7 @@ class TestUtils {
   }
 
   @NonNull
-  static ActivityScenarioRule<ConversationListActivity> getOfflineActivityRule() {
+  public static ActivityScenarioRule<ConversationListActivity> getOfflineActivityRule() {
     Intent intent =
             Intent.makeMainActivity(
                     new ComponentName(getInstrumentation().getTargetContext(), ConversationListActivity.class));

--- a/androidTest/com/b44t/messenger/TestUtils.java
+++ b/androidTest/com/b44t/messenger/TestUtils.java
@@ -1,5 +1,6 @@
 package com.b44t.messenger;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -62,8 +63,21 @@ public class TestUtils {
     Intent intent =
             Intent.makeMainActivity(
                     new ComponentName(getInstrumentation().getTargetContext(), ConversationListActivity.class));
-    TestUtils.createOfflineAccount();
+    createOfflineAccount();
+    prepare();
     return new ActivityScenarioRule<>(intent);
+  }
+
+  @NonNull
+  public static <T extends Activity> ActivityScenarioRule<T> getOnlineActivityRule(Class<T> activityClass) {
+    Context context = getInstrumentation().getTargetContext();
+    AccountManager.getInstance().beginAccountCreation(context);
+    prepare();
+    return new ActivityScenarioRule<>(new Intent(getInstrumentation().getTargetContext(), activityClass));
+  }
+
+  private static void prepare() {
+    Prefs.setBooleanPreference(getInstrumentation().getTargetContext(), Prefs.DOZE_ASKED_DIRECTLY, true);
   }
 
   /**
@@ -71,7 +85,7 @@ public class TestUtils {
    *
    * @param matcher Generic Matcher used to find our view
    */
-  static ViewAction searchFor(Matcher<View> matcher) {
+  private static ViewAction searchFor(Matcher<View> matcher) {
     return new ViewAction() {
 
       public Matcher<View> getConstraints() {

--- a/androidTest/com/b44t/messenger/TestUtils.java
+++ b/androidTest/com/b44t/messenger/TestUtils.java
@@ -156,6 +156,6 @@ class TestUtils {
       resetEnterSends = true;
       Prefs.setEnterSendsEnabled(getInstrumentation().getTargetContext(), true);
     }
-    onView(withHint(R.string.chat_input_placeholder)).perform(typeText("\n"));
+    waitForView(withHint(R.string.chat_input_placeholder), 10000, 100).perform(typeText("\n"));
   }
 }

--- a/androidTest/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
+++ b/androidTest/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
@@ -1,4 +1,4 @@
-package com.b44t.messenger;
+package com.b44t.messenger.uibenchmarks;
 
 import android.util.Log;
 
@@ -6,6 +6,8 @@ import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
+
+import com.b44t.messenger.TestUtils;
 
 import org.junit.After;
 import org.junit.Rule;

--- a/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
@@ -1,4 +1,4 @@
-package com.b44t.messenger;
+package com.b44t.messenger.uitests.offline;
 
 import android.content.ComponentName;
 import android.content.Intent;
@@ -8,6 +8,9 @@ import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
+
+import com.b44t.messenger.DcContext;
+import com.b44t.messenger.TestUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -49,9 +52,7 @@ public class SharingTest {
 
   @Before
   public void createGroup() {
-    activityRule.getScenario().onActivity(a -> {
-      createdGroupId = DcHelper.getContext(a).createGroupChat(false, "group");
-    });
+    activityRule.getScenario().onActivity(a -> createdGroupId = DcHelper.getContext(a).createGroupChat(false, "group"));
   }
 
   @Test

--- a/androidTest/com/b44t/messenger/uitests/online/OnboardingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/online/OnboardingTest.java
@@ -1,8 +1,6 @@
 package com.b44t.messenger.uitests.online;
 
 
-import android.content.Context;
-import android.content.Intent;
 import android.text.TextUtils;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
@@ -18,7 +16,6 @@ import org.junit.runner.RunWith;
 import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.WelcomeActivity;
-import org.thoughtcrime.securesms.connect.AccountManager;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -28,19 +25,12 @@ import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class OnboardingTest {
   @Rule
-  public ActivityScenarioRule<WelcomeActivity> activityRule = new ActivityScenarioRule<>(getIntent());
-
-  private Intent getIntent() {
-    Context context = getInstrumentation().getTargetContext();
-    AccountManager.getInstance().beginAccountCreation(context);
-    return new Intent(getInstrumentation().getTargetContext(), WelcomeActivity.class);
-  }
+  public ActivityScenarioRule<WelcomeActivity> activityRule = TestUtils.getOnlineActivityRule(WelcomeActivity.class);
 
   @Test
   public void testAccountCreation() {

--- a/androidTest/com/b44t/messenger/uitests/online/OnboardingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/online/OnboardingTest.java
@@ -1,4 +1,4 @@
-package com.b44t.messenger;
+package com.b44t.messenger.uitests.online;
 
 
 import android.content.Context;
@@ -8,6 +8,8 @@ import android.text.TextUtils;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
+
+import com.b44t.messenger.TestUtils;
 
 import org.junit.After;
 import org.junit.Rule;

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -126,6 +126,10 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     refreshTitle();
     handleOpenpgp4fpr();
 
+    if (isDirectSharing(this)) {
+      openConversation(getDirectSharingChatId(this), -1);
+    }
+
     if (getIntent().getBooleanExtra(CLEAR_NOTIFICATIONS, false)) {
       DcHelper.getNotificationCenter(this).removeAllNotifiations();
     }
@@ -135,9 +139,6 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     if (isRelayingMessageContent(this)) {
       title.setText(isForwarding(this) ? R.string.forward_to : R.string.chat_share_with_title);
       getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-      if (isDirectSharing(this)) {
-        openConversation(getDirectSharingChatId(this), -1);
-      }
     } else {
       title.setText(DcHelper.getConnectivitySummary(this, R.string.app_name));
       getSupportActionBar().setDisplayHomeAsUpEnabled(false);

--- a/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
+++ b/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
@@ -1,7 +1,6 @@
 package org.thoughtcrime.securesms.components;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.LinearInterpolator;
@@ -112,7 +111,6 @@ public class DeliveryStatusView {
     if (color != null) {
       deliveryIndicator.setColorFilter(color);
     } else {
-      Log.w("dbg", "reset tint, color " + color);
       resetTint();
     }
   }


### PR DESCRIPTION
To be reviewed commit-by-commit.

#2031 has to be merged first.

Fix #2040

The problem was that 

      if (isDirectSharing(this)) {
        openConversation(getDirectSharingChatId(this), -1);
      }

was called in refreshTitle(). But refreshTitle() is also called everytime the connectivity changes, so everytime the connectivity changes a new instance of ConversationActivity was opened.

The last three commits are actually independent (but I think uncontroversial) improvements, if you want I can also make a separate PR for this.