### PR TITLE
synchronize unread-badge-color with desktop

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -12,6 +12,8 @@
     <color name="primary_alpha_focus">#882090ea</color>
     <color name="primary_alpha33">#552090ea</color>
 
+    <color name="unread_count">#ff3792fc</color>
+
     <color name="white">#ffffffff</color>
     <color name="black">#ff000000</color>
     <color name="gray5">#ffeeeeee</color>

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -278,7 +278,7 @@ public class ConversationListItem extends RelativeLayout
               .textColor(Color.WHITE)
               .bold()
               .endConfig()
-              .buildRound(String.valueOf(unreadCount), getResources().getColor(R.color.green_A700)));
+              .buildRound(String.valueOf(unreadCount), getResources().getColor(R.color.unread_count)));
           unreadIndicator.setVisibility(View.VISIBLE);
         }
       }

--- a/src/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
+++ b/src/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
@@ -102,7 +102,7 @@ public class AccountSelectionListItem extends LinearLayout {
               .textColor(Color.WHITE)
               .bold()
               .endConfig()
-              .buildRound(String.valueOf(unreadCount), getResources().getColor(R.color.green_A700)));
+              .buildRound(String.valueOf(unreadCount), getResources().getColor(R.color.unread_count)));
       unreadIndicator.setVisibility(View.VISIBLE);
     }
   }


### PR DESCRIPTION
currently, all three big delta chat uis have different colors for the unread badge:

- desktop is _blue_
- android is _green_
- ios is _red_

esp. for the latter, red seems to be a bad choice as that is easily mixed with error symbols, however, it makes sense to use a similar color for all systems anyway.

in several one-to-one-discussions, there was a majority for _blue_ - so that desktop does not need to do anything to do on that :)
however, blue might also be a good choice as that color is already used on android here and there (headlines etc.) and we were also thinking about chaning the title bar to sth. blueish (however, that is out of scope for now)

i am totally aware that there will ppl that _love_ the current green, these kind of changes are always a matter of taste and cannot be fine for everyone :)

before/after:

<img width="328" alt="Screen Shot 2021-11-28 at 17 31 06" src="https://user-images.githubusercontent.com/9800740/143777189-20cc5339-096a-4bf7-ba9b-5e9a322f8d14.png"> &nbsp; &nbsp; <img width="328" alt="Screen Shot 2021-11-28 at 17 32 19" src="https://user-images.githubusercontent.com/9800740/143777191-ad8351d1-fa08-42a1-b3ee-d0e97c94e279.png">

if we merge that in, i'll create a corresponding pr for ios.
