### PR TITLE
show mailinglist post address in profile

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1289,6 +1289,15 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcChat_getName(JNIEnv *env, jobject ob
 }
 
 
+JNIEXPORT jstring Java_com_b44t_messenger_DcChat_getMailinglistAddr(JNIEnv *env, jobject obj)
+{
+    char* temp = dc_chat_get_mailinglist_addr(get_dc_chat(env, obj));
+        jstring ret = JSTRING_NEW(temp);
+    dc_str_unref(temp);
+    return ret;
+}
+
+
 JNIEXPORT jstring Java_com_b44t_messenger_DcChat_getProfileImage(JNIEnv *env, jobject obj)
 {
     char* temp = dc_chat_get_profile_image(get_dc_chat(env, obj));

--- a/src/com/b44t/messenger/DcChat.java
+++ b/src/com/b44t/messenger/DcChat.java
@@ -31,6 +31,7 @@ public class DcChat {
     public native int     getType           ();
     public native int     getVisibility     ();
     public native String  getName           ();
+    public native String  getMailinglistAddr();
     public native String  getProfileImage   ();
     public native int     getColor          ();
     public native boolean isUnpromoted      ();

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -103,14 +103,15 @@ public class ConversationTitleView extends RelativeLayout {
       }
     }
 
-    subtitle.setText(subtitleStr);
-
     avatar.setAvatar(glideRequests, new Recipient(getContext(), dcChat), false);
-    title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
+
+    subtitle.setText(subtitleStr);
     subtitle.setVisibility(showAddInfo? View.VISIBLE : View.GONE);
 
+    title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
+
     boolean isEphemeral = dcContext.getChatEphemeralTimer(chatId) != 0;
-    ephemeralIcon.setVisibility((showAddInfo && isEphemeral)? View.VISIBLE : View.GONE);
+    ephemeralIcon.setVisibility(isEphemeral? View.VISIBLE : View.GONE);
   }
 
   public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcContact contact) {

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -112,17 +112,16 @@ public class ConversationTitleView extends RelativeLayout {
       }
     }
 
-    avatar.setAvatar(glideRequests, new Recipient(getContext(), dcChat), false);
+    subtitle.setText(subtitleStr);
 
+    avatar.setAvatar(glideRequests, new Recipient(getContext(), dcChat), false);
+    title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
     if (!TextUtils.isEmpty(subtitleStr)) {
       subtitle.setText(subtitleStr);
       subtitle.setVisibility(View.VISIBLE);
     } else {
       subtitle.setVisibility(View.GONE);
     }
-
-    title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
-
     boolean isEphemeral = dcContext.getChatEphemeralTimer(chatId) != 0;
     ephemeralIcon.setVisibility(isEphemeral? View.VISIBLE : View.GONE);
   }

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms;
 
 import android.content.Context;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
@@ -67,7 +68,7 @@ public class ConversationTitleView extends RelativeLayout {
 
     // set title and subtitle texts
     title.setText(dcChat.getName());
-    String subtitleStr = "ErrSubtitle";
+    String subtitleStr = null;
 
     // set icons etc.
     int imgLeft = 0;
@@ -82,11 +83,19 @@ public class ConversationTitleView extends RelativeLayout {
 
     int[] chatContacts = dcContext.getChatContacts(chatId);
     if (dcChat.isMailingList()) {
-      subtitleStr = context.getString(R.string.mailing_list);
+      if (profileView) {
+        subtitleStr = dcChat.getMailinglistAddr();
+      } else {
+        subtitleStr = context.getString(R.string.mailing_list);
+      }
     } else if (dcChat.isBroadcast()) {
-      subtitleStr = context.getResources().getQuantityString(R.plurals.n_recipients, chatContacts.length, chatContacts.length);
+      if (!profileView) {
+        subtitleStr = context.getResources().getQuantityString(R.plurals.n_recipients, chatContacts.length, chatContacts.length);
+      }
     } else if( dcChat.isMultiUser() ) {
-      subtitleStr = context.getResources().getQuantityString(R.plurals.n_members, chatContacts.length, chatContacts.length);
+      if (!profileView) {
+        subtitleStr = context.getResources().getQuantityString(R.plurals.n_members, chatContacts.length, chatContacts.length);
+      }
     } else if( chatContacts.length>=1 ) {
       if( dcChat.isSelfTalk() ) {
         subtitleStr = context.getString(R.string.chat_self_talk_subtitle);
@@ -105,8 +114,12 @@ public class ConversationTitleView extends RelativeLayout {
 
     avatar.setAvatar(glideRequests, new Recipient(getContext(), dcChat), false);
 
-    subtitle.setText(subtitleStr);
-    subtitle.setVisibility(profileView? View.GONE : View.VISIBLE);
+    if (!TextUtils.isEmpty(subtitleStr)) {
+      subtitle.setText(subtitleStr);
+      subtitle.setVisibility(View.VISIBLE);
+    } else {
+      subtitle.setVisibility(View.GONE);
+    }
 
     title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
 

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -57,10 +57,10 @@ public class ConversationTitleView extends RelativeLayout {
   }
 
   public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat) {
-    setTitle(glideRequests, dcChat, true);
+    setTitle(glideRequests, dcChat, false);
   }
 
-  public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat, boolean showAddInfo) {
+  public void setTitle(@NonNull GlideRequests glideRequests, @NonNull DcChat dcChat, boolean profileView) {
     final int chatId = dcChat.getId();
     final Context context = getContext();
     final DcContext dcContext = DcHelper.getContext(context);
@@ -106,7 +106,7 @@ public class ConversationTitleView extends RelativeLayout {
     avatar.setAvatar(glideRequests, new Recipient(getContext(), dcChat), false);
 
     subtitle.setText(subtitleStr);
-    subtitle.setVisibility(showAddInfo? View.VISIBLE : View.GONE);
+    subtitle.setVisibility(profileView? View.GONE : View.VISIBLE);
 
     title.setCompoundDrawablesWithIntrinsicBounds(imgLeft, 0, imgRight, 0);
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -259,7 +259,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     }
     else if (chatId > 0) {
       DcChat dcChat  = dcContext.getChat(chatId);
-      titleView.setTitle(GlideApp.with(this), dcChat, isContactProfile());
+      titleView.setTitle(GlideApp.with(this), dcChat, true);
     }
     else if (isContactProfile()){
       titleView.setTitle(GlideApp.with(this), dcContext.getContact(contactId));


### PR DESCRIPTION
this pr adds the mailinglist-post-address to the profile's subtitle:

<img width=380 src=https://user-images.githubusercontent.com/9800740/181065802-2638397e-061a-4251-8754-37cc0a3416f9.jpg>

counterpart of https://github.com/deltachat/deltachat-ios/pull/1654

moreover, this pr fixes some "bugs":
- show ephemeral icon in profile for groups (before, it was shown there only for contacts)
- show subtitles for saved-messages, device-chat (i think it was hidden as just most subtitles were hidden at some point in profile)

all in all, the code is a _little_ more straight forward now.