### PR TITLE
hidde keyboard when compose panel is hidden

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -972,7 +972,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void setComposePanelVisibility() {
-    composePanel.setVisibility(dcChat.canSend() ? View.VISIBLE : View.GONE);
+    if (dcChat.canSend()) {
+      composePanel.setVisibility(View.VISIBLE);
+    } else {
+      composePanel.setVisibility(View.GONE);
+      hideSoftKeyboard();
+    }
   }
 
   //////// Helper Methods


### PR DESCRIPTION
when leaving a group, the compose panel is hidden but the keyboard or emoji picker keeps open, this pull request fix that