### PR TITLE
provider app support

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -294,6 +294,16 @@
 
     <service android:name=".service.GenericForegroundService" />
 
+    <service
+        android:name=".service.IPCAddAccountsService"
+        android:enabled="true"
+        android:exported="true"
+        >
+        <intent-filter>
+            <action android:name="chat.delta.addaccount" />
+        </intent-filter>
+    </service>
+
     <receiver android:name=".notifications.MarkReadReceiver"
               android:enabled="true"
               android:exported="false">

--- a/res/layout/profile_preference_view.xml
+++ b/res/layout/profile_preference_view.xml
@@ -16,8 +16,8 @@
     <LinearLayout android:orientation="vertical"
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"
-                  android:layout_marginLeft="10dp"
-                  android:layout_marginStart="10dp">
+                  android:layout_marginRight="16dp"
+                  android:layout_marginEnd="16dp">
 
         <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                 android:id="@+id/profile_name"

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -185,6 +185,11 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             emailInput.setText(emailAddress);
             passwordInput.setText(password);
             onLogin();
+          } else {
+            String errorText = "Companion app auto-configuration failed.";
+            errorText += TextUtils.isEmpty(emailAddress) ? " Missing emailAddress." : "";
+            errorText += TextUtils.isEmpty(password) ? " Missing password." : "";
+            Toast.makeText(this, errorText, Toast.LENGTH_LONG).show();
           }
         }
 

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -59,6 +59,7 @@ import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SEND_SERVER;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SEND_USER;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SERVER_FLAGS;
 import static org.thoughtcrime.securesms.connect.DcHelper.getContext;
+import static org.thoughtcrime.securesms.service.IPCAddAccountsService.ACCOUNT_DATA;
 
 public class RegistrationActivity extends BaseActionBarActivity implements DcEventCenter.DcEventDelegate {
 
@@ -175,6 +176,17 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
 
             int certCheckFlags = DcHelper.getInt(this, "imap_certificate_checks");
             certCheck.setSelection(certCheckFlags);
+        } else if (getIntent() != null && getIntent().getBundleExtra(ACCOUNT_DATA) != null) {
+          // Companion app might have sent account data
+          Bundle b = getIntent().getBundleExtra(ACCOUNT_DATA);
+          String emailAddress = b.getString(CONFIG_ADDRESS);
+          String password = b.getString(CONFIG_MAIL_PASSWORD);
+          if (!TextUtils.isEmpty(emailAddress) && !TextUtils.isEmpty(password)) {
+            emailInput.setText(emailAddress);
+            passwordInput.setText(password);
+            updateProviderInfo();
+            onLogin();
+          }
         }
 
         DcHelper.getEventCenter(this).addObserver(DcContext.DC_EVENT_CONFIGURE_PROGRESS, this);

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -184,7 +184,6 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
           if (!TextUtils.isEmpty(emailAddress) && !TextUtils.isEmpty(password)) {
             emailInput.setText(emailAddress);
             passwordInput.setText(password);
-            updateProviderInfo();
             onLogin();
           }
         }

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -84,7 +84,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
           // Since android API 26 only explicit broadcasts are allowed for IPC with a few exceptions.
           // As a result we have to send for each companion app we want to support an intent with a
           // specified package
-          intent.setPackage("org.cyberta");
+          intent.setPackage("chat.delta.AndroidYggmail");
           intent.setAction(DC_REQUEST_ACCOUNT_DATA);
           sendBroadcast(intent);
         }

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -52,6 +52,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     public static final int PICK_BACKUP = 20574;
     private final static String TAG = WelcomeActivity.class.getSimpleName();
     public static final String TMP_BACKUP_FILE = "tmp-backup-file";
+    public static final String DC_REQUEST_ACCOUNT_DATA = "chat.delta.DC_REQUEST_ACCOUNT_DATA";
 
     private boolean manualConfigure = true; // false: configure by QR account creation
     private ProgressDialog progressDialog = null;
@@ -77,6 +78,16 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         DcEventCenter eventCenter = DcHelper.getEventCenter(this);
         eventCenter.addObserver(DcContext.DC_EVENT_CONFIGURE_PROGRESS, this);
         eventCenter.addObserver(DcContext.DC_EVENT_IMEX_PROGRESS, this);
+
+        if (!DcHelper.hasAnyConfiguredContext(this)) {
+          Intent intent = new Intent();
+          // Since android API 26 only explicit broadcasts are allowed for IPC with a few exceptions.
+          // As a result we have to send for each companion app we want to support an intent with a
+          // specified package
+          intent.setPackage("org.cyberta");
+          intent.setAction(DC_REQUEST_ACCOUNT_DATA);
+          sendBroadcast(intent);
+        }
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -81,10 +81,22 @@ public class DcHelper {
         return ApplicationContext.getInstance(context).notificationCenter;
     }
 
+    public static boolean hasAnyConfiguredContext(Context context) {
+      DcAccounts accounts = getAccounts(context);
+      int[] accountIds = accounts.getAll();
+      for (int accountId : accountIds) {
+        if (accounts.getAccount(accountId).isConfigured() == 1) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     public static boolean isConfigured(Context context) {
         DcContext dcContext = getContext(context);
         return dcContext.isConfigured() == 1;
     }
+
 
     public static int getInt(Context context, String key) {
         DcContext dcContext = getContext(context);

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -20,6 +20,10 @@ import java.lang.ref.WeakReference;
 
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ADDRESS;
 
+/**
+ * This service is invoked by companion apps aiming to add a new account to Delta Chat
+ */
+
 public class IPCAddAccountsService extends Service {
   public final static int ADD_ACCOUNT = 1;
   public final static String ACCOUNT_DATA = "ACCOUNT_DATA";
@@ -35,7 +39,6 @@ public class IPCAddAccountsService extends Service {
 
     @Override
     public void handleMessage(@NonNull Message msg) {
-      Log.d(TAG, "handle Message");
       Bundle data = msg.getData();
       Context context = contextRef.get();
       if (data != null && context != null && msg.what == ADD_ACCOUNT) {
@@ -53,26 +56,6 @@ public class IPCAddAccountsService extends Service {
 
   private final Messenger messenger = new Messenger(new IncomingHandler(this));
 
-  /**
-   * Return the communication channel to the service.  May return null if
-   * clients can not bind to the service.  The returned
-   * {@link IBinder} is usually for a complex interface
-   * that has been <a href="{@docRoot}guide/components/aidl.html">described using
-   * aidl</a>.
-   *
-   * <p><em>Note that unlike other application components, calls on to the
-   * IBinder interface returned here may not happen on the main thread
-   * of the process</em>.  More information about the main thread can be found in
-   * <a href="{@docRoot}guide/topics/fundamentals/processes-and-threads.html">Processes and
-   * Threads</a>.</p>
-   *
-   * @param intent The Intent that was used to bind to this service,
-   *               as given to {@link Context#bindService
-   *               Context.bindService}.  Note that any extras that were included with
-   *               the Intent at that point will <em>not</em> be seen here.
-   * @return Return an IBinder through which clients can call on to the
-   * service.
-   */
   @Nullable
   @Override
   public IBinder onBind(Intent intent) {

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -14,8 +14,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.thoughtcrime.securesms.RegistrationActivity;
+import org.thoughtcrime.securesms.connect.AccountManager;
 
 import java.lang.ref.WeakReference;
+
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ADDRESS;
 
 public class IPCAddAccountsService extends Service {
   public final static int ADD_ACCOUNT = 1;
@@ -33,15 +36,11 @@ public class IPCAddAccountsService extends Service {
     @Override
     public void handleMessage(@NonNull Message msg) {
       Log.d(TAG, "handle Message");
-      if (msg.what == ADD_ACCOUNT) {
-        Log.d(TAG, "ADD ACCOUNT called");
-        Bundle data = msg.getData();
-        Context context = contextRef.get();
-        if (data == null || context == null) {
-          // ignore
-          super.handleMessage(msg);
-          return;
-        }
+      Bundle data = msg.getData();
+      Context context = contextRef.get();
+      if (data != null && context != null && msg.what == ADD_ACCOUNT) {
+        Log.d(TAG, "ADD ACCOUNT called for account: " + data.getString(CONFIG_ADDRESS));
+        AccountManager.getInstance().beginAccountCreation(context);
         Intent registrationIntent = new Intent(context, RegistrationActivity.class);
         registrationIntent.putExtra(ACCOUNT_DATA, data);
         registrationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -1,5 +1,8 @@
 package org.thoughtcrime.securesms.service;
 
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -46,7 +49,7 @@ public class IPCAddAccountsService extends Service {
         AccountManager.getInstance().beginAccountCreation(context);
         Intent registrationIntent = new Intent(context, RegistrationActivity.class);
         registrationIntent.putExtra(ACCOUNT_DATA, data);
-        registrationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        registrationIntent.addFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK);
         context.startActivity(registrationIntent);
       } else {
         super.handleMessage(msg);

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -51,8 +51,6 @@ public class IPCAddAccountsService extends Service {
         registrationIntent.putExtra(ACCOUNT_DATA, data);
         registrationIntent.addFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK);
         context.startActivity(registrationIntent);
-      } else {
-        super.handleMessage(msg);
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -43,7 +43,7 @@ public class IPCAddAccountsService extends Service {
         AccountManager.getInstance().beginAccountCreation(context);
         Intent registrationIntent = new Intent(context, RegistrationActivity.class);
         registrationIntent.putExtra(ACCOUNT_DATA, data);
-        registrationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        registrationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
         context.startActivity(registrationIntent);
       } else {
         super.handleMessage(msg);

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -1,0 +1,87 @@
+package org.thoughtcrime.securesms.service;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Message;
+import android.os.Messenger;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.thoughtcrime.securesms.RegistrationActivity;
+
+import java.lang.ref.WeakReference;
+
+public class IPCAddAccountsService extends Service {
+  public final static int ADD_ACCOUNT = 1;
+  public final static String ACCOUNT_DATA = "ACCOUNT_DATA";
+
+  private static final String TAG = IPCAddAccountsService.class.getSimpleName();
+
+  private static class IncomingHandler extends Handler {
+    final WeakReference<Context> contextRef;
+
+    public IncomingHandler(Context context) {
+      contextRef = new WeakReference<>(context);
+    }
+
+    @Override
+    public void handleMessage(@NonNull Message msg) {
+      Log.d(TAG, "handle Message");
+      if (msg.what == ADD_ACCOUNT) {
+        Log.d(TAG, "ADD ACCOUNT called");
+        Bundle data = msg.getData();
+        Context context = contextRef.get();
+        if (data == null || context == null) {
+          // ignore
+          super.handleMessage(msg);
+          return;
+        }
+        Intent registrationIntent = new Intent(context, RegistrationActivity.class);
+        registrationIntent.putExtra(ACCOUNT_DATA, data);
+        registrationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        context.startActivity(registrationIntent);
+      } else {
+        super.handleMessage(msg);
+      }
+    }
+  }
+
+  private final Messenger messenger = new Messenger(new IncomingHandler(this));
+
+  /**
+   * Return the communication channel to the service.  May return null if
+   * clients can not bind to the service.  The returned
+   * {@link IBinder} is usually for a complex interface
+   * that has been <a href="{@docRoot}guide/components/aidl.html">described using
+   * aidl</a>.
+   *
+   * <p><em>Note that unlike other application components, calls on to the
+   * IBinder interface returned here may not happen on the main thread
+   * of the process</em>.  More information about the main thread can be found in
+   * <a href="{@docRoot}guide/topics/fundamentals/processes-and-threads.html">Processes and
+   * Threads</a>.</p>
+   *
+   * @param intent The Intent that was used to bind to this service,
+   *               as given to {@link Context#bindService
+   *               Context.bindService}.  Note that any extras that were included with
+   *               the Intent at that point will <em>not</em> be seen here.
+   * @return Return an IBinder through which clients can call on to the
+   * service.
+   */
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent) {
+    return messenger.getBinder();
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    return START_NOT_STICKY;
+  }
+}

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -29,7 +29,7 @@ import com.b44t.messenger.DcAccounts;
 import com.b44t.messenger.DcContext;
 
 /**
- * This service is invoked by companion apps aiming to add a new account to Delta Chat
+ * This (interprocess communication) service is invoked by companion apps aiming to add a new account to Delta Chat
  */
 
 public class IPCAddAccountsService extends Service {


### PR DESCRIPTION
corresponding yggmail pr: https://github.com/deltachat/AndroidYggmail/pull/15

the goal is to make the interaction as smooth as possible, at best without confirmation, questions etc. the flow is roughly the following:

- start the "provider app", yggmail here, configure account there (just tap "start")

if delta chat is already installed (doesn't need to be running):

- (X) the provider apps sends the new account by a Message object to Delta Chat

if delta chat is not installed:
- the provider app guides the user to downloading Delta Chat (eg. open play store after tapping "start")

if provider app is installed (doesn't need to be running) and delta chat is installed but not yet configured:
- deltachat, when starting unconfigured, sends a broadcast event to possible provider apps
- (X) the provider apps sends the new account by a Message object to Delta Chat

step (X) is identical on both scenarios.