### PR TITLE
option to add webxdc apps to home screen

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,6 +30,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.INSTALL_SHORTCUT" />
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.RAISED_THREAD_PRIORITY" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
@@ -286,7 +287,8 @@
     <activity android:name=".WebxdcActivity"
               android:label=""
               android:theme="@style/TextSecure.LightTheme"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+              android:exported="true">
     </activity>
 
     <activity android:name=".FullMsgActivity"

--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -20,6 +20,11 @@
         android:icon="@drawable/ic_share_white_24dp"
         app:showAsAction="always" />
 
+    <item android:title="@string/add_to_home_screen"
+        android:id="@+id/menu_add_to_home_screen"
+        android:visible="false"
+        app:showAsAction="never" />
+
     <item android:title="@string/menu_copy_to_clipboard"
         android:id="@+id/menu_context_copy"
         android:icon="?menu_copy_icon"

--- a/res/menu/profile_context.xml
+++ b/res/menu/profile_context.xml
@@ -15,6 +15,11 @@
         android:icon="@drawable/ic_share_white_24dp"
         app:showAsAction="always" />
 
+    <item android:id="@+id/menu_add_to_home_screen"
+        android:title="@string/add_to_home_screen"
+        android:visible="false"
+        app:showAsAction="never"/>
+
     <item android:id="@+id/show_in_chat"
         android:title="@string/show_in_chat"
         app:showAsAction="never"/>

--- a/res/menu/webxdc.xml
+++ b/res/menu/webxdc.xml
@@ -2,6 +2,8 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <item android:title="@string/add_to_home_screen"
+        android:id="@+id/menu_add_to_home_screen" />
     <item android:title="@string/source_code"
         android:id="@+id/source_code" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -264,6 +264,8 @@
     <string name="ConversationFragment_quoted_message_not_found">Original message not found</string>
     <string name="reply_privately">Reply Privately</string>
     <string name="source_code">Source Code</string>
+    <!-- Menu item beside an app/chat that adds an icon to the system's home screen. If the user taps that icon, the app/chat is opened directly. -->
+    <string name="add_to_home_screen">Add to Home Screen</string>
 
     <string name="mute_for_one_hour">Mute for 1 hour</string>
     <string name="mute_for_two_hours">Mute for 2 hours</string>

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -52,6 +52,10 @@ public class DcMsg {
         this.msgCPtr = msgCPtr;
     }
 
+    public boolean isOk() {
+      return msgCPtr != 0;
+    }
+
     @Override
     protected void finalize() throws Throwable {
         super.finalize();

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -921,7 +921,7 @@ public class ConversationFragment extends MessageSelectorFragment
                     actionMode.finish();
                     return true;
                 case R.id.menu_add_to_home_screen:
-                    WebxdcActivity.addToHomeScreen(getContext(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId());
+                    WebxdcActivity.addToHomeScreen(getActivity(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId());
                     actionMode.finish();
                     return true;
                 case R.id.menu_context_save_attachment:

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -320,6 +320,7 @@ public class ConversationFragment extends MessageSelectorFragment
             menu.findItem(R.id.menu_context_share).setVisible(false);
             menu.findItem(R.id.menu_context_reply).setVisible(false);
             menu.findItem(R.id.menu_context_reply_privately).setVisible(false);
+            menu.findItem(R.id.menu_add_to_home_screen).setVisible(false);
         } else {
             DcMsg messageRecord = messageRecords.iterator().next();
             DcChat chat = getListAdapter().getChat();
@@ -329,6 +330,7 @@ public class ConversationFragment extends MessageSelectorFragment
             menu.findItem(R.id.menu_context_reply).setVisible(chat.canSend() && canReply);
             boolean showReplyPrivately = chat.isMultiUser() && !messageRecord.isOutgoing() && canReply;
             menu.findItem(R.id.menu_context_reply_privately).setVisible(showReplyPrivately);
+            menu.findItem(R.id.menu_add_to_home_screen).setVisible(messageRecord.getType() == DcMsg.DC_MSG_WEBXDC);
         }
 
         // if one of the selected items cannot be saved, disable saving.
@@ -916,6 +918,10 @@ public class ConversationFragment extends MessageSelectorFragment
                     return true;
                 case R.id.menu_context_forward:
                     handleForwardMessage(getListAdapter().getSelectedItems());
+                    actionMode.finish();
+                    return true;
+                case R.id.menu_add_to_home_screen:
+                    WebxdcActivity.addToHomeScreen(getContext(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId());
                     actionMode.finish();
                     return true;
                 case R.id.menu_context_save_attachment:

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -182,6 +182,9 @@ public class ProfileDocumentsFragment
     menu.findItem(R.id.details).setVisible(singleSelection);
     menu.findItem(R.id.show_in_chat).setVisible(singleSelection);
     menu.findItem(R.id.share).setVisible(singleSelection);
+
+    boolean webxdcApp = singleSelection && messageRecords.iterator().next().getType() == DcMsg.DC_MSG_WEBXDC;
+    menu.findItem(R.id.menu_add_to_home_screen).setVisible(webxdcApp);
   }
 
   private ProfileDocumentsAdapter getListAdapter() {
@@ -224,6 +227,10 @@ public class ProfileDocumentsFragment
           return true;
         case R.id.share:
           handleShare(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+          return true;
+        case R.id.menu_add_to_home_screen:
+          WebxdcActivity.addToHomeScreen(getActivity(), getSelectedMessageRecord(getListAdapter().getSelectedMedia()).getId());
+          mode.finish();
           return true;
         case R.id.show_in_chat:
           handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -259,7 +259,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         .build();
 
       if (ShortcutManagerCompat.requestPinShortcut(context, shortcutInfoCompat, null)) {
-        Toast.makeText(context, R.string.done, Toast.LENGTH_LONG).show();
+        Toast.makeText(context, R.string.done, Toast.LENGTH_SHORT).show();
       } else {
         Toast.makeText(context, "ErrAddToHomescreen: requestPinShortcut() failed", Toast.LENGTH_LONG).show();
       }

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -96,18 +96,24 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     int appMessageId = b.getInt("appMessageId");
 
     this.dcContext = DcHelper.getContext(getApplicationContext());
-    this.dcAppMsg = this.dcContext.getMsg(appMessageId);
-    // `msg_id` in the subdomain makes sure, different apps using same files do not share the same cache entry
-    // (WebView may use a global cache shared across objects).
-    // (a random-id would also work, but would need maintenance and does not add benefits as we regard the file-part interceptRequest() only,
-    // also a random-id is not that useful for debugging)
-    this.baseURL = "https://acc" + dcContext.getAccountId() + "-msg" + appMessageId + ".localhost";
-
     if (dcContext.getAccountId() != b.getInt("accountId")) {
       Toast.makeText(this, "Switch to belonging account first.", Toast.LENGTH_LONG).show();
       finish();
       return;
     }
+
+    this.dcAppMsg = this.dcContext.getMsg(appMessageId);
+    if (!this.dcAppMsg.isOk()) {
+      Toast.makeText(this, "Webxdc does no longer exist.", Toast.LENGTH_LONG).show();
+      finish();
+      return;
+    }
+
+    // `msg_id` in the subdomain makes sure, different apps using same files do not share the same cache entry
+    // (WebView may use a global cache shared across objects).
+    // (a random-id would also work, but would need maintenance and does not add benefits as we regard the file-part interceptRequest() only,
+    // also a random-id is not that useful for debugging)
+    this.baseURL = "https://acc" + dcContext.getAccountId() + "-msg" + appMessageId + ".localhost";
 
     WebSettings webSettings = webView.getSettings();
     webSettings.setJavaScriptEnabled(true);

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -107,6 +107,9 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
     switch (item.getItemId()) {
+      case R.id.menu_add_to_home_screen:
+        addToHomeScreen(this, dcAppMsg.getId());
+        return true;
       case R.id.source_code:
         openUrlInBrowser(this, sourceCodeUrl);
         return true;
@@ -190,6 +193,11 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         }
       });
     });
+  }
+
+  public static void addToHomeScreen(Context context, int msgId) {
+    // TODO
+    Toast.makeText(context, R.string.done, Toast.LENGTH_LONG).show();
   }
 
   class InternalJSApi {

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -87,6 +87,12 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     // also a random-id is not that useful for debugging)
     this.baseURL = "https://acc" + dcContext.getAccountId() + "-msg" + appMessageId + ".localhost";
 
+    if (dcContext.getAccountId() != b.getInt("accountId")) {
+      Toast.makeText(this, "Switch to belonging account first.", Toast.LENGTH_LONG).show();
+      finish();
+      return;
+    }
+
     WebSettings webSettings = webView.getSettings();
     webSettings.setJavaScriptEnabled(true);
     webSettings.setAllowFileAccess(false);

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -21,6 +21,7 @@ import android.webkit.WebView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.app.TaskStackBuilder;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
@@ -68,6 +69,21 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     intent.putExtra("accountId", dcContext.getAccountId());
     intent.putExtra("appMessageId", msgId);
     return intent;
+  }
+
+  private static Intent[] getWebxdcIntentWithParentStack(Context context, int msgId) {
+    DcContext dcContext = DcHelper.getContext(context);
+
+    final Intent chatIntent = new Intent(context, ConversationActivity.class)
+      .putExtra(ConversationActivity.CHAT_ID_EXTRA, dcContext.getMsg(msgId).getChatId())
+      .setAction(Intent.ACTION_VIEW);
+
+    final Intent webxdcIntent = getWebxdcIntent(context, msgId);
+
+    return TaskStackBuilder.create(context)
+      .addNextIntentWithParentStack(chatIntent)
+      .addNextIntent(webxdcIntent)
+      .getIntents();
   }
 
   @Override
@@ -233,7 +249,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       ShortcutInfoCompat shortcutInfoCompat = new ShortcutInfoCompat.Builder(context, "xdc-" + dcContext.getAccountId() + "-" + msgId)
         .setShortLabel(docName.isEmpty() ? xdcName : docName)
         .setIcon(IconCompat.createWithBitmap(bitmap))
-        .setIntent(getWebxdcIntent(context, msgId))
+        .setIntents(getWebxdcIntentWithParentStack(context, msgId))
         .build();
 
       if (ShortcutManagerCompat.requestPinShortcut(context, shortcutInfoCompat, null)) {

--- a/src/org/thoughtcrime/securesms/util/views/ConversationAdaptiveActionsToolbar.java
+++ b/src/org/thoughtcrime/securesms/util/views/ConversationAdaptiveActionsToolbar.java
@@ -24,8 +24,9 @@ public class ConversationAdaptiveActionsToolbar extends Toolbar {
   private static final int OVERFLOW_VIEW_WIDTH_DP = 36;
 
   private static final int ID_NEVER_SHOW_AS_ACTION_1 = R.id.menu_context_reply_privately;
-  private static final int ID_NEVER_SHOW_AS_ACTION_2 = R.id.menu_context_save_attachment;
-  private static final int ID_NEVER_SHOW_AS_ACTION_3 = R.id.menu_resend;
+  private static final int ID_NEVER_SHOW_AS_ACTION_2 = R.id.menu_add_to_home_screen;
+  private static final int ID_NEVER_SHOW_AS_ACTION_3 = R.id.menu_context_save_attachment;
+  private static final int ID_NEVER_SHOW_AS_ACTION_4 = R.id.menu_resend;
   private static final int ID_ALWAYS_SHOW_AS_ACTION = R.id.menu_context_forward;
 
   private int   maxShown;
@@ -81,7 +82,8 @@ public class ConversationAdaptiveActionsToolbar extends Toolbar {
 
       boolean neverShowAsAction = item.getItemId() == ID_NEVER_SHOW_AS_ACTION_1
                                || item.getItemId() == ID_NEVER_SHOW_AS_ACTION_2
-                               || item.getItemId() == ID_NEVER_SHOW_AS_ACTION_3;
+                               || item.getItemId() == ID_NEVER_SHOW_AS_ACTION_3
+                               || item.getItemId() == ID_NEVER_SHOW_AS_ACTION_4;
       boolean alwaysShowAsAction = item.getItemId() == ID_ALWAYS_SHOW_AS_ACTION;
 
       if (alwaysShowAsAction) continue;


### PR DESCRIPTION
this pr adds an option to add webxdc app icons to the launcher ...

<img width=300 src=https://user-images.githubusercontent.com/9800740/181996810-4d6e55f8-b23f-4862-b324-15255841e85a.jpg>

... and start webxdc apps from there directly ...

<img width=360 src=https://user-images.githubusercontent.com/9800740/181389262-d950a03d-0cb1-411e-aa89-abfa283b59c3.jpg>

see commit "[recreate back stack, if possible](https://github.com/deltachat/deltachat-android/pull/2353/commits/0d63f3505cc4eb43a3f08339614d7f81cc7e5163)" for a discussion about about back stack.

closes https://github.com/deltachat/deltachat-android/issues/2350