### PR TITLE
Remove quotes from `Scan to join group %1$s` string

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -762,7 +762,7 @@
     <string name="qrshow_x_has_joined_group">%1$s joined the group.</string>
     <string name="qrshow_join_group_title">QR Invite Code</string>
     <!-- This text is shown inside the "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by the group name, eg. "Scan to join group \"Testing group\"" -->
-    <string name="qrshow_join_group_hint">Scan to join group \"%1$s\"</string>
+    <string name="qrshow_join_group_hint">Scan to join group %1$s</string>
     <string name="qrshow_join_contact_title">QR Invite Code</string>
     <!-- This text is shown inside the "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by name and address eg. "Scan to chat with Alice (alice@example.org)" -->
     <string name="qrshow_join_contact_hint">Scan to chat with %1$s</string>


### PR DESCRIPTION
They were shown as `quot;` instead of `"` in the QR code:

![image_2022-01-31_14-18-13](https://user-images.githubusercontent.com/18012815/151809840-8118ed87-f4b1-4a2e-a725-28f36260248f.jpg)

fix https://github.com/deltachat/deltachat-android/issues/2187

My first try to actually fix it failed (i.e. show the quote in the QR code), so, maybe just remove it?