### PR TITLE
use correct `DC_STATE_OUT_FAILED` name

### DIFF
--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -1,6 +1,5 @@
 package com.b44t.messenger;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
@@ -27,7 +26,7 @@ public class DcMsg {
     public final static int DC_STATE_OUT_PREPARING = 18;
     public final static int DC_STATE_OUT_DRAFT = 19;
     public final static int DC_STATE_OUT_PENDING = 20;
-    public final static int DC_STATE_OUT_ERROR = 24;
+    public final static int DC_STATE_OUT_FAILED = 24;
     public final static int DC_STATE_OUT_DELIVERED = 26;
     public final static int DC_STATE_OUT_MDN_RCVD = 28;
 
@@ -197,7 +196,7 @@ public class DcMsg {
     }
 
     public boolean isFailed() {
-        return getState() == DC_STATE_OUT_ERROR;
+        return getState() == DC_STATE_OUT_FAILED;
     }
     public boolean isPreparing() {
         return getState() == DC_STATE_OUT_PREPARING;

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -278,7 +278,7 @@ public class ConversationListItem extends RelativeLayout
         unreadIndicator.setVisibility(View.VISIBLE);
       }
 
-      if (state == DcMsg.DC_STATE_OUT_ERROR) {
+      if (state == DcMsg.DC_STATE_OUT_FAILED) {
         deliveryStatusIndicator.setFailed();
       } else if (state == DcMsg.DC_STATE_OUT_MDN_RCVD) {
         deliveryStatusIndicator.setRead();
@@ -292,7 +292,7 @@ public class ConversationListItem extends RelativeLayout
         deliveryStatusIndicator.setNone();
       }
 
-      if (state == DcMsg.DC_STATE_OUT_ERROR) {
+      if (state == DcMsg.DC_STATE_OUT_FAILED) {
         deliveryStatusIndicator.setTint(Color.RED);
       } else {
         deliveryStatusIndicator.resetTint();


### PR DESCRIPTION
in core, the state is called `DC_STATE_OUT_FAILED`,
not `DC_STATE_OUT_ERROR`.

the new name also fits better to existing names as `isFailed()`.