### PR TITLE
fix behavior of system-back-button for webxdc

### DIFF
--- a/src/org/thoughtcrime/securesms/ConnectivityActivity.java
+++ b/src/org/thoughtcrime/securesms/ConnectivityActivity.java
@@ -43,11 +43,4 @@ public class ConnectivityActivity extends WebViewActivity implements DcEventCent
   public void handleEvent(@NonNull DcEvent event) {
     refresh();
   }
-
-  @Override
-  public void onBackPressed() {
-    // If we did not override this function, the back button in the connectivity view would sometimes
-    // not work, probably because webView.canGoBack() in WebViewActivity.onBackPressed() wrongly returns true
-    finish();
-  }
 }

--- a/src/org/thoughtcrime/securesms/LocalHelpActivity.java
+++ b/src/org/thoughtcrime/securesms/LocalHelpActivity.java
@@ -69,6 +69,15 @@ public class LocalHelpActivity extends WebViewActivity
     return false;
   }
 
+  @Override
+  public void onBackPressed() {
+    if (webView.canGoBack()) {
+      webView.goBack();
+    } else {
+      super.onBackPressed();
+    }
+  }
+
   private boolean assetExists(String fileName) {
     // test using AssetManager.open();
     // AssetManager.list() is unreliable eg. on my Android 7 Moto G

--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -262,14 +262,8 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
     return false;
   }
 
-  @Override
-  public void onBackPressed() {
-    if (webView.canGoBack()) {
-      webView.goBack();
-    } else {
-      super.onBackPressed();
-    }
-  }
+  // onBackPressed() can be overwritten by derived classes as needed.
+  // the default behavior (close the activity) is just fine eg. for Webxdc, Connectivity, HTML-mails
 
   public static void openUrlInBrowser(Context context, String url) {
     try {


### PR DESCRIPTION
for webxdc, the system-back-button should do the same
as the back-button in the title bar - just close the webxdc.

without this commit, it loads the previous page, which is often unexpected -
eg. many games use reload() for simplicity,
so you would have press one time 'back' for each round :)

even if there may be situations where this may be useful,
we do not want to encourage webxdc to rely on the system-back-button -
eg. desktop or ios currently just do not have this button.

technically, this pr changes the default -
so, for all classes derived from WebViewActivity, the system-back-button will
now behave as the title-bar-back-button.

for the local-help, this behavior is changed explictly -
i think, for HTML-mails, the 'just close' approach is also better.