### PR TITLE
Fix photo view rail

### DIFF
--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -17,6 +17,9 @@
 
 package org.thoughtcrime.securesms;
 
+import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
+import static org.thoughtcrime.securesms.util.RelayUtil.setSharedText;
+
 import android.Manifest;
 import android.content.Intent;
 import android.net.Uri;
@@ -44,9 +47,6 @@ import org.thoughtcrime.securesms.util.RelayUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
-import static org.thoughtcrime.securesms.util.RelayUtil.setSharedText;
 
 /**
  * An activity to quickly share content with chats
@@ -127,7 +127,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
     }
 
     if (needsFilePermission(streamExtras)) {
-      if (Permissions.hasAll(this, Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+      if (Permissions.hasAll(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
         resolveUris(streamExtras);
       } else {
         requestPermissionForFiles(streamExtras);

--- a/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
@@ -25,7 +25,7 @@ public class RecentPhotosLoader extends CursorLoader {
   };
 
   private static final String SELECTION  = Build.VERSION.SDK_INT > 28 ? MediaStore.Images.Media.IS_PENDING + " != 1"
-                                                                      : MediaStore.Images.Media.DATA + " IS NULL";
+                                                                      : null;
 
   private final Context context;
 

--- a/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
@@ -36,7 +36,7 @@ public class RecentPhotosLoader extends CursorLoader {
 
   @Override
   public Cursor loadInBackground() {
-    if (Permissions.hasAll(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+    if (Permissions.hasAll(context, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       return context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                                                 PROJECTION, SELECTION, null,
                                                 MediaStore.Images.ImageColumns.DATE_MODIFIED + " DESC");


### PR DESCRIPTION
Fix #2112

- Don't check for write permission when we don't need it
- Revert one of the changes from Signal. I have no idea why they changed this back then, but it prevents all photos from being shown in the recent photo view rail.