### PR TITLE
prepare 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Delta Chat Android Changelog
 
+## v1.26.0
+2021-11
+
+* re-layout all QR codes and unify appearance among the different platforms
+* show when a contact was "Last seen" in the contact's profile
+* group creation: skip presetting a draft that is deleted most times anyway
+* display auto-generated avatars and unread counters similar across platforms
+* fix chat assignment when forwarding
+* fix layout bug in chatlist title
+* fix crashes when opening map
+* switch from Mapbox to Maplibre
+* update translations
+* update to core68
+
+
 ## v1.24.4
 2021-11
 
@@ -7,6 +22,7 @@
 * fix: apply existing ephemeral timer also to partially downloaded messages;
   after full download, the ephemeral timer starts over
 * update translations and local help
+* update to core65
 
 
 ## v1.24.3

--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 618
-        versionName "1.24.4"
+        versionCode 619
+        versionName "1.26.0"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -946,8 +946,7 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_22">What\'s new in 1.22?\n\n👋 Chat Requests now pop up as single chats and can be inspected in detail before accepting or blocking\n\n🗄️ The Archive is now easily accessible from the main menu - you\'ll also find your old requests there\n\n📮📮📮 Multi-account improved: Switching accounts is now faster and less often blocked by lengthy updates\n\n🤔 Know what\'s going on: Connection problems are shown in the title bar now, tap for details\n\nMore on the blog:</string>
-    <string name="update_1_22_ios">What\'s new in 1.22?\n\n👋 Chat Requests now pop up as single chats and can be inspected in detail before accepting or blocking\n\n🗄️ The Archive is now easily accessible from the settings - you\'ll also find your old requests there\n\n📮📮📮 Multi-account added: Switch and manage accounts in the settings\n\n🤔 Know what\'s going on: Connection problems are shown in the title bar now, tap for details\n\nMore on the blog:</string>
     <string name="update_1_24_android">1.24 at a glance:\n\n• Save taps: Account selection in the upper left corner of the chat list\n• Save more taps: Long-tap the app icon to open recent chats directly\n• Save traffic: Download large files as needed\n• Save nerves: faster, non-blocking QR code joins and new QR code options\n\nMore at 👉</string>
     <string name="update_1_24_ios">1.24 at a glance:\n\n• Start an in-chat search from the chat\'s profile\n• Save traffic: Download large files as needed\n• Save nerves: faster, non-blocking QR code joins\n\nMore at 👉</string>
+    <string name="update_1_26">1.26 polishing 💅\n\n• After making the QR codes non-blocking in 1.24, they also look much nicer now - on all platforms\n• Avatars and badges look similar across platform\n• Lots of bugs fixed</string>
 </resources>

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -100,6 +100,10 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     msg.setText(getString(R.string.update_1_24_android) + " https://delta.chat/en/blog");
     dcContext.addDeviceMsg("update_1_24n_android", msg); // addDeviceMessage() makes sure, messages with the same id are not added twice
 
+    msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+    msg.setText(getString(R.string.update_1_26));
+    dcContext.addDeviceMsg("update_1_26c_android", msg); // addDeviceMessage() makes sure, messages with the same id are not added twice
+
     // create view
     setContentView(R.layout.conversation_list_activity);
 


### PR DESCRIPTION
as this comes shortly after 1.24, as an exception, we keep both device messages:

![Screen Shot 2021-11-28 at 21 47 00](https://user-images.githubusercontent.com/9800740/143785488-e80d0a75-e470-4195-bdb2-9bddab26a433.png)
