### PR TITLE
show webxdc errors when sending fails

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1164,7 +1164,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
             }
 
             if (doSend) {
-              dcContext.sendMsg(dcChat.getId(), msg);
+              if (dcContext.sendMsg(dcChat.getId(), msg) == 0) {
+                Util.runOnMain(()-> Toast.makeText(ConversationActivity.this, dcContext.getLastError(), Toast.LENGTH_LONG).show());
+                return null;
+              }
             }
 
             Util.runOnMain(()-> sendComplete(dcChat.getId()));


### PR DESCRIPTION
this happens only in rare cases as usually the message is always added
and errors happen far later.

but some conditions are checked very soon (webxdc sizes),
and these let an message not even being added.

note, that this pr only shows the error,
it does not change draft handling or so -
it would eg. be better if the message is re-converted to a draft,
however, that would be a larger refactoring and maybe not worth the effort.

closes #2190