### PR TITLE
prepare 1.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,23 @@
 # Delta Chat Android Changelog
 
+## v1.30.2
+2022-05
+
+* show document and chat name in webxdc titles
+* add menu entry access the webxdc's source code
+* remove anyway unused com.google.android.gms from binary to avoid being flagged
+* send normal messages with higher priority than read receipts
+* improve chat encryption info, make it easier to find contacts without keys
+* improve error reporting when creating a folder fails
+* fix: repair encrypted mails "mixed up" by Google Workspace "Append footer" function
+* fix: use same contact-color if email address differ only in upper-/lowercase
+* update translations
+* update to core83
+
+
 ## v1.30.1
 2022-05
+
 * fix wrong language in read receipts
 * fix encoding issue in QR code descriptions
 * webxdc: allow internal pages

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 630
-        versionName "1.30.1"
+        versionCode 631
+        versionName "1.30.2"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
this version mainly fixes an issue with f-droid that disabled the last two versions because of https://github.com/deltachat/deltachat-android/pull/2303

in other words, on f-droid, 1.30.1 was available for some days, however, is disabled now again. 1.30.2 should fix that issue.