### PR TITLE
webxdc: allow internal pages and open some known schemes externally

### DIFF
--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -48,7 +48,8 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
     webView = findViewById(R.id.webview);
     webView.setWebViewClient(new WebViewClient() {
       // `shouldOverrideUrlLoading()` is called when the user clicks a URL,
-      // returning `true` means, the URL is passed to `loadUrl()`, `false` aborts loading.
+      // returning `true` causes the WebView to abort loading the URL,
+      // returning `false` causes the WebView to continue loading the URL as usual.
       // the method is not called for POST request nor for on-page-links.
       //
       // nb: from API 24, `shouldOverrideUrlLoading(String)` is deprecated and
@@ -64,9 +65,8 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
             case "https":
             case "mailto":
             case "openpgp4fpr":
-              openOnlineUrl(url);
-              // URL opened externally, returning `true` causes the WebView to abort loading
-              return true;
+              // open URL externally
+              return openOnlineUrl(url);
           }
         }
         // by returning `true`, we also abort loading other URLs in our WebView;
@@ -271,12 +271,14 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  protected void openOnlineUrl(String url) {
+  protected boolean openOnlineUrl(String url) {
     try {
       startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
     } catch (ActivityNotFoundException e) {
       Toast.makeText(this, R.string.no_browser_installed, Toast.LENGTH_LONG).show();
     }
+    // returning `true` causes the WebView to abort loading
+    return true;
   }
 
   protected WebResourceResponse interceptRequest(String url) {

--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -65,7 +65,6 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
             case "https":
             case "mailto":
             case "openpgp4fpr":
-              // open URL externally
               return openOnlineUrl(url);
           }
         }

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -62,6 +62,11 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
 
     this.dcContext = DcHelper.getContext(getApplicationContext());
     this.dcAppMsg = this.dcContext.getMsg(appMessageId);
+    // `msg_id` in the subdomain makes sure, different apps using same files do not share the same cache entry
+    // (WebView may use a global cache shared across objects).
+    // (a random-id would also work, but would need maintenance and does not add benefits as we regard the file-part interceptRequest() only,
+    // also a random-id is not that useful for debugging)
+    this.baseURL = "https://acc" + dcContext.getAccountId() + "-msg" + appMessageId + ".localhost";
 
     WebSettings webSettings = webView.getSettings();
     webSettings.setJavaScriptEnabled(true);
@@ -75,11 +80,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     webSettings.setDomStorageEnabled(true);
     webView.addJavascriptInterface(new InternalJSApi(), "InternalJSApi");
 
-    // `msg_id` in the subdomain makes sure, different apps using same files do not share the same cache entry
-    // (WebView may use a global cache shared across objects).
-    // (a random-id would also work, but would need maintenance and does not add benefits as we regard the file-part interceptRequest() only,
-    // also a random-id is not that useful for debugging)
-    webView.loadUrl("https://acc" + dcContext.getAccountId() + "-msg" + appMessageId + ".localhost/index.html");
+    webView.loadUrl(this.baseURL + "/index.html");
 
     Util.runOnAnyBackgroundThread(() -> {
       JSONObject info = this.dcAppMsg.getWebxdcInfo();

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -35,6 +35,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   private static final String TAG = WebxdcActivity.class.getSimpleName();
   private DcContext dcContext;
   private DcMsg dcAppMsg;
+  private String baseURL;
 
   public static void openWebxdcActivity(Context context, DcMsg instance) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -105,8 +106,12 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   }
 
   @Override
-  protected void openOnlineUrl(String url) {
-    Toast.makeText(this, "Please embed needed resources.", Toast.LENGTH_LONG).show();
+  protected boolean openOnlineUrl(String url) {
+    if (url.startsWith(baseURL +"/")) {
+      // internal page, continue loading in the WebView
+      return false;
+    }
+    return super.openOnlineUrl(url);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -111,7 +111,8 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       // internal page, continue loading in the WebView
       return false;
     }
-    return super.openOnlineUrl(url);
+    Toast.makeText(this, "Please embed needed resources.", Toast.LENGTH_LONG).show();
+    return true; // returning `true` causes the WebView to abort loading
   }
 
   @Override


### PR DESCRIPTION
 close #2279 

this allows to open internal pages and for other link have the same behavior than the viewer of HTML emails, allowing to open web links externally etc.