### PR TITLE
show download failures

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -362,6 +362,9 @@ public class ConversationItem extends BaseConversationItem
       if (downloadState==DcMsg.DC_DOWNLOAD_IN_PROGRESS) {
         msgActionButton.setEnabled(false);
         msgActionButton.setText(R.string.downloading);
+      } else if (downloadState==DcMsg.DC_DOWNLOAD_FAILURE) {
+        msgActionButton.setEnabled(true);
+        msgActionButton.setText(R.string.download_failed);
       } else {
         msgActionButton.setEnabled(true);
         msgActionButton.setText(R.string.download);


### PR DESCRIPTION
tapping on the message, still allows re-downloading
in case of temporary errors.

https://user-images.githubusercontent.com/9800740/163385728-43a5846e-4006-4018-b7ea-c5f75b2c20ee.MOV

maybe the error message could be nicer, however, not sure if that is worth the effort, at least this is sth. for another time :)

i came over that issue when trying to find out more information about https://github.com/deltachat/deltachat-core-rust/issues/2876