### PR TITLE
display SVG images in chats

### DIFF
--- a/src/org/thoughtcrime/securesms/glide/svg/SvgDecoder.java
+++ b/src/org/thoughtcrime/securesms/glide/svg/SvgDecoder.java
@@ -1,0 +1,40 @@
+package org.thoughtcrime.securesms.glide.svg;
+
+import static com.bumptech.glide.request.target.Target.SIZE_ORIGINAL;
+
+import androidx.annotation.NonNull;
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.ResourceDecoder;
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.resource.SimpleResource;
+import com.caverock.androidsvg.SVG;
+import com.caverock.androidsvg.SVGParseException;
+import java.io.IOException;
+import java.io.InputStream;
+
+/** Decodes an SVG internal representation from an {@link InputStream}. */
+public class SvgDecoder implements ResourceDecoder<InputStream, SVG> {
+
+  @Override
+  public boolean handles(@NonNull InputStream source, @NonNull Options options) {
+    // TODO: Can we tell?
+    return true;
+  }
+
+  public Resource<SVG> decode(
+      @NonNull InputStream source, int width, int height, @NonNull Options options)
+      throws IOException {
+    try {
+      SVG svg = SVG.getFromInputStream(source);
+      if (width != SIZE_ORIGINAL) {
+        svg.setDocumentWidth(width);
+      }
+      if (height != SIZE_ORIGINAL) {
+        svg.setDocumentHeight(height);
+      }
+      return new SimpleResource<>(svg);
+    } catch (SVGParseException ex) {
+      throw new IOException("Cannot load SVG from stream", ex);
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/glide/svg/SvgDrawableTranscoder.java
+++ b/src/org/thoughtcrime/securesms/glide/svg/SvgDrawableTranscoder.java
@@ -1,0 +1,26 @@
+package org.thoughtcrime.securesms.glide.svg;
+
+import android.graphics.Picture;
+import android.graphics.drawable.PictureDrawable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.resource.SimpleResource;
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder;
+import com.caverock.androidsvg.SVG;
+
+/**
+ * Convert the {@link SVG}'s internal representation to an Android-compatible one ({@link Picture}).
+ */
+public class SvgDrawableTranscoder implements ResourceTranscoder<SVG, PictureDrawable> {
+  @Nullable
+  @Override
+  public Resource<PictureDrawable> transcode(
+      @NonNull Resource<SVG> toTranscode, @NonNull Options options) {
+    SVG svg = toTranscode.get();
+    Picture picture = svg.renderToPicture();
+    PictureDrawable drawable = new PictureDrawable(picture);
+    return new SimpleResource<>(drawable);
+  }
+}

--- a/src/org/thoughtcrime/securesms/mms/SignalGlideModule.java
+++ b/src/org/thoughtcrime/securesms/mms/SignalGlideModule.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.mms;
 
 import android.content.Context;
+import android.graphics.drawable.PictureDrawable;
 
 import androidx.annotation.NonNull;
 import android.util.Log;
@@ -12,8 +13,12 @@ import com.bumptech.glide.annotation.GlideModule;
 import com.bumptech.glide.load.model.UnitModelLoader;
 import com.bumptech.glide.module.AppGlideModule;
 
+import com.caverock.androidsvg.SVG;
+
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.thoughtcrime.securesms.glide.ContactPhotoLoader;
+import org.thoughtcrime.securesms.glide.svg.SvgDecoder;
+import org.thoughtcrime.securesms.glide.svg.SvgDrawableTranscoder;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 
 import java.io.File;
@@ -49,5 +54,9 @@ public class SignalGlideModule extends AppGlideModule {
     registry.append(ContactPhoto.class, InputStream.class, new ContactPhotoLoader.Factory(context));
     registry.append(DecryptableUri.class, InputStream.class, new DecryptableStreamUriLoader.Factory(context));
     //registry.replace(GlideUrl.class, InputStream.class, new OkHttpUrlLoader.Factory());
+
+    registry
+        .register(SVG.class, PictureDrawable.class, new SvgDrawableTranscoder())
+        .append(InputStream.class, SVG.class, new SvgDecoder());
   }
 }


### PR DESCRIPTION
now that we are using a lib to display the SVG QR codes, reusing that lib to display SVG files also in chats is cheap, I have taken some example from glide's repo to add SVG support as a glide plugin so no change is needed in all parts of the code that load the images with glide