### PR TITLE
add async allUpdates()

### DIFF
--- a/res/raw/webxdc.js
+++ b/res/raw/webxdc.js
@@ -15,8 +15,8 @@ window.webxdc = (() => {
 
     setUpdateListener: (cb) => (update_listener = cb),
 
-    async allUpdates: () => {
-      return JSON.parse(InternalJSApi.getStatusUpdates(0));
+    allUpdates: () => {
+      return Promise.resolve(JSON.parse(InternalJSApi.getStatusUpdates(0)));
     },
 
     // deprecated, use `await updates = getUpdates()` instead

--- a/res/raw/webxdc.js
+++ b/res/raw/webxdc.js
@@ -19,7 +19,7 @@ window.webxdc = (() => {
       return Promise.resolve(JSON.parse(InternalJSApi.getStatusUpdates(0)));
     },
 
-    // deprecated, use `await updates = getUpdates()` instead
+    // deprecated, use `await updates = allUpdates()` instead
     getAllUpdates: () => {
       return JSON.parse(InternalJSApi.getStatusUpdates(0));
     },

--- a/res/raw/webxdc.js
+++ b/res/raw/webxdc.js
@@ -15,6 +15,11 @@ window.webxdc = (() => {
 
     setUpdateListener: (cb) => (update_listener = cb),
 
+    async allUpdates: () => {
+      return JSON.parse(InternalJSApi.getStatusUpdates(0));
+    },
+
+    // deprecated, use `await updates = getUpdates()` instead
     getAllUpdates: () => {
       return JSON.parse(InternalJSApi.getStatusUpdates(0));
     },


### PR DESCRIPTION
a suggestion to make the api async where needed, trying out to sum up recent discussions in  dev chat:

the changes are because _it is not possible to call from desktop into core and to return things synchronous._ (is that correct?)

- `sendUpdate()` stays sync because it does not return a value (we can change that as needed).

- `selfAddr()` and `selfName()` stays sync because it can return a stored value.

- `getAllUpdates()` seems to need adaption as it cannot easily return a stored value.

the pr suggests to leave `getAllUpdates()` as is (for now, to not break all apps at once) and add an additional `allUpdates()` getter - **question**: what is best practice on getter and setter wordings in js land? in rust, one usually does not add `get`/`set` prefixes - and for `selfAddr()` and `selfName()` we also skipped them for js - so, this little change would even  streamline things.

that way, also the complicated parts when adapting existing code or games do not get the necessity to call into async code - which would then result into large parts of the existing code to be changed to async as well. (if that bit is wrong, please let us know, that would be a game changer in the whole discussion) 

also, question to the js experts: is the syntax correct? or better use Promise? what about compatibility?

comments very welcome!

once this is settled, we need to update https://github.com/deltachat/deltachat-core-rust/blob/master/draft/webxdc-dev-reference.md#webxdc-api