### PR TITLE
make tracking core versions easier

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -15,12 +15,12 @@ this will take some time - meanwhile we're doing some housekeeping:
    $ ./scripts/tx-pull-translations.sh
    $ ./scripts/create-local-help.sh
 
-4. add a device message to ConversationListActivity::onCreate()
-   and update CHANGELOG.md
-   (the core-changelog at
-   https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md
-   and the "N commits to master since last release" on
-   https://github.com/deltachat/deltachat-android/releases gives some hints)
+4. a) update CHANGELOG.md
+      from https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md
+      and https://github.com/deltachat/deltachat-android/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc
+   b) add used core version to CHANGELOG.md
+   c) add a device message to ConversationListActivity::onCreate()
+      or remove the old one
 
 in Android Studio:
 

--- a/scripts/update-core.sh
+++ b/scripts/update-core.sh
@@ -12,11 +12,12 @@ git submodule update --init --recursive
 cd jni/deltachat-core-rust
 git checkout master
 git pull
+commitmsg=`git log -1 --pretty=%s`
 cd ../..
 
 # commit changes
 git add jni/deltachat-core-rust
-git commit -m "update deltachat-core-rust submodule"
+git commit -m "update deltachat-core-rust submodule to '$commitmsg'"
 
 echo "changes are commited to local repo."
 echo "use 'git push' to use them or 'git reset HEAD~1; git submodule update --recursive' to abort on your own risk :)"


### PR DESCRIPTION
this is the outcome of recent dc discussions, see commit messages for details.

i already used the changed script for the last core update, see https://github.com/deltachat/deltachat-android/commit/c67e61c12ef06a9eafd91bdbf0621f61ef23e0cf

