### PR TITLE
prepare 1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Delta Chat Android Changelog
 
+## v1.27.0
+2022-01
+
+* add option to create encrypted database at "Add Account / Advanced",
+  the database passphrase is generated automatically and is stored in the system's keychain,
+  subsequent versions will probably get more options to handle passphrases
+* add initial support for Webxdc extensions
+* add "Advanced / Developer Mode" to help on creating Webxdc extensions
+* add writing support for supported mailinglist types; other mailinglist types stay read-only
+* "Message Info" show routes
+* explicit "Watch Inbox folder" and "Watch DeltaChat folder" settings no longer required;
+  the folders are watched automatically as needed
+* detect correctly signed messages from Thunderbird and show them as such
+* synchronize Seen status across devices
+* more reliable group memberlist and group avatar updates
+* recognize MS Exchange read receipts as such
+* fix leaving groups
+* fix unread count issues in account switcher
+* fix crash when selecting thumbnail image
+* fix add POI if the user cannot send in a chat
+* fix "Reply Privately" in contact request chats
+* add Bulgarian translations, update other translations and local help
+* update provider-database
+* update to core71
+
+
 ## v1.26.2
 2021-12
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 621
-        versionName "1.26.2"
+        versionCode 622
+        versionName "1.27.0"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
this is already ready for review, one approved, we should wait for https://github.com/deltachat/deltachat-core-rust/pull/3004, bump version - and can start the 1.27 testing release series :)