### PR TITLE
enable `Window.sessionStorage`, `Window.localStorage` and `IndexedDB` APIs

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -70,6 +70,8 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     webSettings.setGeolocationEnabled(false);
     webSettings.setAllowFileAccessFromFileURLs(false);
     webSettings.setAllowUniversalAccessFromFileURLs(false);
+    webSettings.setDatabaseEnabled(true);
+    webSettings.setDomStorageEnabled(true);
     webView.addJavascriptInterface(new InternalJSApi(), "InternalJSApi");
 
     // `msg_id` in the subdomain makes sure, different apps using same files do not share the same cache entry

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -78,7 +78,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     // (WebView may use a global cache shared across objects).
     // (a random-id would also work, but would need maintenance and does not add benefits as we regard the file-part interceptRequest() only,
     // also a random-id is not that useful for debugging)
-    webView.loadUrl("webxdc://msg" + appMessageId + ".localhost/index.html");
+    webView.loadUrl("https://msg" + appMessageId + ".localhost/index.html");
 
     Util.runOnAnyBackgroundThread(() -> {
       JSONObject info = this.dcAppMsg.getWebxdcInfo();


### PR DESCRIPTION
after several discussions, we decided to allows these APIs, just natively what the browser/webview provide.

advantages of that approach are:
- existing apps can use the APIs without adaptions, so porting apps are easier
- no re-implementation needed - esp. for `IndexDB` that would probably take weeks~months, plus maintenance 
- as we are not using core, the local storage APIs cannot slow down receiving/sending messages

disadvantages:
- the local storage does not go the backups. it could be done by injecting javascript on exit and get `localStorage` etc. to the database, the other way round on opening. however, that's quite some effort, esp. when it comes to `IndexedDB`, this is probably not worth the effort.

other hints:
- no multi-device-sync possible, however, it is questionable if we would do that if we'd re-implement the APIs - `localStorage` may be used for scrolling positions, themes and so on you may configure differently across devices. also, existing implementations would not expect localStorage to be sth. other than local :)

same should be done for iOS and Desktop, cc @cyBerta , @Simon-Laux - and we need a test.xdc for that.