### PR TITLE
show context of Webxdc window

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -87,7 +87,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       String chatName =  WebxdcActivity.this.dcContext.getChat(WebxdcActivity.this.dcAppMsg.getChatId()).getName();
       Util.runOnMain(() -> {
         try {
-          getSupportActionBar().setTitle(chatName + " – " + info.getString("name"));
+          getSupportActionBar().setTitle(info.getString("name") + " – " + chatName);
         } catch (Exception e) {
           e.printStackTrace();
         }

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -84,9 +84,10 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
 
     Util.runOnAnyBackgroundThread(() -> {
       JSONObject info = this.dcAppMsg.getWebxdcInfo();
+      String chatName =  WebxdcActivity.this.dcContext.getChat(WebxdcActivity.this.dcAppMsg.getChatId()).getName();
       Util.runOnMain(() -> {
         try {
-          getSupportActionBar().setTitle(info.getString("name"));
+          getSupportActionBar().setTitle(chatName + " – " + info.getString("name"));
         } catch (Exception e) {
           e.printStackTrace();
         }


### PR DESCRIPTION
show the chat name in front of the webxdc name to
- prevent phishing (the window will not show just the name of your bank)
- give the user an idea about where the webxdc sends messages to
  (important eg. when using the same webxdc from different chats)

counterpart of https://github.com/deltachat/deltachat-ios/pull/1578
see also https://github.com/deltachat/deltachat-core-rust/pull/3309