### PR TITLE
prepare 1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Delta Chat Android Changelog
 
+## v1.32.0
+2022-07
+
+* update Maplibre
+* update translations
+* using core90
+
+
 ## v1.31.1 Testrun
 2022-07
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 634
-        versionName "1.31.1"
+        versionCode 635
+        versionName "1.32.0"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
i think, it does not make much sense to add a device messages this time, AEAP is currently more a bug fix, better mention that next time. remaining things are mainly bug fixes, and that was already said in the previous device message.

if we want to add one, we can do one in an 1.32.1 easily, this one should be tagged fast so that there is a recent version again on f-droid.