### PR TITLE
tweak webxdc bubble layout

### DIFF
--- a/res/layout/webxdc_view.xml
+++ b/res/layout/webxdc_view.xml
@@ -10,46 +10,37 @@
                       android:clickable="false"
                       android:focusable="false"
                       android:gravity="center_vertical"
-                      android:orientation="horizontal">
+                      android:orientation="vertical">
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/webxdc_icon"
                 android:layout_marginTop="2dp"
-                android:layout_width="72dp"
-                android:layout_height="72dp"
-                android:scaleType="fitCenter"
-                app:srcCompat="@drawable/ic_chevron_up"/>
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                android:scaleType="centerCrop"/>
 
-            <LinearLayout android:layout_width="match_parent"
-                          android:layout_height="wrap_content"
-                          android:layout_marginTop="2dp"
-                          android:layout_marginLeft="6dp"
-                          android:layout_marginStart="6dp"
-                          android:orientation="vertical"
-                          android:focusable="false"
-                          android:clickable="false">
+            <TextView android:id="@+id/webxdc_app_name"
+                      android:layout_width="match_parent"
+                      android:layout_height="wrap_content"
+                      style="@style/Signal.Text.Body"
+                      android:singleLine="true"
+                      android:maxLines="1"
+                      android:ellipsize="end"
+                      android:clickable="false"
+                      android:textColor="?conversation_item_incoming_text_primary_color"
+                      android:textStyle="bold"
+                      tools:text="Great App"/>
 
-                <TextView android:id="@+id/webxdc_app_name"
-                          android:layout_width="match_parent"
-                          android:layout_height="wrap_content"
-                          style="@style/Signal.Text.Body"
-                          android:singleLine="true"
-                          android:maxLines="1"
-                          android:clickable="false"
-                          android:ellipsize="end"
-                          android:textColor="?conversation_item_incoming_text_primary_color"
-                          android:textStyle="bold"
-                          tools:text="Great App"/>
+            <TextView android:id="@+id/webxdc_subtitle"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      style="@style/Signal.Text.Body"
+                      android:singleLine="true"
+                      android:maxLines="1"
+                      android:ellipsize="end"
+                      android:clickable="false"
+                      android:textColor="?conversation_item_incoming_text_primary_color"
+                      tools:text="Tap to start"/>
 
-                <TextView android:id="@+id/webxdc_subtitle"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:maxLines="1"
-                          android:ellipsize="end"
-                          style="@style/Signal.Text.Caption"
-                          android:clickable="false"
-                          android:textColor="?conversation_item_incoming_text_primary_color"
-                          tools:text="24kb"/>
-            </LinearLayout>
         </LinearLayout>
 </merge>


### PR DESCRIPTION
this pr aims to do some _easy_ things to improve the layout of webxdc bubbles:

- larger icon - this came up in discussions here and there
- longer summary line - it is now the full bubble width, the summary is only one line for $reasons (changing this is out of scope of this pr)
- as title left of icon and summary below looks weird, also the title is moved down

before / after:

<img width=320 src=https://user-images.githubusercontent.com/9800740/151217620-d6d59b91-c376-4f60-8d21-ded7e49e4a08.png> <img width=320 src=https://user-images.githubusercontent.com/9800740/151217605-3df5f183-3b58-4c34-b336-94824f725aff.png>

if we agree in general on that layout, we can improve things further - as making the bubble as wide as the normal bubbles (tbh, no idea where to tweak things for that). i was also thinking here and there that landscape icons as on telegram may be nice, however, not totally sure. having this square format fits better to "apps" - the landscape is more a preview of some content.
