### PR TITLE
Fix unread count: Always show exactly the info that core gives us

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -135,19 +135,18 @@ public class ConversationListItem extends RelativeLayout
     this.glideRequests    = glideRequests;
 
     int state       = dcSummary.getState();
-    int unreadCount = ((state==DcMsg.DC_STATE_IN_FRESH || state==DcMsg.DC_STATE_IN_NOTICED) && !thread.isContactRequest())?
-                        thread.getUnreadCount() : 0;
+    int unreadCount = thread.getUnreadCount();
 
     if (highlightSubstring != null) {
       this.fromView.setText(getHighlightedSpan(locale, recipient.getName(), highlightSubstring));
     } else {
-      this.fromView.setText(recipient, unreadCount == 0);
+      this.fromView.setText(recipient, state!=DcMsg.DC_STATE_IN_FRESH);
     }
 
     this.subjectView.setText(thread.getDisplayBody());
-    this.subjectView.setTypeface(unreadCount == 0 ? LIGHT_TYPEFACE : BOLD_TYPEFACE);
-    this.subjectView.setTextColor(unreadCount == 0 ? ThemeUtil.getThemedColor(getContext(), R.attr.conversation_list_item_subject_color)
-                                                   : ThemeUtil.getThemedColor(getContext(), R.attr.conversation_list_item_unread_color));
+    this.subjectView.setTypeface(state==DcMsg.DC_STATE_IN_FRESH ? BOLD_TYPEFACE : LIGHT_TYPEFACE);
+    this.subjectView.setTextColor(state==DcMsg.DC_STATE_IN_FRESH ? ThemeUtil.getThemedColor(getContext(), R.attr.conversation_list_item_unread_color)
+                                                                 : ThemeUtil.getThemedColor(getContext(), R.attr.conversation_list_item_subject_color));
 
     if (thread.getDate() > 0) {
       CharSequence date = DateUtils.getBriefRelativeTimeSpanString(getContext(), locale, thread.getDate());
@@ -264,46 +263,39 @@ public class ConversationListItem extends RelativeLayout
     {
       requestBadgeView.setVisibility(View.GONE);
       archivedBadgeView.setVisibility(View.GONE);
-      if (state==DcMsg.DC_STATE_IN_FRESH || state==DcMsg.DC_STATE_IN_NOTICED)
-      {
-        deliveryStatusIndicator.setNone();
-        if(unreadCount==0) {
-          unreadIndicator.setVisibility(View.GONE);
-        }
-        else {
-          unreadIndicator.setImageDrawable(TextDrawable.builder()
-              .beginConfig()
-              .width(ViewUtil.dpToPx(getContext(), 24))
-              .height(ViewUtil.dpToPx(getContext(), 24))
-              .textColor(Color.WHITE)
-              .bold()
-              .endConfig()
-              .buildRound(String.valueOf(unreadCount), getResources().getColor(R.color.unread_count)));
-          unreadIndicator.setVisibility(View.VISIBLE);
-        }
-      }
-      else
-      {
-        unreadIndicator.setVisibility(View.GONE);
-        if (state == DcMsg.DC_STATE_OUT_ERROR) {
-          deliveryStatusIndicator.setFailed();
-        } else if (state == DcMsg.DC_STATE_OUT_MDN_RCVD) {
-          deliveryStatusIndicator.setRead();
-        } else if (state == DcMsg.DC_STATE_OUT_DELIVERED) {
-          deliveryStatusIndicator.setSent();
-        } else if (state == DcMsg.DC_STATE_OUT_PREPARING) {
-          deliveryStatusIndicator.setPreparing();
-        } else if (state == DcMsg.DC_STATE_OUT_PENDING) {
-          deliveryStatusIndicator.setPending();
-        } else {
-          deliveryStatusIndicator.setNone();
-        }
 
-        if (state == DcMsg.DC_STATE_OUT_ERROR) {
-          deliveryStatusIndicator.setTint(Color.RED);
-        } else {
-          deliveryStatusIndicator.resetTint();
-        }
+      if(unreadCount==0) {
+        unreadIndicator.setVisibility(View.GONE);
+      } else {
+        unreadIndicator.setImageDrawable(TextDrawable.builder()
+                .beginConfig()
+                .width(ViewUtil.dpToPx(getContext(), 24))
+                .height(ViewUtil.dpToPx(getContext(), 24))
+                .textColor(Color.WHITE)
+                .bold()
+                .endConfig()
+                .buildRound(String.valueOf(unreadCount), getResources().getColor(R.color.unread_count)));
+        unreadIndicator.setVisibility(View.VISIBLE);
+      }
+
+      if (state == DcMsg.DC_STATE_OUT_ERROR) {
+        deliveryStatusIndicator.setFailed();
+      } else if (state == DcMsg.DC_STATE_OUT_MDN_RCVD) {
+        deliveryStatusIndicator.setRead();
+      } else if (state == DcMsg.DC_STATE_OUT_DELIVERED) {
+        deliveryStatusIndicator.setSent();
+      } else if (state == DcMsg.DC_STATE_OUT_PREPARING) {
+        deliveryStatusIndicator.setPreparing();
+      } else if (state == DcMsg.DC_STATE_OUT_PENDING) {
+        deliveryStatusIndicator.setPending();
+      } else {
+        deliveryStatusIndicator.setNone();
+      }
+
+      if (state == DcMsg.DC_STATE_OUT_ERROR) {
+        deliveryStatusIndicator.setTint(Color.RED);
+      } else {
+        deliveryStatusIndicator.resetTint();
       }
     }
   }


### PR DESCRIPTION
Probably best reviewed with space changes ignored in the split diff view.

Fix #2163 by making the unread badge visible in the chatlist again. The
user can then go into this chat once in order to mark it as noticed.

Since https://github.com/deltachat/deltachat-core-rust/pull/2861,
the core will prevent the situation "the last message
is outgoing but there are fresh messages" from newly coming up, by
automatically marking the messages as noticed.

This PR removes all the logic that involved some "if the last message is
not fresh|noticed, the unread count should be 0" as this kind of logic
belongs to the core, because otherwise 1) have different behavior on
different platforms 2) issues like #2163 appear.

Now, if the _unread count_ is non-zero, the _unread badge_ is shown.

If the state of the _last message_ is "fresh", the line with the _last
message_ (called `subjectView` in the code) is shown in bold.