### PR TITLE
reduce selected account's checkmark size a bit

### DIFF
--- a/res/layout/account_selection_list_item.xml
+++ b/res/layout/account_selection_list_item.xml
@@ -32,10 +32,10 @@
 
         <ImageView
             android:id="@+id/checkbox"
-            android:layout_width="22dp"
-            android:layout_height="22dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="20dp"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="22dp"
+            android:layout_marginTop="22dp"
             app:layout_constraintStart_toStartOf="@id/contact_photo_image"
             app:layout_constraintTop_toTopOf="@id/contact_photo_image"
             android:src="@drawable/ic_circle_checkbox"


### PR DESCRIPTION
@gerryfrancis complained in the testing group that the check-mark looks too big compared with the avatar size, I was using the size used in Signal but Signal avatars are bigger than in our account selector