### PR TITLE
add `epoll_create1` that is missing in API<21 but needed by tokio

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -7,6 +7,15 @@
 #include "deltachat-core-rust/deltachat-ffi/deltachat.h"
 
 
+#if __ANDROID_API__ < 21
+#include <sys/epoll.h>
+int epoll_create1(int flags) {
+    int fd = epoll_create(1000);
+    return fd;
+}
+#endif
+
+
 static dc_msg_t* get_dc_msg(JNIEnv *env, jobject obj);
 
 

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -9,8 +9,13 @@
 
 #if __ANDROID_API__ < 21
 #include <sys/epoll.h>
+#include <fcntl.h>
 int epoll_create1(int flags) {
     int fd = epoll_create(1000);
+    if (flags & O_CLOEXEC) { /* EPOLL_CLOEXEC == O_CLOEXEC */
+        int f = fcntl(fd, F_GETFD);
+        fcntl(fd, F_SETFD, f | FD_CLOEXEC);
+    }
     return fd;
 }
 #endif


### PR DESCRIPTION
closes https://github.com/deltachat/deltachat-android/issues/2323