### PR TITLE
add 'Source Code' item to webxdc menu

### DIFF
--- a/res/menu/webxdc.xml
+++ b/res/menu/webxdc.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:title="@string/source_code"
+        android:id="@+id/source_code" />
+
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -258,6 +258,7 @@
     <string name="unpin">Unpin</string>
     <string name="ConversationFragment_quoted_message_not_found">Original message not found</string>
     <string name="reply_privately">Reply Privately</string>
+    <string name="source_code">Source Code</string>
 
     <string name="mute_for_one_hour">Mute for 1 hour</string>
     <string name="mute_for_two_hours">Mute for 2 hours</string>

--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms;
 
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
@@ -270,12 +271,16 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  protected boolean openOnlineUrl(String url) {
+  public static void openUrlInBrowser(Context context, String url) {
     try {
-      startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+      context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
     } catch (ActivityNotFoundException e) {
-      Toast.makeText(this, R.string.no_browser_installed, Toast.LENGTH_LONG).show();
+      Toast.makeText(context, R.string.no_browser_installed, Toast.LENGTH_LONG).show();
     }
+  }
+
+  protected boolean openOnlineUrl(String url) {
+    openUrlInBrowser(this, url);
     // returning `true` causes the WebView to abort loading
     return true;
   }

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -38,7 +38,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   private DcContext dcContext;
   private DcMsg dcAppMsg;
   private String baseURL;
-  private boolean hasSourceCodeUrl;
+  private String sourceCodeUrl = "";
 
   public static void openWebxdcActivity(Context context, DcMsg instance) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -98,7 +98,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     // do not call super.onPrepareOptionsMenu() as the default "Search" menu is not needed
     menu.clear();
     this.getMenuInflater().inflate(R.menu.webxdc, menu);
-    menu.findItem(R.id.source_code).setVisible(hasSourceCodeUrl);
+    menu.findItem(R.id.source_code).setVisible(!sourceCodeUrl.isEmpty());
     return true;
   }
 
@@ -107,7 +107,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     super.onOptionsItemSelected(item);
     switch (item.getItemId()) {
       case R.id.source_code:
-        openUrlInBrowser(this, JsonUtils.optString(dcAppMsg.getWebxdcInfo(), "source_code_url"));
+        openUrlInBrowser(this, sourceCodeUrl);
         return true;
     }
     return false;
@@ -175,12 +175,12 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       final String docName = JsonUtils.optString(info, "document");
       final String xdcName = JsonUtils.optString(info, "name");
       final String chatName =  WebxdcActivity.this.dcContext.getChat(WebxdcActivity.this.dcAppMsg.getChatId()).getName();
-      final boolean currHasSourceCodeUrl = !JsonUtils.optString(info, "source_code_url").isEmpty();
+      final String currSourceCodeUrl = JsonUtils.optString(info, "source_code_url");
 
       Util.runOnMain(() -> {
         getSupportActionBar().setTitle((docName.isEmpty() ? xdcName : docName) + " – " + chatName);
-        if (hasSourceCodeUrl != currHasSourceCodeUrl) {
-          hasSourceCodeUrl = currHasSourceCodeUrl;
+        if (!sourceCodeUrl.equals(currSourceCodeUrl)) {
+          sourceCodeUrl = currSourceCodeUrl;
           invalidateOptionsMenu();
         }
       });


### PR DESCRIPTION
the code is a tiny bit more complicated
as we keep the call to getWebxdcInfo() in background
and also avoid a second call to getWebxdcInfo() on startup.

<img width="336" alt="Screen Shot 2022-05-17 at 16 13 39" src="https://user-images.githubusercontent.com/9800740/168832125-827e9678-7f9a-4798-957d-f866b0f0bece.png">
(the menu is a bit lost, however, it will probably fill up in the future :)


closes https://github.com/deltachat/deltachat-android/issues/2298