### PR TITLE
don't force dark mode in webpage for webxdc's webview

### DIFF
--- a/src/org/thoughtcrime/securesms/ConnectivityActivity.java
+++ b/src/org/thoughtcrime/securesms/ConnectivityActivity.java
@@ -15,6 +15,7 @@ public class ConnectivityActivity extends WebViewActivity implements DcEventCent
   @Override
   protected void onCreate(Bundle state, boolean ready) {
     super.onCreate(state, ready);
+    setForceDark();
     getSupportActionBar().setTitle(R.string.connectivity);
     refresh();
 

--- a/src/org/thoughtcrime/securesms/LocalHelpActivity.java
+++ b/src/org/thoughtcrime/securesms/LocalHelpActivity.java
@@ -13,6 +13,7 @@ public class LocalHelpActivity extends WebViewActivity
   @Override
   protected void onCreate(Bundle state, boolean ready) {
     super.onCreate(state, ready);
+    setForceDark();
     getSupportActionBar().setTitle(getString(R.string.menu_help));
 
     String helpPath = "help/LANG/help.html";

--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -46,10 +46,6 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
     webView = findViewById(R.id.webview);
-    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-      WebSettingsCompat.setForceDark(webView.getSettings(),
-                                     DynamicTheme.isDarkTheme(this) ? WebSettingsCompat.FORCE_DARK_ON : WebSettingsCompat.FORCE_DARK_OFF);
-    }
     webView.setWebViewClient(new WebViewClient() {
       // `shouldOverrideUrlLoading()` is called when the user clicks a URL,
       // returning `true` means, the URL is passed to `loadUrl()`, `false` aborts loading.
@@ -107,6 +103,13 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
     // "safe browsing" will never be able to report issues, so it can be disabled.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       webView.getSettings().setSafeBrowsingEnabled(false);
+    }
+  }
+
+  protected void setForceDark() {
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+      WebSettingsCompat.setForceDark(webView.getSettings(),
+                                     DynamicTheme.isDarkTheme(this) ? WebSettingsCompat.FORCE_DARK_ON : WebSettingsCompat.FORCE_DARK_OFF);
     }
   }
 


### PR DESCRIPTION
the forced dark mode usually messes the apps background and colors, it is completely unreadable in some cases, changing color of background images to light colors while the texts remains white