### PR TITLE
improve wording of one-to-one-chat hint

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -359,7 +359,7 @@
     </plurals>
     <string name="chat_no_messages_hint">Send message to %1$s:\n\n• It is okay if %2$s does not use Delta Chat.\n\n• Delivering the first message may take a while and may be unencrypted.</string>
     <!-- The placeholder will be replaced by the name of the recipient in a one-to-one chat. -->
-    <string name="chat_new_one_to_one_hint">Send a first message to %1$s.</string>
+    <string name="chat_new_one_to_one_hint">Send a message. It is okay if %1$s does not use Delta Chat.</string>
     <string name="chat_new_broadcast_hint">In a broadcast list, others will receive messages in their private chats with you.\n\nThe recipients will not be aware of each other.</string>
     <string name="chat_new_group_hint">Others will only see this group after you sent a first message.</string>
     <string name="chat_record_slide_to_cancel">Slide to cancel</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -358,6 +358,8 @@
         <item quantity="other">%d new messages</item>
     </plurals>
     <string name="chat_no_messages_hint">Send message to %1$s:\n\n• It is okay if %2$s does not use Delta Chat.\n\n• Delivering the first message may take a while and may be unencrypted.</string>
+    <!-- The placeholder will be replaced by the name of the recipient in a one-to-one chat. -->
+    <string name="chat_new_one_to_one_hint">Send a first message to %1$s.</string>
     <string name="chat_new_broadcast_hint">In a broadcast list, others will receive messages in their private chats with you.\n\nThe recipients will not be aware of each other.</string>
     <string name="chat_new_group_hint">Others will only see this group after you sent a first message.</string>
     <string name="chat_record_slide_to_cancel">Slide to cancel</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -191,7 +191,7 @@ public class ConversationFragment extends MessageSelectorFragment
             noMessageTextView.setText(R.string.device_talk_explain);
         }
         else {
-            String message = getString(R.string.chat_no_messages_hint, dcChat.getName(), dcChat.getName());
+            String message = getString(R.string.chat_new_one_to_one_hint, dcChat.getName());
             noMessageTextView.setText(message);
         }
     }


### PR DESCRIPTION
at #2134 we shortend the hint shown for an empty group massively,
removing greylisting hints and the hint that the recipient can user other mua. also we do not say anything about encryption on group creation.

the result of that shortening is that the creation of a one-to-one chat
is now way too long :)

i suggest shorten the hint in a similar way,
not much would be left then, however, that is maybe not bad :)

suggestions welcome, of course :)

<img width="335" alt="Screen Shot 2021-12-12 at 11 43 52" src="https://user-images.githubusercontent.com/9800740/145709264-d59c6efb-24d5-4b3b-89d9-e3ed4bf3f634.png"> &nbsp; <img width="337" alt="Screen Shot 2021-12-08 at 12 58 15" src="https://user-images.githubusercontent.com/9800740/145205573-4aa9c972-4026-4b2e-a41e-e8d6a0ad8796.png">  
_left: new one-to-one hint in this pr; right: already improved group hint_

EDIT: updated screenshots:

