### PR TITLE
Don't animate the spinning circle if animations are disabled

### DIFF
--- a/androidTest/com/b44t/messenger/TestUtils.java
+++ b/androidTest/com/b44t/messenger/TestUtils.java
@@ -19,6 +19,7 @@ import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.util.AccessibilityUtil;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -80,6 +81,10 @@ public class TestUtils {
 
   private static void prepare() {
     Prefs.setBooleanPreference(getInstrumentation().getTargetContext(), Prefs.DOZE_ASKED_DIRECTLY, true);
+    if (!AccessibilityUtil.areAnimationsDisabled(getInstrumentation().getTargetContext())) {
+      throw new RuntimeException("To run the tests, disable animations at Developer options' " +
+              "-> 'Window/Transition/Animator animation scale' -> Set all 3 to 'off'");
+    }
   }
 
   /**

--- a/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
+++ b/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
@@ -8,6 +8,7 @@ import android.view.animation.RotateAnimation;
 import android.widget.ImageView;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.AccessibilityUtil;
 
 public class DeliveryStatusView {
 
@@ -24,6 +25,8 @@ public class DeliveryStatusView {
 
   private void animatePrepare()
   {
+    if (AccessibilityUtil.areAnimationsDisabled(context)) return;
+    
     if(prepareAnimation ==null) {
       prepareAnimation = new RotateAnimation(360f, 0f,
           Animation.RELATIVE_TO_SELF, 0.5f,
@@ -39,6 +42,8 @@ public class DeliveryStatusView {
 
   private void animateSending()
   {
+    if (AccessibilityUtil.areAnimationsDisabled(context)) return;
+
     if(sendingAnimation ==null) {
       sendingAnimation = new RotateAnimation(0, 360f,
           Animation.RELATIVE_TO_SELF, 0.5f,


### PR DESCRIPTION
This is needed for the UI tests to run (since https://github.com/deltachat/deltachat-core-rust/pull/3150 didn't get merged, but I didn't try to run the UI tests since then).

Plus, it's just the correct behavior; if the animations are disabled system-wide, there should be no animations. A slight downside of this PR is that the circle doesn't make that much sense if it's not spinning, so we could alternatively replace the image with an hourclock or a clock. I don't think that's worth it though, because the kind of users that disables the animations probably won't mind.

Also, this PR shows an error if someone tries to run the tests with animations on (since they will probably fail anyway).