### PR TITLE
add usage string for connectivity view

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -459,6 +459,8 @@
     <string name="not_supported_by_provider">Not supported by your provider.</string>
     <!-- Used as a subtitle in quota context of "Connetivity" view. Should be be plural always, no number is prefixed or so. -->
     <string name="messages">Messages</string>
+    <!-- Used for describing resource usage, resulting string will be eg. "1.2 GiB of 3 GiB used" -->
+    <string name="part_of_total_used">%1$s of %2$s used</string>
 
 
     <!-- welcome and login -->

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -186,7 +186,8 @@ public class DcHelper {
     dcContext.setStockTranslation(112, context.getString(R.string.error_x));
     dcContext.setStockTranslation(113, context.getString(R.string.not_supported_by_provider));
     dcContext.setStockTranslation(114, context.getString(R.string.messages));
-    dcContext.setStockTranslation(116, context.getString(R.string.broadcast_list));
+    dcContext.setStockTranslation(115, context.getString(R.string.broadcast_list));
+    dcContext.setStockTranslation(116, context.getString(R.string.part_of_total_used));
   }
 
   public static File getImexDir() {


### PR DESCRIPTION
moreover, fix the id used for 'Broadcast List' (116 was just wrong here) (some script for extracting things from deltachat.h would avoid these errors, however, we did not really have problems with that yet - even that one would not have been a serious bug when released)