### PR TITLE
[WIP] Try for webxdc fix

### DIFF
--- a/src/org/thoughtcrime/securesms/attachments/DcAttachment.java
+++ b/src/org/thoughtcrime/securesms/attachments/DcAttachment.java
@@ -1,12 +1,14 @@
 package org.thoughtcrime.securesms.attachments;
 
-import java.io.File;
 import android.net.Uri;
+
 import androidx.annotation.Nullable;
 
 import com.b44t.messenger.DcMsg;
 
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
+
+import java.io.File;
 
 public class DcAttachment extends Attachment {
 
@@ -34,5 +36,9 @@ public class DcAttachment extends Attachment {
       return Uri.fromFile(new File(dcMsg.getFile()+"-preview.jpg"));
     }
     return getDataUri();
+  }
+
+  public DcMsg getDcMsg() {
+    return dcMsg;
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/DocumentSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/DocumentSlide.java
@@ -3,22 +3,20 @@ package org.thoughtcrime.securesms.mms;
 
 import android.content.Context;
 import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.b44t.messenger.DcMsg;
 
-import org.thoughtcrime.securesms.attachments.Attachment;
 import org.thoughtcrime.securesms.attachments.DcAttachment;
 import org.thoughtcrime.securesms.util.StorageUtil;
 
 public class DocumentSlide extends Slide {
-  private int dcMsgType = DcMsg.DC_MSG_UNDEFINED;
 
   public DocumentSlide(Context context, DcMsg dcMsg) {
     super(context, new DcAttachment(dcMsg));
     dcMsgId = dcMsg.getId();
-    dcMsgType = dcMsg.getType();
   }
 
   public DocumentSlide(@NonNull Context context, @NonNull Uri uri,
@@ -34,7 +32,13 @@ public class DocumentSlide extends Slide {
   }
 
   @Override
-  public boolean isWebxdcDocument() {
-    return dcMsgType == DcMsg.DC_MSG_WEBXDC;
+  public DcMsg getWebxdcMsg() {
+    if (attachment instanceof DcAttachment) {
+      DcMsg dcMsg = ((DcAttachment) attachment).getDcMsg();
+      if (dcMsg.getType() == DcMsg.DC_MSG_WEBXDC) {
+        return dcMsg;
+      }
+    }
+    return null;
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/Slide.java
+++ b/src/org/thoughtcrime/securesms/mms/Slide.java
@@ -18,9 +18,11 @@ package org.thoughtcrime.securesms.mms;
 
 import android.content.Context;
 import android.net.Uri;
-import androidx.annotation.DrawableRes;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.b44t.messenger.DcMsg;
 
 import org.thoughtcrime.securesms.attachments.Attachment;
 import org.thoughtcrime.securesms.attachments.UriAttachment;
@@ -48,7 +50,7 @@ public abstract class Slide {
     return dcMsgId;
   }
 
-  public String getContentType() {
+public String getContentType() {
     return attachment.getContentType();
   }
 
@@ -94,8 +96,8 @@ public abstract class Slide {
     return false;
   }
 
-  public boolean isWebxdcDocument() {
-    return false;
+  public DcMsg getWebxdcMsg() {
+    return null;
   }
 
   public boolean hasLocation() {

--- a/src/org/thoughtcrime/securesms/mms/SlideDeck.java
+++ b/src/org/thoughtcrime/securesms/mms/SlideDeck.java
@@ -19,8 +19,6 @@ package org.thoughtcrime.securesms.mms;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.b44t.messenger.DcMsg;
-
 import org.thoughtcrime.securesms.attachments.Attachment;
 
 import java.util.LinkedList;
@@ -78,7 +76,7 @@ public class SlideDeck {
   // Webxdc requires draft-ids to be used; this function returns the previously used draft-id, if any.
   public int getWebxdctDraftId() {
     for (Slide slide: slides) {
-      if (slide.isWebxdcDocument()) {
+      if (slide.getWebxdcMsg() != null) {
         return slide.dcMsgId;
       }
     }


### PR DESCRIPTION
Recognizing as a webxdc app works now, but opening it doesn't.

The problem was that on Android 10, `data.getData().toString().endsWith(".xdc")` can't be used to check for the type (you get `content:// URIs, and they don't have a file ending).

The correct file name is computed in `getManuallyCalculatedSlideInfo()`/`getContentResolverSlideInfo()`.

No idea what the new bug is.