### PR TITLE
Make ndk-make.sh debug builds (for just one arch) more usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ ffpr
 test/androidTestEspresso/res/values/arrays.xml
 obj/
 jni/libspeex/.deps/
+ndkArch
 
 # ignore debug symbols created by ./tools/upload-release.sh
 *-symbols.zip

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ android {
 
         buildConfigField("String", "TEST_ADDR", buildConfigProperty("TEST_ADDR"))
         buildConfigField("String", "TEST_MAIL_PW", buildConfigProperty("TEST_MAIL_PW"))
+        buildConfigField("String", "NDK_ARCH", getNdkArch())
     }
 
     compileOptions {
@@ -229,8 +230,18 @@ String propertyOrEmpty(String name) {
     return (String) p
 }
 
-String environmentVariable(String name) {
+static String environmentVariable(String name) {
     String env = System.getenv(name)
     if (env == null) return ""
     return env
+}
+
+String getNdkArch() {
+    Properties properties = new Properties()
+    def file = project.rootProject.file('ndkArch')
+    if (!file.exists()) return "\"\""
+    properties.load(file.newDataInputStream())
+    def arch = properties.getProperty('NDK_ARCH')
+    if (arch == null) return "\"\""
+    return "\"$arch\""
 }

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -10,9 +10,9 @@
 #
 #     adb shell uname -m
 #
-# or:
-#
-#     adb shell cat /proc/cpuinfo
+# Or you just guess your phone's architecture to be arm64-v8a and if you
+# guessed wrongly, a warning message will pop up inside the app, telling
+# you what the correct one is.
 #
 # The values in the following lines mean the same:
 #
@@ -27,6 +27,9 @@
 # typing `nmake`:
 #
 # nmake() {(cd ../..; ./ndk-make.sh arm64-v8a && ./gradlew installFatDebug; notify-send "install finished")}
+#
+#
+# If anything doesn't work, please open an issue!!
 
 set -e
 echo "starting time: `date`"
@@ -142,5 +145,11 @@ ndk-build
 cd jni
 # Restore old Application.mk:
 echo "$oldDotMk" > Application.mk
+
+if test $1; then
+    echo "NDK_ARCH=$1" > ../ndkArch
+else
+    rm ../ndkArch 2>/dev/null || true # Remove ndkArch, ignore if it doesn't exist
+fi
 
 echo "ending time: `date`"


### PR DESCRIPTION
Debug builds of the core (like `ndk-make.sh arm64-v8a`) take about a minute, while
a release bulid (`ndk-make.sh`) takes about 15 minutes.

But as most people seem not to use debug builds regularly because
they are tricky to use, here comes an improvement :) If you gave the wrong argument to `ndk-make.sh`, a warning dialog will now pop up inside the app, telling you what you did wrong and what you should do instead.

`ndk-make.sh` writes its argument into the file `ndkArch`.
`getNdkArch()` in `build.gradle` then reads this file and its content is assigned to
`BuildConfig.NDK_ARCH`. `checkNdkArchitecture()` then checks this.

Maybe in another PR I'll also make DC show a helpful error message if someone is completely new to DC and never ran `ndk-make.sh` at all.