### PR TITLE
Mark already seen messages as seen

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -670,7 +670,7 @@ public class ConversationFragment extends MessageSelectorFragment
         int index = 0;
         for(int pos = firstPos; pos <= lastPos; pos++) {
             DcMsg message = ((ConversationAdapter) list.getAdapter()).getMsg(pos);
-            if (message.getFromId() != DC_CONTACT_ID_SELF && !message.isSeen()) {
+            if (message.getFromId() != DC_CONTACT_ID_SELF) {
                 ids[index] = message.getId();
                 index++;
             }


### PR DESCRIPTION
Marking the message as seen starts ephemeral timer if it is not
already started.

Due to the bug in the core, sometimes messages were marked as seen
without starting ephemeral timer. This can also happen due to other
errors, like database access timeout.

Always calling markseenMsgs whenever the message is displayed, even if
it is already seen, ensures that ephemeral timer is started
eventually.