### PR TITLE
Make it possible to create an encrypted database

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -313,13 +313,13 @@ JNIEXPORT jlong Java_com_b44t_messenger_DcContext_createContextCPtr(JNIEnv *env,
 }
 
 
-JNIEXPORT jint Java_com_b44t_messenger_DcContext_open(JNIEnv *env, jobject obj, jstring passphrase)
+JNIEXPORT jboolean Java_com_b44t_messenger_DcContext_open(JNIEnv *env, jobject obj, jstring passphrase)
 {
     CHAR_REF(passphrase);
-    jint ret = dc_context_open(get_dc_context(env, obj), passphrasePtr);
+    jboolean ret = dc_context_open(get_dc_context(env, obj), passphrasePtr);
     CHAR_UNREF(passphrase);
     return ret;
-} // TODO should maybe return jboolean
+}
 
 
 JNIEXPORT jboolean Java_com_b44t_messenger_DcContext_isOpen(JNIEnv *env, jobject obj)

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -206,6 +206,12 @@ JNIEXPORT jint Java_com_b44t_messenger_DcAccounts_addAccount(JNIEnv *env, jobjec
 }
 
 
+JNIEXPORT jint Java_com_b44t_messenger_DcAccounts_addClosedAccount(JNIEnv *env, jobject obj)
+{
+    return dc_accounts_add_closed_account(get_dc_accounts(env, obj));
+}
+
+
 JNIEXPORT jint Java_com_b44t_messenger_DcAccounts_migrateAccount(JNIEnv *env, jobject obj, jstring dbfile)
 {
     CHAR_REF(dbfile);
@@ -304,6 +310,21 @@ JNIEXPORT jlong Java_com_b44t_messenger_DcContext_createContextCPtr(JNIEnv *env,
     CHAR_UNREF(dbfile)
     CHAR_UNREF(osname);
     return contextCPtr;
+}
+
+
+JNIEXPORT jint Java_com_b44t_messenger_DcContext_open(JNIEnv *env, jobject obj, jstring passphrase)
+{
+    CHAR_REF(passphrase);
+    jint ret = dc_context_open(get_dc_context(env, obj), passphrasePtr);
+    CHAR_UNREF(passphrase);
+    return ret;
+} // TODO should maybe return jboolean
+
+
+JNIEXPORT jboolean Java_com_b44t_messenger_DcContext_isOpen(JNIEnv *env, jobject obj)
+{
+    return dc_context_is_open(get_dc_context(env, obj));
 }
 
 

--- a/res/layout/dialog_with_checkbox.xml
+++ b/res/layout/dialog_with_checkbox.xml
@@ -14,7 +14,7 @@
         android:orientation="vertical">
 
         <TextView
-            android:id="@+id/autodel_ask_msg"
+            android:id="@+id/dialog_message"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textSize="16sp"
@@ -23,8 +23,8 @@
             tools:text="Really delete these msgs?" />
 
         <CheckBox
-            android:id="@+id/i_understand"
-            android:text="@string/autodel_confirm"
+            android:id="@+id/dialog_checkbox"
+            tools:text="@string/autodel_confirm"
             android:textSize="16sp"
             android:textColor="@color/red_500"
             android:layout_width="wrap_content"

--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -121,7 +121,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="inbox, imap_login, imap_server, imap_port, imap_security_label, imap_security, outbox_view_spacer_top,
+            tools:visibility="visible"
+            app:constraint_referenced_ids="encrypt_checkbox, inbox, imap_login, imap_server, imap_port, imap_security_label, imap_security, outbox_view_spacer_top,
             outbox, smtp_login, smtp_password, smtp_server, smtp_port, smtp_security_label, smtp_security, auth_method_label, auth_method, cert_check_label, cert_check, view_log_button" />
 
         <ImageView
@@ -150,15 +151,26 @@
             app:layout_constraintStart_toEndOf="@id/advanced_icon"
             app:layout_constraintTop_toBottomOf="@id/no_servers_hint" />
 
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/encrypt_checkbox"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="Encrypt database (experimental)"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="12dp"
+            app:layout_constraintStart_toStartOf="@id/guideline_root_start"
+            app:layout_constraintEnd_toEndOf="@id/guideline_root_end"
+            app:layout_constraintTop_toBottomOf="@id/advanced_text" />
+
         <TextView
             android:id="@+id/inbox"
             android:layout_width="wrap_content"
             android:layout_height="24dp"
             android:gravity="center"
-            android:paddingTop="8dp"
+            android:layout_marginTop="8dp"
             android:text="@string/login_inbox"
             app:layout_constraintStart_toStartOf="@id/guideline_root_start"
-            app:layout_constraintTop_toBottomOf="@id/advanced_text" />
+            app:layout_constraintTop_toBottomOf="@id/encrypt_checkbox" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/imap_login"

--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -155,7 +155,7 @@
             android:id="@+id/encrypt_checkbox"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Encrypt database (experimental)"
+            android:text="Encrypt database (highly experimental, use at your own risk)"
             android:layout_marginTop="12dp"
             android:layout_marginBottom="12dp"
             app:layout_constraintStart_toStartOf="@id/guideline_root_start"

--- a/src/com/b44t/messenger/DcAccounts.java
+++ b/src/com/b44t/messenger/DcAccounts.java
@@ -25,6 +25,7 @@ public class DcAccounts {
     public native void            maybeNetwork         ();
 
     public native int             addAccount           ();
+    public native int             addClosedAccount     ();
     public native int             migrateAccount       (String dbfile);
     public native boolean         removeAccount        (int accountId);
     public native int[]           getAll               ();

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -119,6 +119,8 @@ public class DcContext {
     public native void         configure            ();
     public native void         stopOngoingProcess   ();
     public native int          isConfigured         ();
+    public native int          open                 (String passphrase);
+    public native boolean      isOpen               ();
 
     // when using DcAccounts, use DcAccounts.startIo() instead
     public native void         startIo              ();

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -119,7 +119,7 @@ public class DcContext {
     public native void         configure            ();
     public native void         stopOngoingProcess   ();
     public native int          isConfigured         ();
-    public native int          open                 (String passphrase);
+    public native boolean      open                 (String passphrase);
     public native boolean      isOpen               ();
 
     // when using DcAccounts, use DcAccounts.startIo() instead

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 //import com.squareup.leakcanary.LeakCanary;
 
 public class ApplicationContext extends MultiDexApplication {
+  private static final String TAG = ApplicationContext.class.getSimpleName();
 
   public DcAccounts             dcAccounts;
   public DcContext              dcContext;
@@ -83,8 +84,10 @@ public class ApplicationContext extends MultiDexApplication {
     for (int accountId : allAccounts) {
       DcContext ac = dcAccounts.getAccount(accountId);
       if (!ac.isOpen()) {
-        DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(this);
-        ac.open(secret.asString());
+        DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(this, accountId);
+        int res = ac.open(secret.asString());
+        if (res == 1) Log.i(TAG, "Successfully opened account " + accountId);
+        else Log.e(TAG, "Error opening account " + accountId);
       }
     }
     if (allAccounts.length == 0) {

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -86,7 +86,7 @@ public class ApplicationContext extends MultiDexApplication {
       if (!ac.isOpen()) {
         DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(this, accountId);
         int res = ac.open(secret.asString());
-        if (res == 1) Log.i(TAG, "Successfully opened account " + accountId);
+        if (res == 1) Log.i(TAG, "Successfully opened account " + accountId + ", path: " + ac.getBlobdir());
         else Log.e(TAG, "Error opening account " + accountId);
       }
     }

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -84,10 +84,15 @@ public class ApplicationContext extends MultiDexApplication {
     for (int accountId : allAccounts) {
       DcContext ac = dcAccounts.getAccount(accountId);
       if (!ac.isOpen()) {
-        DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(this, accountId);
-        boolean res = ac.open(secret.asString());
-        if (res) Log.i(TAG, "Successfully opened account " + accountId + ", path: " + ac.getBlobdir());
-        else Log.e(TAG, "Error opening account " + accountId);
+        try {
+          DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(this, accountId);
+          boolean res = ac.open(secret.asString());
+          if (res) Log.i(TAG, "Successfully opened account " + accountId + ", path: " + ac.getBlobdir());
+          else Log.e(TAG, "Error opening account " + accountId + ", path: " + ac.getBlobdir());
+        } catch (Exception e) {
+          Log.e(TAG, "Failed to open account " + accountId + ", path: " + ac.getBlobdir() + ": " + e);
+          e.printStackTrace();
+        }
       }
     }
     if (allAccounts.length == 0) {

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -85,8 +85,8 @@ public class ApplicationContext extends MultiDexApplication {
       DcContext ac = dcAccounts.getAccount(accountId);
       if (!ac.isOpen()) {
         DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(this, accountId);
-        int res = ac.open(secret.asString());
-        if (res == 1) Log.i(TAG, "Successfully opened account " + accountId + ", path: " + ac.getBlobdir());
+        boolean res = ac.open(secret.asString());
+        if (res) Log.i(TAG, "Successfully opened account " + accountId + ", path: " + ac.getBlobdir());
         else Log.e(TAG, "Error opening account " + accountId);
       }
     }

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -1,51 +1,5 @@
 package org.thoughtcrime.securesms;
 
-import android.content.ActivityNotFoundException;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.content.res.Resources;
-import android.net.Uri;
-import android.os.Bundle;
-import androidx.annotation.IdRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.constraintlayout.widget.Group;
-
-import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcProvider;
-import com.google.android.material.textfield.TextInputEditText;
-import com.google.android.material.textfield.TextInputLayout;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AlertDialog;
-
-import android.text.Editable;
-import android.text.TextUtils;
-import android.text.TextWatcher;
-import android.util.Patterns;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.widget.ImageView;
-import android.widget.Spinner;
-import android.widget.TextView;
-import android.widget.Toast;
-
-import com.b44t.messenger.DcContext;
-
-import org.thoughtcrime.securesms.connect.DcEventCenter;
-import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.permissions.Permissions;
-import org.thoughtcrime.securesms.util.DynamicTheme;
-import org.thoughtcrime.securesms.util.IntentUtils;
-import org.thoughtcrime.securesms.util.concurrent.ListenableFuture;
-import org.thoughtcrime.securesms.util.concurrent.SettableFuture;
-import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
-import org.thoughtcrime.securesms.util.views.ProgressDialog;
-
-import java.lang.ref.WeakReference;
-import java.util.concurrent.ExecutionException;
-
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ADDRESS;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_MAIL_PASSWORD;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_MAIL_PORT;
@@ -60,6 +14,54 @@ import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SEND_USER;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SERVER_FLAGS;
 import static org.thoughtcrime.securesms.connect.DcHelper.getContext;
 import static org.thoughtcrime.securesms.service.IPCAddAccountsService.ACCOUNT_DATA;
+
+import android.content.ActivityNotFoundException;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.net.Uri;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.util.Patterns;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.ImageView;
+import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.constraintlayout.widget.Group;
+
+import com.b44t.messenger.DcContext;
+import com.b44t.messenger.DcEvent;
+import com.b44t.messenger.DcProvider;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
+
+import org.thoughtcrime.securesms.connect.AccountManager;
+import org.thoughtcrime.securesms.connect.DcEventCenter;
+import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.permissions.Permissions;
+import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.IntentUtils;
+import org.thoughtcrime.securesms.util.concurrent.ListenableFuture;
+import org.thoughtcrime.securesms.util.concurrent.SettableFuture;
+import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
+import org.thoughtcrime.securesms.util.views.ProgressDialog;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ExecutionException;
 
 public class RegistrationActivity extends BaseActionBarActivity implements DcEventCenter.DcEventDelegate {
 
@@ -78,6 +80,8 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
     private TextView providerHint;
     private TextView providerLink;
     private @Nullable DcProvider provider;
+
+    private CheckBox encryptCheckbox;
 
     private Group advancedGroup;
     private ImageView advancedIcon;
@@ -102,6 +106,8 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
         providerHint = findViewById(R.id.provider_hint);
         providerLink = findViewById(R.id.provider_link);
         providerLink.setOnClickListener(l -> onProviderLink());
+
+        encryptCheckbox = findViewById(R.id.encrypt_checkbox);
 
         advancedGroup = findViewById(R.id.advanced_group);
         advancedIcon = findViewById(R.id.advanced_icon);
@@ -176,6 +182,10 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
 
             int certCheckFlags = DcHelper.getInt(this, "imap_certificate_checks");
             certCheck.setSelection(certCheckFlags);
+            encryptCheckbox.setHeight(0);
+            encryptCheckbox.setClickable(false);
+            encryptCheckbox.setFocusable(false);
+            Log.e("dbg", "set vis to gone, dbg");
         } else if (getIntent() != null && getIntent().getBundleExtra(ACCOUNT_DATA) != null) {
           // Companion app might have sent account data
           Bundle b = getIntent().getBundleExtra(ACCOUNT_DATA);
@@ -517,6 +527,11 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
     }
 
     private void setupConfig() {
+        if (encryptCheckbox.isSelected()) {
+            AccountManager accountManager = AccountManager.getInstance();
+            accountManager.switchToEncrypted(this);
+        }
+
         setConfig(R.id.email_text, "addr", true);
         setConfig(R.id.password_text, "mail_pw", false);
         setConfig(R.id.imap_server_text, "mail_server", true);

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -24,7 +24,6 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.util.Patterns;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -185,7 +184,6 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             encryptCheckbox.setHeight(0);
             encryptCheckbox.setClickable(false);
             encryptCheckbox.setFocusable(false);
-            Log.e("dbg", "set vis to gone, dbg");
         } else if (getIntent() != null && getIntent().getBundleExtra(ACCOUNT_DATA) != null) {
           // Companion app might have sent account data
           Bundle b = getIntent().getBundleExtra(ACCOUNT_DATA);

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -525,9 +525,10 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
     }
 
     private void setupConfig() {
-        if (encryptCheckbox.isSelected()) {
+        if (encryptCheckbox.isChecked()) {
             AccountManager accountManager = AccountManager.getInstance();
             accountManager.switchToEncrypted(this);
+            encryptCheckbox.setEnabled(false); // Prevent the user from disabling the checkbox again
         }
 
         setConfig(R.id.email_text, "addr", true);

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -165,15 +165,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                                     .setNegativeButton(android.R.string.cancel, null)
                                     .setPositiveButton(android.R.string.ok, (dialog, which) -> startImport(backupFile, null, encryptCheckbox.isChecked()))
                                     .show();
-
-
-
-//                            new AlertDialog.Builder(this)
-//                                    .setTitle(R.string.import_backup_title)
-//                                    .setMessage(String.format(getResources().getString(R.string.import_backup_ask), backupFile))
-//                                    .setNegativeButton(android.R.string.cancel, null)
-//                                    .setPositiveButton(android.R.string.ok, (dialog, which) -> startImport(backupFile, null, false))
-//                                    .show();
                         }
                         else {
                             new AlertDialog.Builder(this)

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -13,14 +13,13 @@ import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.ConversationListActivity;
-import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.WelcomeActivity;
 import org.thoughtcrime.securesms.accounts.AccountSelectionListFragment;
+import org.thoughtcrime.securesms.crypto.DatabaseSecret;
+import org.thoughtcrime.securesms.crypto.DatabaseSecretProvider;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
-import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 
 import java.io.File;
-import java.lang.ref.WeakReference;
 
 public class AccountManager {
 
@@ -133,6 +132,22 @@ public class AccountManager {
         } else {
             activity.startActivity(new Intent(activity.getApplicationContext(), ConversationListActivity.class));
         }
+    }
+
+    public void switchToEncrypted(Activity activity) {
+        DcAccounts accounts = DcHelper.getAccounts(activity);
+        DcContext selectedAccount = accounts.getSelectedAccount();
+        if (selectedAccount.isConfigured() == 1) {
+            throw new RuntimeException("Can't switch to encrypted account if already configured");
+        }
+
+        int selectedAccountId = selectedAccount.getAccountId();
+        accounts.addClosedAccount();
+        accounts.removeAccount(selectedAccountId);
+
+        DcContext newAccount = accounts.getSelectedAccount();
+        DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(activity);
+        newAccount.open(secret.asString());
     }
 
     // ui

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -134,11 +134,15 @@ public class AccountManager {
         }
     }
 
+    /**
+     * Deletes the current account (must be unconfigured) and creates an encrypted account instead.
+     * @throws IllegalStateException if the currently selected account is already configured.
+     */
     public void switchToEncrypted(Activity activity) {
         DcAccounts accounts = DcHelper.getAccounts(activity);
         DcContext selectedAccount = accounts.getSelectedAccount();
         if (selectedAccount.isConfigured() == 1) {
-            throw new RuntimeException("Can't switch to encrypted account if already configured");
+            throw new IllegalStateException("Can't switch to encrypted account if already configured");
         }
 
         int selectedAccountId = selectedAccount.getAccountId();

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -152,6 +152,7 @@ public class AccountManager {
         DcContext newAccount = accounts.getSelectedAccount();
         DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(activity);
         newAccount.open(secret.asString());
+        resetDcContext(activity);
     }
 
     // ui

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.preference.PreferenceManager;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
@@ -139,6 +140,7 @@ public class AccountManager {
      * @throws IllegalStateException if the currently selected account is already configured.
      */
     public void switchToEncrypted(Activity activity) {
+        Log.i(TAG, "Switching to encrypted account...");
         DcAccounts accounts = DcHelper.getAccounts(activity);
         DcContext selectedAccount = accounts.getSelectedAccount();
         if (selectedAccount.isConfigured() == 1) {
@@ -150,7 +152,7 @@ public class AccountManager {
         accounts.removeAccount(selectedAccountId);
 
         DcContext newAccount = accounts.getSelectedAccount();
-        DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(activity);
+        DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(activity, newAccount.getAccountId());
         newAccount.open(secret.asString());
         resetDcContext(activity);
     }

--- a/src/org/thoughtcrime/securesms/crypto/DatabaseSecret.java
+++ b/src/org/thoughtcrime/securesms/crypto/DatabaseSecret.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms.crypto;
+
+
+import androidx.annotation.NonNull;
+
+import org.thoughtcrime.securesms.util.Hex;
+
+import java.io.IOException;
+
+public class DatabaseSecret {
+
+  private final byte[] key;
+  private final String encoded;
+
+  public DatabaseSecret(@NonNull byte[] key) {
+    this.key = key;
+    this.encoded = Hex.toStringCondensed(key);
+  }
+
+  public DatabaseSecret(@NonNull String encoded) throws IOException {
+    this.key     = Hex.fromStringCondensed(encoded);
+    this.encoded = encoded;
+  }
+
+  public String asString() {
+    return encoded;
+  }
+
+  public byte[] asBytes() {
+    return key;
+  }
+}

--- a/src/org/thoughtcrime/securesms/crypto/DatabaseSecretProvider.java
+++ b/src/org/thoughtcrime/securesms/crypto/DatabaseSecretProvider.java
@@ -1,0 +1,91 @@
+package org.thoughtcrime.securesms.crypto;
+
+
+import android.content.Context;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+import org.thoughtcrime.securesms.util.Prefs;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+
+/**
+ * It can be rather expensive to read from the keystore, so this class caches the key in memory
+ * after it is created.
+ */
+public final class DatabaseSecretProvider {
+
+  private static volatile DatabaseSecret instance;
+
+  public static DatabaseSecret getOrCreateDatabaseSecret(@NonNull Context context) {
+    if (instance == null) {
+      synchronized (DatabaseSecretProvider.class) {
+        if (instance == null) {
+          instance = getOrCreate(context);
+        }
+      }
+    }
+
+    return instance;
+  }
+
+  private DatabaseSecretProvider() {
+  }
+
+  private static @NonNull DatabaseSecret getOrCreate(@NonNull Context context) {
+    String unencryptedSecret = Prefs.getDatabaseUnencryptedSecret(context);
+    String encryptedSecret   = Prefs.getDatabaseEncryptedSecret(context);
+
+    if      (unencryptedSecret != null) return getUnencryptedDatabaseSecret(context, unencryptedSecret);
+    else if (encryptedSecret != null)   return getEncryptedDatabaseSecret(encryptedSecret);
+    else                                return createAndStoreDatabaseSecret(context);
+  }
+
+  private static @NonNull DatabaseSecret getUnencryptedDatabaseSecret(@NonNull Context context, @NonNull String unencryptedSecret)
+  {
+    try {
+      DatabaseSecret databaseSecret = new DatabaseSecret(unencryptedSecret);
+
+      if (Build.VERSION.SDK_INT < 23) {
+        return databaseSecret;
+      } else {
+        KeyStoreHelper.SealedData encryptedSecret = KeyStoreHelper.seal(databaseSecret.asBytes());
+
+        Prefs.setDatabaseEncryptedSecret(context, encryptedSecret.serialize());
+        Prefs.setDatabaseUnencryptedSecret(context, null);
+
+        return databaseSecret;
+      }
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static @NonNull DatabaseSecret getEncryptedDatabaseSecret(@NonNull String serializedEncryptedSecret) {
+    if (Build.VERSION.SDK_INT < 23) {
+      throw new AssertionError("OS downgrade not supported. KeyStore sealed data exists on platform < M!");
+    } else {
+      KeyStoreHelper.SealedData encryptedSecret = KeyStoreHelper.SealedData.fromString(serializedEncryptedSecret);
+      return new DatabaseSecret(KeyStoreHelper.unseal(encryptedSecret));
+    }
+  }
+
+  private static @NonNull DatabaseSecret createAndStoreDatabaseSecret(@NonNull Context context) {
+    SecureRandom random = new SecureRandom();
+    byte[]       secret = new byte[32];
+    random.nextBytes(secret);
+
+    DatabaseSecret databaseSecret = new DatabaseSecret(secret);
+
+    if (Build.VERSION.SDK_INT >= 23) {
+      KeyStoreHelper.SealedData encryptedSecret = KeyStoreHelper.seal(databaseSecret.asBytes());
+      Prefs.setDatabaseEncryptedSecret(context, encryptedSecret.serialize());
+    } else {
+      Prefs.setDatabaseUnencryptedSecret(context, databaseSecret.asString());
+    }
+
+    return databaseSecret;
+  }
+}

--- a/src/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
+++ b/src/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
@@ -1,0 +1,208 @@
+package org.thoughtcrime.securesms.crypto;
+
+
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.thoughtcrime.securesms.util.JsonUtils;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableEntryException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+public final class KeyStoreHelper {
+
+  private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+  private static final String KEY_ALIAS         = "SignalSecret";
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  public static SealedData seal(@NonNull byte[] input) {
+    SecretKey secretKey = getOrCreateKeyStoreEntry();
+
+    try {
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+
+      byte[] iv   = cipher.getIV();
+      byte[] data = cipher.doFinal(input);
+
+      return new SealedData(iv, data);
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  public static byte[] unseal(@NonNull SealedData sealedData) {
+    SecretKey secretKey = getKeyStoreEntry();
+
+    try {
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, sealedData.iv));
+
+      return cipher.doFinal(sealedData.data);
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  private static SecretKey getOrCreateKeyStoreEntry() {
+    if (hasKeyStoreEntry()) return getKeyStoreEntry();
+    else                    return createKeyStoreEntry();
+  }
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  private static SecretKey createKeyStoreEntry() {
+    try {
+      KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+      KeyGenParameterSpec keyGenParameterSpec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+              .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+              .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+              .build();
+
+      keyGenerator.init(keyGenParameterSpec);
+
+      return keyGenerator.generateKey();
+    } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  private static SecretKey getKeyStoreEntry() {
+    KeyStore keyStore = getKeyStore();
+
+    try {
+      // Attempt 1
+      return getSecretKey(keyStore);
+    } catch (UnrecoverableKeyException e) {
+      try {
+        // Attempt 2
+        return getSecretKey(keyStore);
+      } catch (UnrecoverableKeyException e2) {
+        throw new AssertionError(e2);
+      }
+    }
+  }
+
+  private static SecretKey getSecretKey(KeyStore keyStore) throws UnrecoverableKeyException {
+    try {
+      KeyStore.SecretKeyEntry entry = (KeyStore.SecretKeyEntry) keyStore.getEntry(KEY_ALIAS, null);
+      return entry.getSecretKey();
+    } catch (UnrecoverableKeyException e) {
+      throw e;
+    } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableEntryException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static KeyStore getKeyStore() {
+    try {
+      KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+      keyStore.load(null);
+      return keyStore;
+    } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  private static boolean hasKeyStoreEntry() {
+    try {
+      KeyStore ks = KeyStore.getInstance(ANDROID_KEY_STORE);
+      ks.load(null);
+
+      return ks.containsAlias(KEY_ALIAS) && ks.entryInstanceOf(KEY_ALIAS, KeyStore.SecretKeyEntry.class);
+    } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  public static class SealedData {
+
+    @SuppressWarnings("unused")
+    private static final String TAG = KeyStoreHelper.class.getSimpleName();
+
+    @JsonProperty
+    @JsonSerialize(using = ByteArraySerializer.class)
+    @JsonDeserialize(using = ByteArrayDeserializer.class)
+    private byte[] iv;
+
+    @JsonProperty
+    @JsonSerialize(using = ByteArraySerializer.class)
+    @JsonDeserialize(using = ByteArrayDeserializer.class)
+    private byte[] data;
+
+    SealedData(@NonNull byte[] iv, @NonNull byte[] data) {
+      this.iv   = iv;
+      this.data = data;
+    }
+
+    @SuppressWarnings("unused")
+    public SealedData() {}
+
+    public String serialize() {
+      try {
+        return JsonUtils.toJson(this);
+      } catch (IOException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    public static SealedData fromString(@NonNull String value) {
+      try {
+        return JsonUtils.fromJson(value, SealedData.class);
+      } catch (IOException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    private static class ByteArraySerializer extends JsonSerializer<byte[]> {
+      @Override
+      public void serialize(byte[] value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(Base64.encodeToString(value, Base64.NO_WRAP | Base64.NO_PADDING));
+      }
+    }
+
+    private static class ByteArrayDeserializer extends JsonDeserializer<byte[]> {
+
+      @Override
+      public byte[] deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return Base64.decode(p.getValueAsString(), Base64.NO_WRAP | Base64.NO_PADDING);
+      }
+    }
+
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
+++ b/src/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
@@ -43,7 +43,7 @@ import javax.crypto.spec.GCMParameterSpec;
 public final class KeyStoreHelper {
 
   private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
-  private static final String KEY_ALIAS         = "SignalSecret";
+  private static final String KEY_ALIAS         = "DeltaSecret";
 
   @RequiresApi(Build.VERSION_CODES.M)
   public static SealedData seal(@NonNull byte[] input) {

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -1,5 +1,8 @@
 package org.thoughtcrime.securesms.preferences;
 
+import static android.app.Activity.RESULT_OK;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SHOW_EMAILS;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
@@ -7,7 +10,6 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -25,9 +27,6 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.Util;
-
-import static android.app.Activity.RESULT_OK;
-import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SHOW_EMAILS;
 
 public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   private static final String TAG = ChatsPreferenceFragment.class.getSimpleName();
@@ -217,15 +216,16 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
         boolean fromServer = coreKey.equals("delete_server_after");
         int delCount = DcHelper.getContext(context).estimateDeletionCount(fromServer, timeout);
 
-        View gl = View.inflate(getActivity(), R.layout.autodel_confirm, null);
-        CheckBox confirmCheckbox = gl.findViewById(R.id.i_understand);
-        TextView msg = gl.findViewById(R.id.autodel_ask_msg);
+        View gl = View.inflate(getActivity(), R.layout.dialog_with_checkbox, null);
+        CheckBox confirmCheckbox = gl.findViewById(R.id.dialog_checkbox);
+        TextView msg = gl.findViewById(R.id.dialog_message);
 
         // If we'd use both `setMessage()` and `setView()` on the same AlertDialog, on small screens the
         // "OK" and "Cancel" buttons would not be show. So, put the message into our custom view:
         msg.setText(String.format(context.getString(fromServer?
                 R.string.autodel_server_ask : R.string.autodel_device_ask),
                 delCount, getSelectedSummary(preference, newValue)));
+        confirmCheckbox.setText(R.string.autodel_confirm);
 
         new AlertDialog.Builder(context)
                 .setTitle(preference.getTitle())

--- a/src/org/thoughtcrime/securesms/util/Hex.java
+++ b/src/org/thoughtcrime/securesms/util/Hex.java
@@ -16,6 +16,8 @@
  */
 package org.thoughtcrime.securesms.util;
 
+import java.io.IOException;
+
 /**
  * Utility for generating hex dumps.
  */
@@ -31,6 +33,28 @@ public class Hex {
       appendHexChar(buf, bytes[i]);
     }
     return buf.toString();
+  }
+
+  public static byte[] fromStringCondensed(String encoded) throws IOException {
+    final char[] data = encoded.toCharArray();
+    final int    len  = data.length;
+
+    if ((len & 0x01) != 0) {
+      throw new IOException("Odd number of characters.");
+    }
+
+    final byte[] out = new byte[len >> 1];
+
+    // two characters form the hex value.
+    for (int i = 0, j = 0; j < len; i++) {
+      int f = Character.digit(data[j], 16) << 4;
+      j++;
+      f = f | Character.digit(data[j], 16);
+      j++;
+      out[i] = (byte) (f & 0xFF);
+    }
+
+    return out;
   }
 
   private static void appendHexChar(StringBuffer buf, int b) {

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -1,5 +1,7 @@
 package org.thoughtcrime.securesms.util;
 
+import static com.mapbox.mapboxsdk.constants.MapboxConstants.MINIMUM_ZOOM;
+
 import android.content.ContentUris;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -25,8 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.mapbox.mapboxsdk.constants.MapboxConstants.MINIMUM_ZOOM;
-
 public class Prefs {
 
   private static final String TAG = Prefs.class.getSimpleName();
@@ -35,6 +35,9 @@ public class Prefs {
   public  static final String THEME_PREF                       = "pref_theme";
   public  static final String LANGUAGE_PREF                    = "pref_language";
   public  static final String BACKGROUND_PREF                  = "pref_chat_background";
+
+  private static final String DATABASE_ENCRYPTED_SECRET        = "pref_database_encrypted_secret";
+  private static final String DATABASE_UNENCRYPTED_SECRET      = "pref_database_unencrypted_secret";
 
   public  static final String RINGTONE_PREF                    = "pref_key_ringtone";
   private static final String VIBRATE_PREF                     = "pref_key_vibrate";
@@ -82,6 +85,22 @@ public class Prefs {
 
   public static void setScreenLockEnabled(@NonNull Context context, boolean value) {
     setBooleanPreference(context, SCREEN_LOCK, value);
+  }
+
+  public static void setDatabaseEncryptedSecret(@NonNull Context context, @NonNull String secret) {
+    setStringPreference(context, DATABASE_ENCRYPTED_SECRET, secret);
+  }
+
+  public static void setDatabaseUnencryptedSecret(@NonNull Context context, @Nullable String secret) {
+    setStringPreference(context, DATABASE_UNENCRYPTED_SECRET, secret);
+  }
+
+  public static @Nullable String getDatabaseUnencryptedSecret(@NonNull Context context) {
+    return getStringPreference(context, DATABASE_UNENCRYPTED_SECRET, null);
+  }
+
+  public static @Nullable String getDatabaseEncryptedSecret(@NonNull Context context) {
+    return getStringPreference(context, DATABASE_ENCRYPTED_SECRET, null);
   }
 
   public static boolean isIncognitoKeyboardEnabled(Context context) {

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -36,8 +36,8 @@ public class Prefs {
   public  static final String LANGUAGE_PREF                    = "pref_language";
   public  static final String BACKGROUND_PREF                  = "pref_chat_background";
 
-  private static final String DATABASE_ENCRYPTED_SECRET        = "pref_database_encrypted_secret";
-  private static final String DATABASE_UNENCRYPTED_SECRET      = "pref_database_unencrypted_secret";
+  private static final String DATABASE_ENCRYPTED_SECRET        = "pref_database_encrypted_secret_"; // followed by account-id
+  private static final String DATABASE_UNENCRYPTED_SECRET      = "pref_database_unencrypted_secret_"; // followed by account-id
 
   public  static final String RINGTONE_PREF                    = "pref_key_ringtone";
   private static final String VIBRATE_PREF                     = "pref_key_vibrate";
@@ -87,20 +87,20 @@ public class Prefs {
     setBooleanPreference(context, SCREEN_LOCK, value);
   }
 
-  public static void setDatabaseEncryptedSecret(@NonNull Context context, @NonNull String secret) {
-    setStringPreference(context, DATABASE_ENCRYPTED_SECRET, secret);
+  public static void setDatabaseEncryptedSecret(@NonNull Context context, @NonNull String secret, int accountId) {
+    setStringPreference(context, DATABASE_ENCRYPTED_SECRET + accountId, secret);
   }
 
-  public static void setDatabaseUnencryptedSecret(@NonNull Context context, @Nullable String secret) {
-    setStringPreference(context, DATABASE_UNENCRYPTED_SECRET, secret);
+  public static void setDatabaseUnencryptedSecret(@NonNull Context context, @Nullable String secret, int accountId) {
+    setStringPreference(context, DATABASE_UNENCRYPTED_SECRET + accountId, secret);
   }
 
-  public static @Nullable String getDatabaseUnencryptedSecret(@NonNull Context context) {
-    return getStringPreference(context, DATABASE_UNENCRYPTED_SECRET, null);
+  public static @Nullable String getDatabaseUnencryptedSecret(@NonNull Context context, int accountId) {
+    return getStringPreference(context, DATABASE_UNENCRYPTED_SECRET + accountId, null);
   }
 
-  public static @Nullable String getDatabaseEncryptedSecret(@NonNull Context context) {
-    return getStringPreference(context, DATABASE_ENCRYPTED_SECRET, null);
+  public static @Nullable String getDatabaseEncryptedSecret(@NonNull Context context, int accountId) {
+    return getStringPreference(context, DATABASE_ENCRYPTED_SECRET + accountId, null);
   }
 
   public static boolean isIncognitoKeyboardEnabled(Context context) {


### PR DESCRIPTION
![Screenshot_20220110-131339 (1)](https://user-images.githubusercontent.com/18012815/148764674-60c9811b-8890-4c72-ae06-a2ee0e17d2cd.png)

Depends on ~~https://github.com/deltachat/deltachat-core-rust/pull/2956~~ https://github.com/deltachat/deltachat-core-rust/pull/2980.

Currently:
- Before Android 6 (API 23), there was no KeyStore yet. Currently, you can still create an encrypted account, but the passphrase is stored in clear-text, because that's how Signal is doing things.
- There is no option to manually set the keyphrase or to unlock via fingerprint. This has the advantage that we never need user input for unlocking the accounts and can simply unlock all accounts on startup and the obvious disadvantage that anyone with access to the unlocked device can open DC.
- Each account is encrypted with a different passphrase.
- When importing, you can chosse to encrypt the account.

Findings:
- It may be useful (better UX) to have an API that tells you whether an opened account is encrypted, but no high-prio. Like, have a function `dc_accounts_is_encrypted(account_id) -> {Unencrypted | Encrypted-Closed | Encrypted-Opened}`
- Switching to encrypted after a context has already been created but not configured is kind of complex, but necessary as we already create an unconfigured context before we know whether the user wants to encrypt; but it's OKish already, and I'm not sure we should create a core function just for this, so maybe it's fine:

```java
    public void switchToEncrypted(Activity activity) {
        DcAccounts accounts = DcHelper.getAccounts(activity);
        DcContext selectedAccount = accounts.getSelectedAccount();
        if (selectedAccount.isConfigured() == 1) {
            throw new RuntimeException("Can't switch to encrypted account if already configured");
        }

        int selectedAccountId = selectedAccount.getAccountId();
        accounts.addClosedAccount();
        accounts.removeAccount(selectedAccountId);

        DcContext newAccount = accounts.getSelectedAccount();
        DatabaseSecret secret = DatabaseSecretProvider.getOrCreateDatabaseSecret(activity);
        newAccount.open(secret.asString());
    }
```