### PR TITLE
avoid rotated avatar image when selecting new self-avatar from Gallery

### DIFF
--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -42,13 +42,13 @@ public class AvatarHelper {
         return new File(dirString);
     }
 
-    public static void setSelfAvatar(@NonNull Context context, @Nullable byte[] data) throws IOException {
-        if (data == null) {
+    public static void setSelfAvatar(@NonNull Context context, @Nullable Bitmap bitmap) throws IOException {
+        if (bitmap == null) {
             DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, null);
         } else {
             File avatar = File.createTempFile("selfavatar", ".jpg", context.getCacheDir());
             FileOutputStream out = new FileOutputStream(avatar);
-            out.write(data);
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out);
             out.close();
             DcHelper.set(context, DcHelper.CONFIG_SELF_AVATAR, avatar.getPath()); // The avatar is copied to the blobs directory here...
             //noinspection ResultOfMethodCallIgnored


### PR DESCRIPTION
fixes 50% of #1835, when selecting image from Gallery, that is usually 99% of the use case when you set an avatar, I think it is rare to take the picture at the moment, the issue is still present in that case because the dependency we use to crop the avatars, which is outdated and causes other issues like #1566, need to be replaced by the image editor we have already, then #1835 will be 100% fixed