### PR TITLE
webxdc: warn when the app tries sendUpdate() and the user cannot send

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -379,6 +379,9 @@
     <string name="mailing_list">Mailing List</string>
     <string name="mailing_list_profile_info">Changes on mailing list name and image apply to this device only.</string>
 
+    <!-- webxdc -->
+    <string name="accept_request_first">Please accept the chat request first.</string>
+
     <!-- map -->
     <string name="filter_map_on_time">Show locations in time frame</string>
     <string name="show_location_traces">Show traces</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -380,6 +380,9 @@
     <string name="mailing_list_profile_info">Changes on mailing list name and image apply to this device only.</string>
 
     <!-- webxdc -->
+    <!-- "Start..." button for an app -->
+    <string name="start_app">Start…</string>
+    <!-- this is a warning that is shown when one tries to send something to a chat that is not yet accepted. -->
     <string name="accept_request_first">Please accept the chat request first.</string>
 
     <!-- map -->

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -377,7 +377,7 @@ public class ConversationItem extends BaseConversationItem
     } else if (messageRecord.getType() == DcMsg.DC_MSG_WEBXDC) {
       msgActionButton.setVisibility(View.VISIBLE);
       msgActionButton.setEnabled(true);
-      msgActionButton.setText("Start…");
+      msgActionButton.setText(R.string.start_app);
       msgActionButton.setOnClickListener(view -> {
         if (batchSelected.isEmpty()) {
           WebxdcActivity.openWebxdcActivity(getContext(), messageRecord);

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
+import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
 import com.b44t.messenger.DcMsg;
@@ -166,7 +167,16 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     @JavascriptInterface
     public boolean sendStatusUpdate(String payload, String descr) {
       Log.i(TAG, "sendStatusUpdate");
-      return WebxdcActivity.this.dcContext.sendWebxdcStatusUpdate(WebxdcActivity.this.dcAppMsg.getId(), payload, descr);
+      if (!WebxdcActivity.this.dcContext.sendWebxdcStatusUpdate(WebxdcActivity.this.dcAppMsg.getId(), payload, descr)) {
+        DcChat dcChat =  WebxdcActivity.this.dcContext.getChat(WebxdcActivity.this.dcAppMsg.getChatId());
+        Toast.makeText(WebxdcActivity.this,
+                      dcChat.isContactRequest() ?
+                          WebxdcActivity.this.getString(R.string.accept_request_first) :
+                          WebxdcActivity.this.dcContext.getLastError(),
+                      Toast.LENGTH_LONG).show();
+        return false;
+      }
+      return true;
     }
 
     @JavascriptInterface


### PR DESCRIPTION
show a warning when the app tries to use sendUpdate() for contact requests or other chats the user cannot send to.

this and https://github.com/deltachat/deltachat-core-rust/pull/3001 already catches many cases and improves things a lot, we'll see how that works out in practice.

wording suggestions welcome :)