### PR TITLE
Target SDK/API 30

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -45,7 +45,6 @@
                  android:theme="@style/TextSecure.LightTheme"
                  android:largeHeap="true"
                  tools:ignore="GoogleAppIndexingWarning"
-                 android:requestLegacyExternalStorage="true"
         >
 
     <!-- android car support, see https://developer.android.com/training/auto/start/,

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -122,10 +122,14 @@
             <category android:name="android.intent.category.BROWSABLE"/>
             <!-- Android's scheme matcher is case-sensitive, so include most likely variations -->
             <data android:scheme="openpgp4fpr" />
-            <data android:scheme="OPENPGP4FPR" />
-            <data android:scheme="OpenPGP4FPR" />
-            <data android:scheme="OpenPGP4Fpr" />
-            <data android:scheme="OpenPGP4fpr" />
+            <data android:scheme="OPENPGP4FPR"
+                tools:ignore="AppLinkUrlError" />
+            <data android:scheme="OpenPGP4FPR"
+                tools:ignore="AppLinkUrlError" />
+            <data android:scheme="OpenPGP4Fpr"
+                tools:ignore="AppLinkUrlError" />
+            <data android:scheme="OpenPGP4fpr"
+                tools:ignore="AppLinkUrlError" />
         </intent-filter>
 
         <meta-data android:name="com.sec.minimode.icon.portrait.normal"
@@ -344,6 +348,11 @@
     <meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_H" android:value="598.0dip" />
     <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_W" android:value="632.0dip" />
     <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_H" android:value="598.0dip" />
-
 </application>
+
+<queries>
+    <intent>
+        <action android:name="android.media.action.IMAGE_CAPTURE" />
+    </intent>
+</queries>
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:7.0.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
 
 android {
     flavorDimensions "none"
-    compileSdkVersion 29
+    compileSdkVersion 30
     useLibrary 'org.apache.http.legacy'
 
     dexOptions {
@@ -106,7 +106,7 @@ android {
         multiDexEnabled true
 
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
 
         vectorDrawables.useSupportLibrary = true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4608m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 09 18:28:04 CEST 2019
+#Wed Oct 27 11:37:14 CEST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -26,10 +26,8 @@ import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.PowerManager;
-
-import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.TypedValue;
@@ -38,14 +36,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.database.NoExternalStorageException;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Scrubber;
-import org.thoughtcrime.securesms.util.StorageUtil;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -116,7 +115,7 @@ public class LogViewFragment extends Fragment {
     String           logFileName = "deltachat-log-" + dateFormat.format(now) + ".txt";
 
     try {
-      outputDir = StorageUtil.getDownloadDir();
+      outputDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
       String logText =  logPreview.getText().toString();
       if(!logText.trim().equals("")){
         File logFile = new File(outputDir + "/" + logFileName);
@@ -128,7 +127,7 @@ public class LogViewFragment extends Fragment {
         logFileBufferWriter.write(logText);
         logFileBufferWriter.close();
       }
-    } catch (IOException | NoExternalStorageException e) {
+    } catch (IOException e) {
       e.printStackTrace();
       return false;
     }

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -336,7 +336,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                     break;
             }
         } else if (requestCode == PICK_BACKUP) {
-            Uri uri = data.getData();
+            Uri uri = (data != null ? data.getData() : null);
             if (uri == null) {
                 Log.e(TAG, " Can't import null URI");
                 return;

--- a/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
+++ b/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
@@ -117,7 +117,7 @@ public class AttachmentTypeSelector extends PopupWindow {
   }
 
   public void show(@NonNull Activity activity, final @NonNull View anchor) {
-    if (Permissions.hasAll(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+    if (Permissions.hasAll(activity, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       recentRail.setVisibility(View.VISIBLE);
       loaderManager.restartLoader(1, null, recentRail);
     } else {

--- a/src/org/thoughtcrime/securesms/components/AvatarSelector.java
+++ b/src/org/thoughtcrime/securesms/components/AvatarSelector.java
@@ -80,7 +80,7 @@ public class AvatarSelector extends PopupWindow {
   }
 
   public void show(@NonNull Activity activity, final @NonNull View anchor) {
-    if (Permissions.hasAll(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+    if (Permissions.hasAll(activity, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       recentRail.setVisibility(View.VISIBLE);
       loaderManager.restartLoader(1, null, recentRail);
     } else {

--- a/src/org/thoughtcrime/securesms/components/RecentPhotoViewRail.java
+++ b/src/org/thoughtcrime/securesms/components/RecentPhotoViewRail.java
@@ -1,11 +1,19 @@
 package org.thoughtcrime.securesms.components;
 
 
+import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.MediaStore;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.loader.app.LoaderManager;
@@ -13,12 +21,6 @@ import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import android.util.AttributeSet;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.FrameLayout;
-import android.widget.ImageView;
 
 import com.bumptech.glide.load.Key;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -102,13 +104,13 @@ public class RecentPhotoViewRail extends FrameLayout implements LoaderManager.Lo
     public void onBindItemViewHolder(RecentPhotoViewHolder viewHolder, @NonNull Cursor cursor) {
       viewHolder.imageView.setImageDrawable(null);
 
-      long   id           = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns._ID));
+      long   rowId        = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns._ID));
       long   dateTaken    = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_TAKEN));
       long   dateModified = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED));
       String mimeType     = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.MIME_TYPE));
       int    orientation  = cursor.getInt(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.ORIENTATION));
 
-      final Uri uri = Uri.withAppendedPath(baseUri, Long.toString(id));
+      final Uri uri = ContentUris.withAppendedId(RecentPhotosLoader.BASE_URL, rowId);
 
       Key signature = new MediaStoreSignature(mimeType, dateModified, orientation);
 

--- a/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
@@ -5,7 +5,9 @@ import android.Manifest;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
+
 import androidx.loader.content.CursorLoader;
 
 import org.thoughtcrime.securesms.permissions.Permissions;
@@ -22,6 +24,9 @@ public class RecentPhotosLoader extends CursorLoader {
       MediaStore.Images.ImageColumns.MIME_TYPE
   };
 
+  private static final String SELECTION  = Build.VERSION.SDK_INT > 28 ? MediaStore.Images.Media.IS_PENDING + " != 1"
+                                                                      : MediaStore.Images.Media.DATA + " IS NULL";
+
   private final Context context;
 
   public RecentPhotosLoader(Context context) {
@@ -33,7 +38,7 @@ public class RecentPhotosLoader extends CursorLoader {
   public Cursor loadInBackground() {
     if (Permissions.hasAll(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       return context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                                                PROJECTION, null, null,
+                                                PROJECTION, SELECTION, null,
                                                 MediaStore.Images.ImageColumns.DATE_MODIFIED + " DESC");
     } else {
       return null;

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -27,6 +27,7 @@ import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import android.util.Log;
@@ -53,6 +54,7 @@ import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.scribbles.ScribbleActivity;
 import org.thoughtcrime.securesms.util.MediaUtil;
+import org.thoughtcrime.securesms.util.StorageUtil;
 import org.thoughtcrime.securesms.util.ThemeUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.concurrent.ListenableFuture;
@@ -506,12 +508,20 @@ public class AttachmentManager {
         .execute();
   }
 
-  private static void selectMediaType(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode) {
+  public static void selectMediaType(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode) {
+    selectMediaType(activity, type, extraMimeType, requestCode, null);
+  }
+
+  public static void selectMediaType(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode, @Nullable Uri initialUri) {
     final Intent intent = new Intent();
     intent.setType(type);
 
     if (extraMimeType != null && Build.VERSION.SDK_INT >= 19) {
       intent.putExtra(Intent.EXTRA_MIME_TYPES, extraMimeType);
+    }
+
+    if (initialUri != null && Build.VERSION.SDK_INT >= 26) {
+      intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialUri);
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -383,17 +383,12 @@ public class AttachmentManager {
   }
 
   public static void selectDocument(Activity activity, int requestCode) {
-    Permissions.with(activity)
-               .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-               .ifNecessary()
-               .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
-               .onAllGranted(() -> selectMediaType(activity, "*/*", null, requestCode))
-               .execute();
+    selectMediaType(activity, "*/*", null, requestCode);
   }
 
   public static void selectGallery(Activity activity, int requestCode) {
     Permissions.with(activity)
-               .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+               .request(Manifest.permission.READ_EXTERNAL_STORAGE)
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
                .onAllGranted(() -> selectMediaType(activity, "image/*", new String[] {"image/*", "video/*"}, requestCode))
@@ -402,7 +397,7 @@ public class AttachmentManager {
 
   public static void selectImage(Activity activity, int requestCode) {
     Permissions.with(activity)
-            .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            .request(Manifest.permission.READ_EXTERNAL_STORAGE)
             .ifNecessary()
             .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
             .onAllGranted(() -> selectMediaType(activity, "image/*", null, requestCode))
@@ -411,7 +406,7 @@ public class AttachmentManager {
 
   public static void selectAudio(Activity activity, int requestCode) {
     Permissions.with(activity)
-               .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+               .request(Manifest.permission.READ_EXTERNAL_STORAGE)
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
                .onAllGranted(() -> selectMediaType(activity, "audio/*", null, requestCode))

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -4,13 +4,14 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import android.webkit.MimeTypeMap;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import com.b44t.messenger.DcMsg;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -45,6 +46,7 @@ public class MediaUtil {
   public static final String AUDIO_AAC         = "audio/aac";
   public static final String AUDIO_UNSPECIFIED = "audio/*";
   public static final String VIDEO_UNSPECIFIED = "video/*";
+  public static final String OCTET             = "application/octet-stream";
 
 
   public static Slide getSlideForMsg(Context context, DcMsg dcMsg) {
@@ -192,6 +194,18 @@ public class MediaUtil {
 
   public static boolean isVideoType(String contentType) {
     return (null != contentType) && contentType.startsWith("video/");
+  }
+
+  public static boolean isOctetStream(@Nullable String contentType) {
+    return OCTET.equals(contentType);
+  }
+
+  public static boolean isImageOrVideoType(String contentType) {
+    return isImageType(contentType) || isVideoType(contentType);
+  }
+
+  public static boolean isImageVideoOrAudioType(String contentType) {
+    return isImageOrVideoType(contentType) || isAudioType(contentType);
   }
 
   public static class ThumbnailSize {

--- a/src/org/thoughtcrime/securesms/util/StorageUtil.java
+++ b/src/org/thoughtcrime/securesms/util/StorageUtil.java
@@ -1,9 +1,17 @@
 package org.thoughtcrime.securesms.util;
 
+import android.Manifest;
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
+import android.provider.MediaStore;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.thoughtcrime.securesms.database.NoExternalStorageException;
+import org.thoughtcrime.securesms.permissions.Permissions;
 
 import java.io.File;
 
@@ -31,20 +39,46 @@ public class StorageUtil {
     return storage.canWrite();
   }
 
-  public static File getVideoDir() throws NoExternalStorageException {
-    return new File(getStorageDir(), Environment.DIRECTORY_MOVIES);
+  public static boolean canWriteToMediaStore(Context context) {
+    return Build.VERSION.SDK_INT > 28 ||
+            Permissions.hasAll(context, Manifest.permission.WRITE_EXTERNAL_STORAGE);
   }
 
-  public static File getAudioDir() throws NoExternalStorageException {
-    return new File(getStorageDir(), Environment.DIRECTORY_MUSIC);
+  public static @NonNull Uri getVideoUri() {
+    if (Build.VERSION.SDK_INT < 21) {
+      return getLegacyUri(Environment.DIRECTORY_MOVIES);
+    } else {
+      return MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+    }
   }
 
-  public static File getImageDir() throws NoExternalStorageException {
-    return new File(getStorageDir(), Environment.DIRECTORY_PICTURES);
+  public static @NonNull
+  Uri getAudioUri() {
+    if (Build.VERSION.SDK_INT < 21) {
+      return getLegacyUri(Environment.DIRECTORY_MUSIC);
+    } else {
+      return MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+    }
   }
 
-  public static File getDownloadDir() throws NoExternalStorageException {
-    return new File(getStorageDir(), Environment.DIRECTORY_DOWNLOADS);
+  public static @NonNull Uri getImageUri() {
+    if (Build.VERSION.SDK_INT < 21) {
+      return getLegacyUri(Environment.DIRECTORY_PICTURES);
+    } else {
+      return MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+    }
+  }
+
+  public static @NonNull Uri getDownloadUri() {
+    if (Build.VERSION.SDK_INT < 29) {
+      return getLegacyUri(Environment.DIRECTORY_DOWNLOADS);
+    } else {
+      return MediaStore.Downloads.EXTERNAL_CONTENT_URI;
+    }
+  }
+
+  public static @NonNull Uri getLegacyUri(@NonNull String directory) {
+    return Uri.fromFile(Environment.getExternalStoragePublicDirectory(directory));
   }
 
   public static @Nullable String getCleanFileName(@Nullable String fileName) {

--- a/src/org/thoughtcrime/securesms/util/StreamUtil.java
+++ b/src/org/thoughtcrime/securesms/util/StreamUtil.java
@@ -1,0 +1,25 @@
+package org.thoughtcrime.securesms.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+class StreamUtil {
+
+  public static long copy(InputStream in, OutputStream out) throws IOException {
+    byte[] buffer = new byte[64 * 1024];
+    int read;
+    long total = 0;
+
+    while ((read = in.read(buffer)) != -1) {
+      out.write(buffer, 0, read);
+      total += read;
+    }
+
+    in.close();
+    out.close();
+
+    return total;
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/util/StreamUtil.java
+++ b/src/org/thoughtcrime/securesms/util/StreamUtil.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-class StreamUtil {
+public class StreamUtil {
 
   public static long copy(InputStream in, OutputStream out) throws IOException {
     byte[] buffer = new byte[64 * 1024];


### PR DESCRIPTION
Closes #1849.

Probably best reviewed commit-by-commit and with white-space changes ignored.

- [x] Use the MediaStore API (Scoped Storage) for attachments
- [x] Doing "Add attachment -> Camera" doesn't work yet: https://stackoverflow.com/questions/64392621/android-camera-intent-not-responding-in-android-11
  To fix this, I had to add a `queries` tag to AndroidManifest.xml. But older versions of Gradle don't support this yet, so I also had to update Gradle. I then also had to update Android Studio as Gradle wouldn't work with my old version anymore. And apparently they made some warning a hard error, so I had to add `tools:ignore="AppLinkUrlError"` four times to AndroidManifest.xml (no the warning was not legit, we did everything fine)
- [x] Importing backups (exporting seems to have worked fine before already)
  Unfortunately, I did this by copying the backup file to the private storage first, making importing a backup take longer and require more space unnecessarily.
  The problem is that native code [can only access files that we created ourselves or that are in our private directory](https://developer.android.google.cn/training/data-storage/shared/media?hl=en#direct-file-paths).
  What we have is a `content://` URI, and in Java code we can use it to get an InputStream using `getContentResolver().openInputStream(uri))`.
  Some ideas what we could do to fix this, but none of them sounds too great:
  - Transfer a Stream between the Java and Rust, e.g. via HTTP
  - Hand the Stream object to the Rust code and try to somehow use it
  - Poke around a bit more and see if we find some possibility to still access the file from native code. Mabye I understood the documentation wrongly (it's formulated wishy-washy) and there is a possibility. Like, somehow get the file name from the `content://` URI and then access is from the native code.
  - Re-implement importing backups in Java
- [ ] Lots of testing on lots of Android versions
- [ ] Discuss about the tradeoffs I explained above esp. under "Importing backups"

**Testing checklist**

- Saving a logfile (and check that it was actually saved to "Downloads") (from Settings -> Advanced -> View Log -> Menu -> Save Log)
- Share a file to DC
- Share a file from DC to another app
- Select a file via "Add Attachment -> File"
- Tap "Add Attachment" and check that recent photos can be directly attached from there
- Tap on a file in DC to open it in another app (this only works if the file is NOT an image, video or audio)
- Tap "Add Attachment -> Camera" to take an image using an external camera app
- Export an attachment Check that the shown toast (`File saved to "<folder name>"`) is correct. Check that it was actually saved to this folder.
- Export a backup
- Delete DC, install it again, import the backup. Alternatively, import a backup that was transferred from another device.
- Check that requesting storage permissions works