### PR TITLE
pause/destroy webview when activity is paused/destroyed

### DIFF
--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -114,15 +114,23 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    webView.onPause();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     dynamicTheme.onResume(this);
     dynamicLanguage.onResume(this);
+    webView.onResume();
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    webView.destroy();
   }
 
   @Override


### PR DESCRIPTION
close #2258

(note: at least in my phone, the music is not paused when the webview is paused, but at least when the webxdc is closed destroying the webview stops the music)