### PR TITLE
rename "Docs" tab to "Files"

### DIFF
--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -362,7 +362,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
           return getString(R.string.tab_gallery);
 
         case TAB_DOCS:
-          return getString(R.string.tab_docs);
+          return getString(R.string.files);
 
         case TAB_LINKS:
           return getString(R.string.tab_links);


### PR DESCRIPTION
- "Files" is broader than "Docs"
  (documents are just one type of files,
  files can also be executables and whatnot)
- at other places in the app, we also speak of "Files"
  ("sending files" etc.)
- Delta Chat iOS also uses the term "Files"

cmp https://support.delta.chat/t/tabs-for-links-and-files/2142