### PR TITLE
don't allow to add POI if user can't send in current chat

### DIFF
--- a/src/org/thoughtcrime/securesms/map/MapActivity.java
+++ b/src/org/thoughtcrime/securesms/map/MapActivity.java
@@ -306,7 +306,7 @@ public class MapActivity extends BaseActivity implements Observer,
     }
 
     private boolean handleAddPoiClick(LatLng point) {
-        if (chatId == 0) {
+        if (chatId == 0 || !DcHelper.getContext(this).getChat(chatId).canSend()) {
             return false;
         }
 


### PR DESCRIPTION
a fix for an issue reported by @link2xt  recently in the DC-Android group