### PR TITLE
fix backups for android10

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -45,6 +45,7 @@
                  android:theme="@style/TextSecure.LightTheme"
                  android:largeHeap="true"
                  tools:ignore="GoogleAppIndexingWarning"
+                 android:requestLegacyExternalStorage="true"
         >
 
     <!-- android car support, see https://developer.android.com/training/auto/start/,

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -121,7 +121,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                 .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
                 .onAllGranted(() -> {
                     File imexDir = DcHelper.getImexDir();
-                    if (Build.VERSION.SDK_INT >= 29) {
+                    if (Build.VERSION.SDK_INT >= 30) {
                         AttachmentManager.selectMediaType(this, "application/x-tar", null, PICK_BACKUP, StorageUtil.getDownloadUri());
                     } else {
                         final String backupFile = dcContext.imexHasBackup(imexDir.getAbsolutePath());


### PR DESCRIPTION
- Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
  was not writable for android10 (older and newer androids are okay)

- the import selectMediaType() showed up,
  however never did show the exported file on android10 (also here, older and newer androids are okay)

re-adding the flag `android:requestLegacyExternalStorage="true"` that was removed in #2087
fixed both problems, at least in the emulator.

seems as if the flag is still respected when running on sdk29 even when targeting sdk30;
when running on sdk30, however, the flag is ignored.

at least the following doc does not say that the flag is needless in sdk30:
https://developer.android.com/reference/android/R.attr#requestLegacyExternalStorage

@Hocuri maybe you can have a second look at the docs and confirm or falsify :)

fixes #2120 