### PR TITLE
simpler account switching

### DIFF
--- a/src/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
@@ -16,7 +16,6 @@ import com.b44t.messenger.DcAccounts;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.AccountManager;
-import org.thoughtcrime.securesms.connect.AccountManager.SwitchAccountAsyncTask;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -74,9 +73,9 @@ public class AccountSelectionListFragment extends DialogFragment
       AccountSelectionListFragment.this.dismiss();
       int accountId = contact.getAccountId();
       if (accountId == DC_CONTACT_ID_ADD_ACCOUNT) {
-        new SwitchAccountAsyncTask(activity, R.string.one_moment, 0, null).execute();
+        AccountManager.getInstance().switchAccountAndStartActivity(activity, 0, null);
       } else if (accountId != DcHelper.getAccounts(activity).getSelectedAccount().getAccountId()) {
-        new SwitchAccountAsyncTask(activity, R.string.switching_account, accountId, null).execute();
+        AccountManager.getInstance().switchAccountAndStartActivity(activity, accountId, null);
       }
     }
 

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -102,51 +102,25 @@ public class AccountManager {
           accounts.removeAccount(selectedAccount.getAccountId());
         }
 
-        new SwitchAccountAsyncTask(activity, R.string.switching_account, accounts.getSelectedAccount().getAccountId(), null).execute();
+        switchAccountAndStartActivity(activity, accounts.getSelectedAccount().getAccountId(), null);
     }
 
-
-    // helper class for switching accounts gracefully
-
-    public static class SwitchAccountAsyncTask extends ProgressDialogAsyncTask<Void, Void, Void> {
-        private final WeakReference<Activity> activityWeakReference;
-        private final int destAccountId; // 0 creates a new account
-        private final @Nullable String qrAccount;
-
-        public SwitchAccountAsyncTask(Activity activity, int title, int destAccountId, @Nullable String qrAccount) {
-            super(activity, null, activity.getString(title));
-            this.activityWeakReference = new WeakReference<>(activity);
-            this.destAccountId = destAccountId;
-            this.qrAccount = qrAccount;
-        }
-        @Override
-        protected Void doInBackground(Void... voids) {
-            Activity activity = activityWeakReference.get();
-            if (activity!=null) {
-                if (destAccountId==0) {
-                    AccountManager.getInstance().beginAccountCreation(activity);
-                } else {
-                    AccountManager.getInstance().switchAccount(activity, destAccountId);
-                }
-            }
-            return null;
+    public void switchAccountAndStartActivity(Activity activity, int destAccountId, @Nullable String qrAccount) {
+        if (destAccountId==0) {
+            beginAccountCreation(activity);
+        } else {
+            switchAccount(activity, destAccountId);
         }
 
-        @Override
-        protected void onPostExecute(Void result) {
-            Activity activity = activityWeakReference.get();
-            if (activity!=null) {
-                activity.finishAffinity();
-                if (destAccountId==0) {
-                    Intent intent = new Intent(activity, WelcomeActivity.class);
-                    if (qrAccount!=null) {
-                        intent.putExtra(WelcomeActivity.QR_ACCOUNT_EXTRA, qrAccount);
-                    }
-                    activity.startActivity(intent);
-                } else {
-                    activity.startActivity(new Intent(activity.getApplicationContext(), ConversationListActivity.class));
-                }
+        activity.finishAffinity();
+        if (destAccountId==0) {
+            Intent intent = new Intent(activity, WelcomeActivity.class);
+            if (qrAccount!=null) {
+                intent.putExtra(WelcomeActivity.QR_ACCOUNT_EXTRA, qrAccount);
             }
+            activity.startActivity(intent);
+        } else {
+            activity.startActivity(new Intent(activity.getApplicationContext(), ConversationListActivity.class));
         }
     }
 
@@ -158,6 +132,6 @@ public class AccountManager {
     }
 
     public void addAccountFromQr(Activity activity, String qr) {
-        new SwitchAccountAsyncTask(activity, R.string.one_moment, 0, qr).execute();
+        switchAccountAndStartActivity(activity, 0, qr);
     }
 }


### PR DESCRIPTION
remove the "progress" dialog that shows up for a fraction of a second.
as all accounts are already in memory since the switch to dc_accounts_t,
there is nothing that can take so much time to satisfy a "wait" dialog.

the switching is now at least visually nicer -
however, due to less task switching and less code,
it should also be a bit faster.

note: can someone test burner accounts? i do not have a device able to scan accounts (the one i have has an outdated root certificate and [cannot use testrun burner accounts](https://github.com/deltachat/deltachat-core-rust/issues/2748))