### PR TITLE
Update to Android NDK r23c

### DIFF
--- a/.github/workflows/preview-apk.yml
+++ b/.github/workflows/preview-apk.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r21d
+          ndk-version: r23c
 
       - name: Compile core
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,20 @@ USER $USER
 ENV ANDROID_SDK_ROOT /home/${USER}/android-sdk
 RUN mkdir ${ANDROID_SDK_ROOT}
 WORKDIR $ANDROID_SDK_ROOT
-RUN wget -q https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip && \
-  unzip commandlinetools-linux-6200805_latest.zip && \
-  rm commandlinetools-linux-6200805_latest.zip
+RUN wget -q https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip && \
+  unzip commandlinetools-linux-8512546_latest.zip && \
+  rm commandlinetools-linux-8512546_latest.zip
 
-RUN yes | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --licenses
+RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --licenses
 
-ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/tools/bin
+ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/bin
 
 # Install NDK manually. Other SDK parts are installed automatically by gradle.
-RUN sdkmanager --sdk_root=${ANDROID_SDK_ROOT} ndk-bundle
+#
+# NDK version r23c LTS aka 23.2.8568313
+RUN sdkmanager --sdk_root=${ANDROID_SDK_ROOT} 'ndk;23.2.8568313'
 
-ENV ANDROID_NDK_ROOT ${ANDROID_SDK_ROOT}/ndk-bundle
+ENV ANDROID_NDK_ROOT ${ANDROID_SDK_ROOT}/ndk/23.2.8568313
 ENV PATH ${PATH}:${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/:${ANDROID_NDK_ROOT}
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -93,7 +93,10 @@ fi
 # It is built against r22b NDK toolchains and still requires -lgcc instead of -lunwind used in newer r23 NDK.
 # See discussion at <https://github.com/rust-lang/rust/pull/85806>
 TMPLIB="$(mktemp -d)"
-echo 'INPUT(-lunwind)' >"$TMPLIB/libgcc.a"
+if test -z "$(find "$ANDROID_NDK_ROOT" -name libgcc.a -print -quit)"; then
+    # NDK is does not contain libgcc.a, add a linker script to fake it.
+    echo 'INPUT(-lunwind)' >"$TMPLIB/libgcc.a"
+fi
 
 if test -z $1 || test $1 = armeabi-v7a; then
     echo "-- cross compiling to armv7-linux-androideabi (arm) --"


### PR DESCRIPTION
Android NDK is updated from legacy ndk-bundle stuck at unsupported
r22b to LTS NDK r23c (23.2.8568313).

Since GNU binutils have been removed from NDK since r23 (see
https://github.com/android/ndk/wiki/Changelog-r23), ndk-make.sh now
uses TARGET_AR=llvm-ar and uses a workaround for `-lgcc` requirement.

Android command line tools used in the Dockerfile are updated to build
8512546

Preview APKs now use NDK r23c too.