### PR TITLE
re-add "Add Attachment" menu entry

### DIFF
--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -39,4 +39,7 @@
         android:icon="@drawable/ic_map_white_24dp"
         app:showAsAction="ifRoom" />
 
+    <item android:title="@string/menu_add_attachment"
+          android:id="@+id/menu_add_attachment" />
+
 </menu>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -515,6 +515,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       Log.e(TAG, "cannot set up in-chat-search: ", e);
     }
 
+    if (!dcChat.canSend()) {
+      MenuItem attachItem =  menu.findItem(R.id.menu_add_attachment);
+      if (attachItem!=null) {
+        attachItem.setVisible(false);
+      }
+    }
+
     super.onPrepareOptionsMenu(menu);
     return true;
   }
@@ -523,6 +530,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
     switch (item.getItemId()) {
+      case R.id.menu_add_attachment:        handleAddAttachment();             return true;
       case R.id.menu_leave:                 handleLeaveGroup();                return true;
       case R.id.menu_archive_chat:          handleArchiveChat();               return true;
       case R.id.menu_delete_chat:           handleDeleteChat();                return true;


### PR DESCRIPTION
this partly reverts #2079

it was removed to have some menu entries,
however, on recent discussions,
it turns out clearer and clearer that this will break some workflows
(writing text first, then adding attachment).

i just had a look at other "large" messengers -
all of them support "write text, then add attachment" -
as well as our iOS and Desktop apps.
also, this order seems to be pretty normal when it comes to "E-Mail".

all in all,
i think, we should not sacrify this workflow just to save one menu entry.

at some point,
maybe we want to have the "Attach" button always visible left of the input bar
as most other messengers do (as well as iOS and Desktop),
however, this is a larger thing and also has its drawbacks on smaller screens.

so, just leave things as is seems not to be the worse idea here.

the "View Profile" menu entry, however stays, removed,
so, there is some cleanup.