### PR TITLE
remove deprecated gradle element 'dexOptions'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,6 @@ android {
     compileSdkVersion 30
     useLibrary 'org.apache.http.legacy'
 
-    dexOptions {
-        javaMaxHeapSize "4g"
-    }
-
     defaultConfig {
         versionCode 613
         versionName "1.23.0"


### PR DESCRIPTION
without, there is a warning in gradle7 that says:

"DSL element 'dexOptions' is obsolete and should be removed.
It will be removed in version 8.0 of the Android Gradle plugin.
Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically."

not sure, what the option was about in older gradles.