### PR TITLE
use Dismiss instead of Mark as Read in notification action

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -791,6 +791,7 @@
 
     <!-- notifications  -->
     <string name="notify_n_messages_in_m_chats">%1$d new messages in %2$d chats</string>
+    <string name="notify_dismiss">Dismiss</string>
     <string name="notify_mark_read">Mark Read</string>
     <string name="notify_reply_button">Reply</string>
     <string name="notify_new_message">New message</string>

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -428,7 +428,7 @@ public class NotificationCenter {
                     PendingIntent markReadIntent = getMarkAsReadIntent(chatId, true);
 
                     NotificationCompat.Action markAsReadAction = new NotificationCompat.Action(R.drawable.check,
-                            context.getString(R.string.notify_mark_read),
+                            context.getString(R.string.notify_dismiss),
                             markReadIntent);
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {


### PR DESCRIPTION
"mark as read" leads to users assuming the message will be marked as seen and a read receipt will be sent