### PR TITLE
Introduce dedicated ConversationListRelayingActivity to fix forwarding bug

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -153,6 +153,12 @@
                 android:value="org.thoughtcrime.securesms.ConversationListActivity" />
     </activity>
 
+    <activity android:name=".ConversationListRelayingActivity"
+              android:label="@string/app_name"
+              android:launchMode="singleTask"
+              android:theme="@style/TextSecure.LightNoActionBar"
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize" />
+
     <activity android:name=".ConversationActivity"
               android:windowSoftInputMode="stateUnchanged"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"

--- a/androidTest/com/b44t/messenger/uitests/offline/ForwardingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/offline/ForwardingTest.java
@@ -1,0 +1,97 @@
+package com.b44t.messenger.uitests.offline;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.longClick;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import androidx.test.espresso.IdlingPolicies;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import com.b44t.messenger.DcContact;
+import com.b44t.messenger.DcContext;
+import com.b44t.messenger.TestUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.thoughtcrime.securesms.ConversationListActivity;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.connect.DcHelper;
+
+import java.util.concurrent.TimeUnit;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ForwardingTest {
+  private static int createdGroupId;
+
+  @BeforeClass
+  public static void beforeClass() {
+    IdlingPolicies.setMasterPolicyTimeout(10, TimeUnit.SECONDS);
+    IdlingPolicies.setIdlingResourceTimeout(10, TimeUnit.SECONDS);
+  }
+
+  @Rule
+  public ActivityScenarioRule<ConversationListActivity> activityRule = TestUtils.getOfflineActivityRule();
+
+  @Before
+  public void createChats() {
+    DcContext dcContext = DcHelper.getContext(getInstrumentation().getTargetContext());
+    dcContext.createChatByContactId(DcContact.DC_CONTACT_ID_SELF);
+    // Disable bcc_self so that DC doesn't try to send messages to the server.
+    // If we didn't do this, messages would stay in DC_STATE_OUT_PENDING forever.
+    // The thing is, DC_STATE_OUT_PENDING show a rotating circle animation, and Espresso doesn't work
+    // with animations, and the tests would hang and never finish.
+    dcContext.setConfig("bcc_self", "0");
+    activityRule.getScenario().onActivity(a -> createdGroupId = DcHelper.getContext(a).createGroupChat(false, "group"));
+  }
+
+  @After
+  public void cleanup() {
+    TestUtils.cleanup();
+  }
+
+  @Test
+  public void testSimpleForwarding() {
+    // Open device talk
+    // The group is at position 0, self chat is at position 1, device talk is at position 2
+    onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(2, click()));
+    onView(withId(R.id.title)).check(matches(withText(R.string.device_talk)));
+    onView(withId(android.R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(0, longClick()));
+    onView(withId(R.id.menu_context_forward)).perform(click());
+    // Send it to self chat (which is sorted to the top because we're forwarding)
+    onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+
+    onView(withId(R.id.title)).check(matches(withText(R.string.device_talk)));
+
+    pressBack();
+
+    onView(withId(R.id.toolbar_title)).check(matches(withText(R.string.connectivity_not_connected)));
+    // Self chat moved up because we sent a message there
+    onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+    onView(withId(R.id.title)).check(matches(withText(R.string.saved_messages)));
+    onView(withId(android.R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(0, longClick()));
+    onView(withId(R.id.menu_context_forward)).perform(click());
+    // Send it to the group
+    onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(1, click()));
+    onView(withText(android.R.string.ok)).perform(click());
+    onView(withId(R.id.title)).check(matches(withText("group")));
+
+    pressBack();
+    onView(withId(R.id.title)).check(matches(withText(R.string.saved_messages)));
+
+    pressBack();
+    onView(withId(R.id.toolbar_title)).check(matches(withText(R.string.connectivity_not_connected)));
+  }
+}

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -16,6 +16,9 @@
  */
 package org.thoughtcrime.securesms;
 
+import static com.b44t.messenger.DcContact.DC_CONTACT_ID_SELF;
+import static org.thoughtcrime.securesms.util.RelayUtil.setForwardingMessageIds;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -76,10 +79,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
-
-import static com.b44t.messenger.DcContact.DC_CONTACT_ID_SELF;
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
-import static org.thoughtcrime.securesms.util.RelayUtil.setForwardingMessageIds;
 
 @SuppressLint("StaticFieldLeak")
 public class ConversationFragment extends MessageSelectorFragment
@@ -433,10 +432,10 @@ public class ConversationFragment extends MessageSelectorFragment
     }
 
     private void handleForwardMessage(final Set<DcMsg> messageRecords) {
-        Intent composeIntent = new Intent(getActivity(), ConversationListActivity.class);
+        Intent composeIntent = new Intent();
         int[] msgIds = DcMsg.msgSetToIds(messageRecords);
         setForwardingMessageIds(composeIntent, msgIds);
-        startActivityForResult(composeIntent, REQUEST_RELAY);
+        ConversationListRelayingActivity.start(this, composeIntent);
         getActivity().overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
     }
 

--- a/src/org/thoughtcrime/securesms/ConversationListRelayingActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListRelayingActivity.java
@@ -1,0 +1,37 @@
+package org.thoughtcrime.securesms;
+
+import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Intent;
+
+import androidx.fragment.app.Fragment;
+
+/**
+ * "Relaying" means "Forwarding or Sharing".
+ *
+ * When forwarding or sharing, we show the ConversationListActivity to the user.
+ * However, ConversationListActivity has `launchMode="singleTask"`, which means that this will
+ * destroy the existing ConversationListActivity.
+ *
+ * In API 20-29, `startActivityForResult()` could be used instead of `startActivity()`
+ * to override this behavior and get two instances of ConversationListActivity.
+ *
+ * As this is not possible anymore starting with API 30, we needed another solution, and created
+ * this activity here.
+ *
+ * See https://github.com/deltachat/deltachat-android/issues/1704.
+ */
+
+public class ConversationListRelayingActivity extends ConversationListActivity {
+  public static void start(Fragment fragment, Intent intent) {
+    intent.setComponent(new ComponentName(fragment.getContext(), ConversationListRelayingActivity.class));
+    fragment.startActivityForResult(intent, REQUEST_RELAY);
+  }
+
+  public static void start(Activity activity, Intent intent) {
+    intent.setComponent(new ComponentName(activity, ConversationListRelayingActivity.class));
+    activity.startActivityForResult(intent, REQUEST_RELAY);
+  }
+}

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -17,7 +17,6 @@
 
 package org.thoughtcrime.securesms;
 
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.setSharedText;
 
 import android.Manifest;
@@ -263,11 +262,13 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
     if (chatId != -1) {
       composeIntent = getBaseShareIntent(ConversationActivity.class);
       composeIntent.putExtra(EXTRA_CHAT_ID, chatId);
+      RelayUtil.setSharedUris(composeIntent, resolvedExtras);
+      startActivity(composeIntent);
     } else {
-      composeIntent = getBaseShareIntent(ConversationListActivity.class);
+      composeIntent = getBaseShareIntent(ConversationListRelayingActivity.class);
+      RelayUtil.setSharedUris(composeIntent, resolvedExtras);
+      ConversationListRelayingActivity.start(this, composeIntent);
     }
-    RelayUtil.setSharedUris(composeIntent, resolvedExtras);
-    startActivityForResult(composeIntent, REQUEST_RELAY);
     // We use startActivityForResult() here so that the conversations list is correctly updated. (hide "Device messages", ...)a
     // With startActivity() the list was not always updated before and after sharing and incorrectly showed or did not show the device talk.
     finish();


### PR DESCRIPTION
fix https://github.com/deltachat/deltachat-android/issues/1704 by creating an extra activity:

https://github.com/deltachat/deltachat-android/pull/2246/files#diff-5027fc167512e95578b7074b02d0740011435b3d033a2fe66d4893a74d81e0e2R12-R24

Also create some new UI test (and test it with the old UI tests) because we had so many regressions wrt sharing, forwarding and switching activities in the past. The test depends on https://github.com/deltachat/deltachat-core-rust/pull/3150; if it doesn't get merged, I'll have to find another method to disable this animation.