### PR TITLE
hack: remove quotes from qr-code group join string

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -200,7 +200,11 @@ public class DcHelper {
     dcContext.setStockTranslation(117, context.getString(R.string.secure_join_started));
     dcContext.setStockTranslation(118, context.getString(R.string.secure_join_replies));
     dcContext.setStockTranslation(119, context.getString(R.string.qrshow_join_contact_hint));
-    dcContext.setStockTranslation(120, context.getString(R.string.qrshow_join_group_hint));
+
+    // HACK: svg does not handle entities correctly and shows `&quot;` as the text `quot;`.
+    // until that is fixed, we fix the most obvious errors (core uses encode_minimal, so this does not affect so many characters)
+    // cmp. https://github.com/deltachat/deltachat-android/issues/2187
+    dcContext.setStockTranslation(120, context.getString(R.string.qrshow_join_group_hint).replace("\"", ""));
   }
 
   public static File getImexDir() {


### PR DESCRIPTION
alternative to https://github.com/deltachat/deltachat-android/pull/2214

that should work with all translations and can be easily undone without burden anything to the translators.

closes https://github.com/deltachat/deltachat-android/issues/2187