### PR TITLE
adapt strings to new welcome screen

### DIFF
--- a/res/layout/welcome_activity.xml
+++ b/res/layout/welcome_activity.xml
@@ -26,20 +26,9 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:padding="16dp"
-        android:text="@string/welcome_desktop"
+        android:text="@string/welcome_chat_over_email"
         android:textSize="22sp"
         android:textStyle="bold"/>
-
-    <TextView
-        android:id="@+id/welcome_sub_header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/welcome_intro1_message"
-        android:textSize="18sp"/>
 
     <androidx.legacy.widget.Space
         android:layout_weight="1"
@@ -73,7 +62,7 @@
             android:layout_height="wrap_content"
             android:padding="16dp"
             android:gravity="center"
-            android:text="@string/qrscan_title"
+            android:text="@string/scan_invitation_code"
             android:textSize="16sp"
             android:textColor="@color/delta_accent"/>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -461,9 +461,11 @@
 
 
     <!-- welcome and login -->
+    <string name="welcome_chat_over_email">Chat over E-Mail.</string>
+    <string name="scan_invitation_code">Scan Invitation Code</string>
     <string name="welcome_intro1_message">The messenger with the broadest audience in the world. Free and independent.</string>
     <string name="login_title">Log In</string>
-    <string name="login_header">Log In to Your Server</string>
+    <string name="login_header">Log into your E-Mail Account</string>
     <string name="login_explain">Log in with an existing e-mail account</string>
     <string name="login_subheader">For known e-mail providers additional settings are set up automatically. Sometimes IMAP needs to be enabled in the web settings. Consult your e-mail provider or friends for help.</string>
     <string name="login_no_servers_hint">There are no Delta Chat servers, your data stays on your device.</string>
@@ -495,7 +497,7 @@
     <string name="login_error_server">Please enter a valid server / IP address</string>
     <string name="login_error_port">Please enter a valid port (1–65535)</string>
     <string name="login_error_required_fields">Please enter a valid e-mail address and a password</string>
-    <string name="import_backup_title">Import Backup</string>
+    <string name="import_backup_title">Restore from Backup</string>
     <string name="import_backup_ask">Backup found at \"%1$s\".\n\nDo you want to import and use all data and settings from it?</string>
     <string name="import_backup_no_backup_found">No backups found.\n\nCopy the backup to \"%1$s\" and try again. Alternatively, press \"Start messaging\" to continue with the normal setup process.</string>
     <!-- Translators: %1$s will be replaced by the e-mail address -->


### PR DESCRIPTION
this pr is only about fine-tuning the new strings before they can get translated; wrt case: we are using "first letter uppercase for most words" on all buttons and items meanwhile, therefore i slightly adapted that.

suggestions welcome - once this is approved/merged, we can go for layout, positioning, logo (which is less time critical as no external persons involved)

before/after:

<img width="337" alt="Screen Shot 2022-04-25 at 22 00 47" src="https://user-images.githubusercontent.com/9800740/165167338-f4f11c78-a691-4b89-8af7-9713456dfdd8.png"> &nbsp; <img width="337" alt="Screen Shot 2022-04-25 at 22 12 36" src="https://user-images.githubusercontent.com/9800740/165167355-8ccfae46-c041-4682-8b73-dac10ba272f7.png">
