### PR TITLE
add dclogin scheme to qr code scan

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -197,7 +197,22 @@
     <activity android:name=".WelcomeActivity"
               android:launchMode="singleTask"
               android:theme="@style/TextSecure.LightNoActionBar"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW"/>
+            <category android:name="android.intent.category.DEFAULT"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+            <!-- Android's scheme matcher is case-sensitive, so include most likely variations -->
+            <data android:scheme="DCACCOUNT"
+                tools:ignore="AppLinkUrlError" />
+            <data android:scheme="dcaccount"
+                tools:ignore="AppLinkUrlError" />
+            <data android:scheme="DCLOGIN"
+                tools:ignore="AppLinkUrlError" />
+            <data android:scheme="dclogin"
+                tools:ignore="AppLinkUrlError" />
+        </intent-filter>
+    </activity>
 
     <activity android:name=".RegistrationActivity"
               android:launchMode="singleTask"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -879,6 +879,8 @@
     <string name="qraccount_success_enter_name">Login successful—your e-mail address is %1$s\n\nIf you like, you can now enter a name and an profile image that will be displayed to people you write to.</string>
     <string name="qraccount_qr_code_cannot_be_used">The scanned QR code cannot be used to set up a new account.</string>
     <string name="qraccount_use_on_new_install">The scanned QR code is for setting up a new account. You can scan the QR code when setting up a new Delta Chat installation.</string>
+    <string name="qrlogin_ask_login">Login to \"%1$s\"?</string>
+    <string name="qrlogin_ask_login_another">Login to \"%1$s\"?\n\nYour existing account will not be deleted. Use the \"Switch Account\" item to switch between your accounts.</string>
     <!-- first placeholder will be replaced by name and address of the inviter, second placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_started">%1$s invited you to join this group.\n\nWaiting for the device of %2$s to reply…</string>
     <!-- placeholder will be replaced by the name of the inviter. -->

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -58,6 +58,7 @@ public class DcContext {
     public final static int DC_QR_WITHDRAW_VERIFYGROUP   = 502;
     public final static int DC_QR_REVIVE_VERIFYCONTACT   = 510;
     public final static int DC_QR_REVIVE_VERIFYGROUP     = 512;
+    public final static int DC_QR_LOGIN             = 520;
 
     public final static int DC_LP_AUTH_OAUTH2          =     0x2;
     public final static int DC_LP_AUTH_NORMAL          =     0x4;

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -126,7 +126,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         String qrAccount = getIntent().getStringExtra(QR_ACCOUNT_EXTRA);
         if (qrAccount!=null) {
             manualConfigure = false;
-            startQrAccountOrQrLoginCreation(qrAccount);
+            startQrAccountCreation(qrAccount);
         }
     }
 
@@ -280,7 +280,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         }
     }
 
-    private void startQrAccountOrQrLoginCreation(String qrCode)
+    private void startQrAccountCreation(String qrCode)
     {
         if (progressDialog!=null) {
             progressDialog.dismiss();
@@ -410,7 +410,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                     String address = qrParsed.getText1();
                     new AlertDialog.Builder(this)
                             .setMessage(getString(R.string.qrlogin_ask_login, address))
-                            .setPositiveButton(R.string.ok, (dialog, which) -> startQrAccountOrQrLoginCreation(qrRaw))
+                            .setPositiveButton(R.string.ok, (dialog, which) -> startQrAccountCreation(qrRaw))
                             .setNegativeButton(R.string.cancel, null)
                             .setCancelable(false)
                             .show();
@@ -420,7 +420,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                     String domain = qrParsed.getText1();
                     new AlertDialog.Builder(this)
                             .setMessage(getString(R.string.qraccount_ask_create_and_login, domain))
-                            .setPositiveButton(R.string.ok, (dialog, which) -> startQrAccountOrQrLoginCreation(qrRaw))
+                            .setPositiveButton(R.string.ok, (dialog, which) -> startQrAccountCreation(qrRaw))
                             .setNegativeButton(R.string.cancel, null)
                             .setCancelable(false)
                             .show();

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -32,6 +32,7 @@ import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.AttachmentManager;
 import org.thoughtcrime.securesms.permissions.Permissions;
+import org.thoughtcrime.securesms.qr.QrCodeHandler;
 import org.thoughtcrime.securesms.qr.RegistrationQrActivity;
 import org.thoughtcrime.securesms.service.GenericForegroundService;
 import org.thoughtcrime.securesms.service.NotificationController;
@@ -50,6 +51,8 @@ import java.io.OutputStream;
 
 public class WelcomeActivity extends BaseActionBarActivity implements DcEventCenter.DcEventDelegate {
     public static final String QR_ACCOUNT_EXTRA = "qr_account_extra";
+    private static final String DCACCOUNT = "dcaccount";
+    private static final String DCLOGIN = "dclogin";
     public static final int PICK_BACKUP = 20574;
     private final static String TAG = WelcomeActivity.class.getSimpleName();
     public static final String TMP_BACKUP_FILE = "tmp-backup-file";
@@ -87,6 +90,8 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
           intent.setAction(DC_REQUEST_ACCOUNT_DATA);
           sendBroadcast(intent);
         }
+
+        handleIntent();
     }
 
     private void registerForEvents() {
@@ -94,6 +99,25 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         DcEventCenter eventCenter = DcHelper.getEventCenter(this);
         eventCenter.addObserver(DcContext.DC_EVENT_CONFIGURE_PROGRESS, this);
         eventCenter.addObserver(DcContext.DC_EVENT_IMEX_PROGRESS, this);
+    }
+
+    private void handleIntent() {
+        if (getIntent() != null && Intent.ACTION_VIEW.equals(getIntent().getAction())) {
+            Uri uri = getIntent().getData();
+            if (uri == null) return;
+
+            if (uri.getScheme().equalsIgnoreCase(DCACCOUNT) || uri.getScheme().equalsIgnoreCase(DCLOGIN)) {
+                QrCodeHandler qrCodeHandler = new QrCodeHandler(this);
+                qrCodeHandler.handleQrData(uri.toString());
+            }
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleIntent();
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -102,7 +102,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         String qrAccount = getIntent().getStringExtra(QR_ACCOUNT_EXTRA);
         if (qrAccount!=null) {
             manualConfigure = false;
-            startQrAccountCreation(qrAccount);
+            startQrAccountOrQrLoginCreation(qrAccount);
         }
     }
 
@@ -256,7 +256,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         }
     }
 
-    private void startQrAccountCreation(String qrCode)
+    private void startQrAccountOrQrLoginCreation(String qrCode)
     {
         if (progressDialog!=null) {
             progressDialog.dismiss();
@@ -382,11 +382,21 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
             String qrRaw = scanResult.getContents();
             DcLot qrParsed = dcContext.checkQr(qrRaw);
             switch (qrParsed.getState()) {
+                case DcContext.DC_QR_LOGIN:
+                    String address = qrParsed.getText1();
+                    new AlertDialog.Builder(this)
+                            .setMessage(getString(R.string.qrlogin_ask_login, address))
+                            .setPositiveButton(R.string.ok, (dialog, which) -> startQrAccountOrQrLoginCreation(qrRaw))
+                            .setNegativeButton(R.string.cancel, null)
+                            .setCancelable(false)
+                            .show();
+                    break;
+
                 case DcContext.DC_QR_ACCOUNT:
                     String domain = qrParsed.getText1();
                     new AlertDialog.Builder(this)
                             .setMessage(getString(R.string.qraccount_ask_create_and_login, domain))
-                            .setPositiveButton(R.string.ok, (dialog, which) -> startQrAccountCreation(qrRaw))
+                            .setPositiveButton(R.string.ok, (dialog, which) -> startQrAccountOrQrLoginCreation(qrRaw))
                             .setNegativeButton(R.string.cancel, null)
                             .setCancelable(false)
                             .show();

--- a/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -75,6 +75,7 @@ public class QrCodeHandler {
                 builder.setNegativeButton(R.string.cancel, null);
                 builder.setCancelable(false);
                 break;
+
             case DcContext.DC_QR_LOGIN:
                 String email = qrParsed.getText1();
                 builder.setMessage(activity.getString(R.string.qrlogin_ask_login_another, email));

--- a/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -75,6 +75,16 @@ public class QrCodeHandler {
                 builder.setNegativeButton(R.string.cancel, null);
                 builder.setCancelable(false);
                 break;
+            
+            case DcContext.DC_QR_LOGIN:
+                String email = qrParsed.getText1();
+                builder.setMessage(activity.getString(R.string.qrlogin_ask_login_another, email));
+                builder.setPositiveButton(R.string.ok, (dialog, which) -> {
+                    AccountManager.getInstance().addAccountFromQr(activity, rawString);
+                });
+                builder.setNegativeButton(R.string.cancel, null);
+                builder.setCancelable(false);
+                break;
 
             case DcContext.DC_QR_WEBRTC:
                 builder.setMessage(activity.getString(R.string.videochat_instance_from_qr, qrParsed.getText1()));

--- a/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -75,7 +75,6 @@ public class QrCodeHandler {
                 builder.setNegativeButton(R.string.cancel, null);
                 builder.setCancelable(false);
                 break;
-            
             case DcContext.DC_QR_LOGIN:
                 String email = qrParsed.getText1();
                 builder.setMessage(activity.getString(R.string.qrlogin_ask_login_another, email));


### PR DESCRIPTION
see https://github.com/deltachat/interface/pull/48 for spec.

needs a core with https://github.com/deltachat/deltachat-core-rust/pull/3541 merged.

I started with android implementation mainly to add the strings that they are swiftly discussed and then translated.

### Tasks
- [X] scan as first account
- [X] scan as second account
- [X] strings
- [x]  register DC as `dclogin:` scheme handler systemwide


those intents are beyond me, I can't figure out how to register DC as `dclogin:` scheme handler systemwide. sure it needs to go into `AndroidManifest.xml` but then the java code besides that is to hard for me. (I strongly dislike coding java) so it's better done by someone with real android experience, maybe together with #2365, as those two tasks are very similar.

so feel free to just push java stuff to this branch, I'm tired and annoyed of writing java.