### PR TITLE
adapt 'self-profile' hint to reality

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -539,7 +539,7 @@
     <string name="blocked_empty_hint">If you block contacts, they will be shown here.</string>
     <string name="pref_profile_photo_remove_ask">Remove profile image?</string>
     <string name="pref_password_and_account_settings">Password and Account</string>
-    <string name="pref_who_can_see_profile_explain">Your profile image, name and signature will be shown alongside your messages when communicating with other users.</string>
+    <string name="pref_who_can_see_profile_explain">Your profile image, name and signature will be sent together with your messages when communicating with other users.</string>
     <string name="pref_your_name">Your Name</string>
     <!-- Translators: The value entered here is visible only to recipients who DO NOT use Deltachat, so its not a "Status" but the last line in the E-Mail. -->
     <string name="pref_default_status_label">Signature Text</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -539,7 +539,7 @@
     <string name="blocked_empty_hint">If you block contacts, they will be shown here.</string>
     <string name="pref_profile_photo_remove_ask">Remove profile image?</string>
     <string name="pref_password_and_account_settings">Password and Account</string>
-    <string name="pref_who_can_see_profile_explain">Your profile image and name will be shown alongside your messages when communicating with other users. Already sent information can not be deleted or removed.</string>
+    <string name="pref_who_can_see_profile_explain">Your profile image, name and signature will be shown alongside your messages when communicating with other users.</string>
     <string name="pref_your_name">Your Name</string>
     <!-- Translators: The value entered here is visible only to recipients who DO NOT use Deltachat, so its not a "Status" but the last line in the E-Mail. -->
     <string name="pref_default_status_label">Signature Text</string>


### PR DESCRIPTION
- the profile hint misses that also the signature
  is sent out, together with name and image

- strike the part about that sent information cannot be retracted -
  that is pretty clear,
  and if we say that here, why not beside every message ;)
  not sure where that comes from,
  i checked similar settings in other messengers,
  there is no comparable hint.