### PR TITLE
new group from profile

### DIFF
--- a/res/layout/group_create_activity.xml
+++ b/res/layout/group_create_activity.xml
@@ -32,7 +32,7 @@
             android:lines="1"
             android:maxLength="255"
             android:inputType="textAutoCorrect"
-            android:hint="@string/group_name" />
+            android:hint="@string/name_desktop" />
     </LinearLayout>
 
     <TextView

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -172,6 +172,8 @@
     <string name="menu_new_contact">New Contact</string>
     <string name="menu_new_chat">New Chat</string>
     <string name="menu_new_group">New Group</string>
+    <!-- "Subject" here must be the same wording as used in the e-mail context, so. eg. "Betreff" in german (the idea is to help people coming from the e-mail context) -->
+    <string name="new_group_or_subject">New Group or Subject</string>
     <string name="menu_new_verified_group">New Verified Group</string>
     <!-- consider keeping the term "broadcast"; check how these lists are called eg. on whatsapp in the destination language -->
     <string name="broadcast_list">Broadcast List</string>

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -209,7 +209,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
         Recipient recipient = result.recipient.get();
         Address address = recipient.getAddress();
         if(address.isDcContact()) {
-          activity.getAdapter().add(recipient, true);
+          activity.getAdapter().add(recipient);
         }
       }
       activity.updateViewState();

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -65,6 +65,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   public static final String EDIT_GROUP_CHAT_ID = "edit_group_chat_id";
   public static final String GROUP_CREATE_VERIFIED_EXTRA  = "group_create_verified";
   public static final String CREATE_BROADCAST  = "group_create_broadcast";
+  public static final String SUGGESTED_CONTACT_IDS = "suggested_contact_ids";
 
   private final DynamicTheme    dynamicTheme    = new DynamicTheme();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -85,6 +86,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   private boolean      isEdit;
   private boolean      avatarChanged;
   private boolean      imageLoaded;
+  private boolean      hasSuggestedContacts;
   private AttachmentManager attachmentManager;
 
   @Override
@@ -148,6 +150,8 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     }
     else if(broadcast) {
       title = getString(R.string.new_broadcast_list);
+    } else if (hasSuggestedContacts) {
+      title = getString(R.string.new_group_or_subject);
     }
     else if(verified) {
       title = getString(R.string.menu_new_verified_group);
@@ -222,6 +226,13 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     if (!broadcast) {
       DcContact self = dcContext.getContact(DC_CONTACT_ID_SELF);
       initList.add(new Recipient(this, self));
+    }
+    ArrayList<Integer> suggestedContactIds = getIntent().getIntegerArrayListExtra(SUGGESTED_CONTACT_IDS);
+    if (suggestedContactIds != null && !suggestedContactIds.isEmpty()) {
+      hasSuggestedContacts = true;
+      for (Integer contactId : suggestedContactIds) {
+        initList.add(new Recipient(this, dcContext.getContact(contactId)));
+      }
     }
     SelectedRecipientsAdapter adapter = new SelectedRecipientsAdapter(this, GlideApp.with(this), initList);
     adapter.setOnRecipientDeletedListener(this);

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -114,6 +114,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     if(groupChatId !=0) {
       isEdit = true;
       DcChat dcChat = dcContext.getChat(groupChatId);
+      verified = dcChat.isProtected();
       broadcast = dcChat.isBroadcast();
     }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -261,9 +261,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
   private void editAvatar() {
     Intent intent = new Intent(this, GroupCreateActivity.class);
     intent.putExtra(GroupCreateActivity.EDIT_GROUP_CHAT_ID, editAvatarChatId);
-    if (dcContext.getChat(editAvatarChatId).isProtected()) {
-      intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, true);
-    }
     startActivity(intent);
     finish(); // avoid the need to update the enlarged-avatar
   }

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -142,12 +142,10 @@ public class NewConversationActivity extends ContactSelectionActivity {
       Intent intent = new Intent(this, GroupCreateActivity.class);
       intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, specialId == DcContact.DC_CONTACT_ID_NEW_VERIFIED_GROUP);
       startActivity(intent);
-      finish();
     } else if(specialId == DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST) {
       Intent intent = new Intent(this, GroupCreateActivity.class);
       intent.putExtra(GroupCreateActivity.CREATE_BROADCAST, true);
       startActivity(intent);
-      finish();
     }
     else {
       if(!dcContext.mayBeValidAddr(addr)) {

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -496,9 +496,6 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       if (chatIsMailingList || dcChat.canSend()) {
         Intent intent = new Intent(this, GroupCreateActivity.class);
         intent.putExtra(GroupCreateActivity.EDIT_GROUP_CHAT_ID, chatId);
-        if (dcChat.isProtected()) {
-          intent.putExtra(GroupCreateActivity.GROUP_CREATE_VERIFIED_EXTRA, true);
-        }
         startActivity(intent);
       }
     }

--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -31,7 +31,8 @@ import java.util.Set;
 public class ProfileSettingsAdapter extends RecyclerView.Adapter
                                     implements StickyHeaderAdapter<ProfileSettingsAdapter.HeaderViewHolder>
 {
-  public static final int SETTING_NEW_CHAT = 120;
+  public static final int SETTING_SEND_MESSAGE = 120;
+  public static final int SETTING_NEW_GROUP    = 130;
 
   private final @NonNull Context              context;
   private final @NonNull Locale               locale;
@@ -310,7 +311,8 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
 
       itemDataContact = dcContact;
       if (!chatIsDeviceTalk) {
-        itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_CHAT, context.getString(R.string.send_message)));
+        itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_SEND_MESSAGE, context.getString(R.string.send_message)));
+        itemData.add(new ItemData(ItemData.TYPE_PRIMARY_SETTING, SETTING_NEW_GROUP, context.getString(R.string.new_group_or_subject)));
       }
 
       itemDataStatusText = dcContact.getStatus();

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -249,7 +249,11 @@ public class ProfileSettingsFragment extends Fragment
   }
 
   private void onNewGroupWith() {
+    ArrayList<Integer> preselectedContactIds = new ArrayList<>();
+    preselectedContactIds.add(contactId);
+
     Intent intent = new Intent(getActivity(), GroupCreateActivity.class);
+    intent.putExtra(GroupCreateActivity.SUGGESTED_CONTACT_IDS, preselectedContactIds);
     getActivity().startActivity(intent);
   }
 

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -143,8 +143,12 @@ public class ProfileSettingsFragment extends Fragment
   @Override
   public void onSettingsClicked(int settingsId) {
     switch(settingsId) {
-      case ProfileSettingsAdapter.SETTING_NEW_CHAT:
-        onNewChat();
+      case ProfileSettingsAdapter.SETTING_SEND_MESSAGE:
+        onSendMessage();
+        break;
+
+      case ProfileSettingsAdapter.SETTING_NEW_GROUP:
+        onNewGroupWith();
         break;
     }
   }
@@ -233,7 +237,7 @@ public class ProfileSettingsFragment extends Fragment
     getActivity().finish();
   }
 
-  private void onNewChat() {
+  private void onSendMessage() {
     DcContact dcContact = dcContext.getContact(contactId);
     int chatId = dcContext.createChatByContactId(dcContact.getId());
     if (chatId != 0) {
@@ -242,6 +246,11 @@ public class ProfileSettingsFragment extends Fragment
       getActivity().startActivity(intent);
       getActivity().finish();
     }
+  }
+
+  private void onNewGroupWith() {
+    Intent intent = new Intent(getActivity(), GroupCreateActivity.class);
+    getActivity().startActivity(intent);
   }
 
   private class ActionModeCallback implements ActionMode.Callback {

--- a/src/org/thoughtcrime/securesms/util/SelectedRecipientsAdapter.java
+++ b/src/org/thoughtcrime/securesms/util/SelectedRecipientsAdapter.java
@@ -48,13 +48,13 @@ public class SelectedRecipientsAdapter extends BaseAdapter {
     this.recipients    = wrapExistingMembers(existingRecipients);
   }
 
-  public void add(@NonNull Recipient recipient, boolean isPush) {
+  public void add(@NonNull Recipient recipient) {
     if (!find(recipient).isPresent()) {
       boolean isModifiable = true;
       if (recipient.getAddress().getDcContactId() == DC_CONTACT_ID_SELF) {
         isModifiable = false;
       }
-      RecipientWrapper wrapper = new RecipientWrapper(recipient, isModifiable, isPush);
+      RecipientWrapper wrapper = new RecipientWrapper(recipient, isModifiable);
       this.recipients.add(0, wrapper);
       notifyDataSetChanged();
     }
@@ -146,7 +146,7 @@ public class SelectedRecipientsAdapter extends BaseAdapter {
       if (recipient.getAddress().getDcContactId() == DC_CONTACT_ID_SELF) {
         isModifiable = false;
       }
-      wrapperList.add(new RecipientWrapper(recipient, isModifiable, true));
+      wrapperList.add(new RecipientWrapper(recipient, isModifiable));
     }
     return wrapperList;
   }
@@ -162,15 +162,12 @@ public class SelectedRecipientsAdapter extends BaseAdapter {
   public static class RecipientWrapper {
     private final Recipient recipient;
     private final boolean   modifiable;
-    private final boolean   push;
 
     public RecipientWrapper(final @NonNull Recipient recipient,
-                            final boolean modifiable,
-                            final boolean push)
+                            final boolean modifiable)
     {
       this.recipient  = recipient;
       this.modifiable = modifiable;
-      this.push       = push;
     }
 
     public @NonNull Recipient getRecipient() {


### PR DESCRIPTION
this pr adds the button "Create Group or Subject" to the profile of each contact, allowing to easily create a group with that contact. this is useful for:

- create a verified group with that contact (when point 1. of https://github.com/deltachat/deltachat-android/issues/2099 is implemented)

- the group name is used as a subject in normal MUA - this change makes it ux wise more understandable how to create a "normal" email

- of course, this is also handy to create a normal group and to add more members

moreover, this pr cleans up the code a bit.

<img width=320 src=https://user-images.githubusercontent.com/9800740/139456097-08b655ae-ef47-49f0-b68b-06826da38e14.png> <img width=320 src=https://user-images.githubusercontent.com/9800740/139456104-647745d1-7bd7-4fb2-ae6b-f1d81a6148c8.png>

nb: not sure, which wording we agreed on finally, i find this **New Group or Subject** pretty intuitive, also wrt classic mail. maybe we can also rename the "normal" "New Group" button that way to make it clearer that the group name becomes the subject.
