### PR TITLE
tweak confirm-to-forward dialog

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -715,6 +715,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
                 successfulForwardingAttempt = true;
               })
               .setNegativeButton(R.string.cancel, (dialogInterface, i) -> finish())
+              .setOnCancelListener(dialog -> finish())
               .show();
     }
   }


### PR DESCRIPTION
go back to chatlist when back button is pressed or user touches outside the dialog in the dialog asking to confirm to forward message inside chat.

currently if back is pressed, the dialog is canceled but the chat stays open and you have to press back again to go to the chatlist with the "Forward to..." title