### PR TITLE
package names should always be lower cased

### DIFF
--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -84,7 +84,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
           // Since android API 26 only explicit broadcasts are allowed for IPC with a few exceptions.
           // As a result we have to send for each companion app we want to support an intent with a
           // specified package
-          intent.setPackage("chat.delta.AndroidYggmail");
+          intent.setPackage("chat.delta.androidyggmail");
           intent.setAction(DC_REQUEST_ACCOUNT_DATA);
           sendBroadcast(intent);
         }


### PR DESCRIPTION
rename `chat.delta.AndroidYggmail` to `chat.delta.androidyggmail`

compare: https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html