### PR TITLE
show more info messages by adapting spacing to the overall layout

### DIFF
--- a/res/layout/conversation_item_update.xml
+++ b/res/layout/conversation_item_update.xml
@@ -8,8 +8,8 @@
     android:focusable="true"
     android:gravity="center"
     android:orientation="vertical"
-    android:paddingTop="13dp"
-    android:paddingBottom="13dp"
+    android:paddingTop="5dp"
+    android:paddingBottom="7dp"
     android:paddingLeft="28dp"
     android:paddingRight="28dp">
 


### PR DESCRIPTION
the spacing was just a bit too much,
eg. bubble spacing is 6dp atop and abottom.

this was always not-so-good, however, as info-messages are
more in use by webxdc now, it gets more visible.

the new spacing roughly matches the layout on ios.

before/after:

<img width=300 src=https://user-images.githubusercontent.com/9800740/172047531-b265fa36-68bb-492a-80ea-ce5cabd7190a.png> <img width=300  src=https://user-images.githubusercontent.com/9800740/172047528-f9667496-347a-4a28-b79c-d011e4cd1338.png>

nb: some of the info-messages from the screenshot will be cleaned up by https://github.com/deltachat/deltachat-core-rust/pull/3395 , but other series would not :)
