### PR TITLE
don't jump to parent if parent is not a webxdc

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -778,7 +778,7 @@ public class ConversationFragment extends MessageSelectorFragment
             else if(DozeReminder.isDozeReminderMsg(getContext(), messageRecord)) {
                 DozeReminder.dozeReminderTapped(getContext());
             }
-            else if(messageRecord.isInfo() && messageRecord.getParent() != null) {
+            else if(messageRecord.isInfo() && messageRecord.getParent() != null && messageRecord.getParent().getType() == DcMsg.DC_MSG_WEBXDC) {
                 scrollMaybeSmoothToMsgId(messageRecord.getParent().getId());
             }
             else {


### PR DESCRIPTION
close #2250 

this doesn't solve the issue in 100% of cases, in some rare cases a "member removed/added" etc might has a webxdc as parent, I guess the proper fix must be done in core, perhaps set the parent webxdc as quote and use that instead of parent or make get_parent only return parent for webxdc's info messages