### PR TITLE
exclude com.google.android.gms from apk binaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,9 @@ dependencies {
     }
     implementation 'com.annimon:stream:1.1.8' // brings future java streams api to SDK Version < 24
     implementation 'com.codewaves.stickyheadergrid:stickyheadergrid:0.9.4' // glues the current time segment text in the gallery to the top.
-    implementation 'org.maplibre.gl:android-sdk:9.4.0'
+    implementation ('org.maplibre.gl:android-sdk:9.4.0') {
+        exclude group: 'com.google.android.gms'
+    }
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
recently DeltaLab got added to [IzzyOnDroid](https://android.izzysoft.de/repo) repo and after being scanned with some apk analyzer got marked with anti-features because GMS blobs are bundled in the apk due to maplibre including it, this is also happening in official Delta Chat.

I excluded gms and all seems to work fine because in practice we don't use google services, and reading maplibre's repo, the class using the `gms` package is `com.mapbox.mapboxsdk.location.engine.GoogleLocationEngineImpl` and in:
https://github.com/maplibre/maplibre-gl-native/blob/ea234edf67bb3aec75f077e15c1c30c99756b926/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java#L83
it says that for `GoogleLocationEngineImpl` to be used:
> simply add the Google Play Location Services dependency in your build script.

since we don't add it, it is unused, but yet the `com.google.android.gms` was bundled in the apk

Without this Delta Chat might get flagged on f-droid (other apps are getting similar issues, check https://gitlab.com/fdroid/fdroiddata/-/merge_requests/10991 )

as a plus this should make the apk size a bit smaller :)