### PR TITLE
check can_send() on tapping avatar

### DIFF
--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -492,12 +492,15 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
   private void onEditName() {
     if (chatIsMultiUser) {
-      Intent intent = new Intent(this, GroupCreateActivity.class);
-      intent.putExtra(GroupCreateActivity.EDIT_GROUP_CHAT_ID, chatId);
-      if (dcContext.getChat(chatId).isProtected()) {
-        intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, true);
+      DcChat dcChat = dcContext.getChat(chatId);
+      if (chatIsMailingList || dcChat.canSend()) {
+        Intent intent = new Intent(this, GroupCreateActivity.class);
+        intent.putExtra(GroupCreateActivity.EDIT_GROUP_CHAT_ID, chatId);
+        if (dcChat.isProtected()) {
+          intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, true);
+        }
+        startActivity(intent);
       }
-      startActivity(intent);
     }
     else {
       DcContact dcContact = dcContext.getContact(contactId);


### PR DESCRIPTION
editing name/avatar is only possible when one can send to a chat;
for the menu entry, this is already checked (the menu entry is hidden then),
but it was forgotten on avatar tapping.