### PR TITLE
reword "Webxdc content"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -155,7 +155,9 @@
     <string name="images_and_videos">Images and Videos</string>
     <string name="file">File</string>
     <string name="files">Files</string>
+    <!-- "Private App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Private App</string>
+    <!-- plural of "Private App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">Private Apps</string>
     <string name="files_and_webxdx_apps">Files and Private Apps</string>
     <string name="unknown">Unknown</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -155,10 +155,9 @@
     <string name="images_and_videos">Images and Videos</string>
     <string name="file">File</string>
     <string name="files">Files</string>
-    <string name="webxdc_app">Webxdc App</string>
-    <!-- Plural of "Webxdc App", used eg. as menu entry or title for an app selector. -->
-    <string name="webxdc_apps">Webxdc Apps</string>
-    <string name="files_and_webxdx_apps">Files and Webxdc Apps</string>
+    <string name="webxdc_app">Private App</string>
+    <string name="webxdc_apps">Private Apps</string>
+    <string name="files_and_webxdx_apps">Files and Private Apps</string>
     <string name="unknown">Unknown</string>
 
     <string name="green">Green</string>
@@ -449,7 +448,7 @@
     <string name="tab_image_empty_hint">Images shared in this chat will appear here.</string>
     <string name="tab_video_empty_hint">Videos shared in this chat will appear here.</string>
     <string name="tab_audio_empty_hint">Audio files and voice messages shared in this chat will appear here.</string>
-    <string name="tab_webxdc_empty_hint">Webxdc apps shared in this chat will appear here.</string>
+    <string name="tab_webxdc_empty_hint">Private apps shared in this chat will appear here.</string>
     <string name="media_preview">Media Preview</string>
     <string name="send_message">Send Message</string>
     <!-- Placeholder %1$s will be replaced by the name of the contact changing their address. Placeholders %2$s and %3$s will be replaced by old/new email addresses. -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -155,6 +155,10 @@
     <string name="images_and_videos">Images and Videos</string>
     <string name="file">File</string>
     <string name="files">Files</string>
+    <string name="webxdc_app">Webxdc App</string>
+    <!-- Plural of "Webxdc App", used eg. as menu entry or title for an app selector. -->
+    <string name="webxdc_apps">Webxdc Apps</string>
+    <string name="files_and_webxdx_apps">Files and Webxdc Apps</string>
     <string name="unknown">Unknown</string>
 
     <string name="green">Green</string>
@@ -445,7 +449,7 @@
     <string name="tab_image_empty_hint">Images shared in this chat will appear here.</string>
     <string name="tab_video_empty_hint">Videos shared in this chat will appear here.</string>
     <string name="tab_audio_empty_hint">Audio files and voice messages shared in this chat will appear here.</string>
-    <string name="tab_webxdc_empty_hint">Webxdc content shared in this chat will appear here.</string>
+    <string name="tab_webxdc_empty_hint">Webxdc apps shared in this chat will appear here.</string>
     <string name="media_preview">Media Preview</string>
     <string name="send_message">Send Message</string>
     <!-- Placeholder %1$s will be replaced by the name of the contact changing their address. Placeholders %2$s and %3$s will be replaced by old/new email addresses. -->

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -469,7 +469,7 @@ public class ConversationItem extends BaseConversationItem
       if (documentViewStub.resolved())   documentViewStub.get().setVisibility(View.GONE);
       if (stickerStub.resolved())        stickerStub.get().setVisibility(View.GONE);
 
-      webxdcViewStub.get().setWebxdc(messageRecord, "Webxdc");
+      webxdcViewStub.get().setWebxdc(messageRecord, context.getString(R.string.webxdc_app));
       webxdcViewStub.get().setWebxdcClickListener(new ThumbnailClickListener());
       webxdcViewStub.get().setOnLongClickListener(passthroughClickListener);
 

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsAdapter.java
@@ -116,7 +116,7 @@ class ProfileDocumentsAdapter extends StickyHeaderGridAdapter {
       viewHolder.documentView.setVisibility(View.GONE);
 
       viewHolder.webxdcView.setVisibility(View.VISIBLE);
-      viewHolder.webxdcView.setWebxdc(dcMsg, "Webxdc");
+      viewHolder.webxdcView.setWebxdc(dcMsg, context.getString(R.string.webxdc_app));
       viewHolder.webxdcView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));
       viewHolder.webxdcView.setOnLongClickListener(view -> { itemClickListener.onMediaLongClicked(dcMsg); return true; });
       viewHolder.itemView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));


### PR DESCRIPTION
adding "App" to the term makes things much clearer to the user,
was "Webxdc" is about [^1]

eg. on iOS, we have an app selector meanwhile,
calling that _just_ "Webxdc" in the menu or in the title makes it pretty
unclear to the user what this is about.
same for the tab "Webxdc" on desktop or the default description in the summary.
otoh, calling it _only_ "Apps" (as now), may also raise false expectations
and may be mixed with "normal" apps.

so, "Webxdc App" seems to be a good approach.

there is also the term "Mini App" [^2], we could also go for that,
but this is a broader discussion as this would give up the term "Webxdc" partly.
but i would not be against "Mini App" :)

in any case, if there is few space in the UI,
it seems to be okay to abbreviate with just "App" or "Apps" as needed,
if it is otherwise clear that the thing is a "Webxdc App" or "Mini App".

[^1]: we decided meanwhile that using the term "App" should not be a no-go :)
[^2]: the term "Mini App" is aleady known for similar types of apps
(some "small app" running in a "super app")
cmp. https://www.w3.org/TR/mini-app-white-paper/#what-is-miniapp .  
of course, our "Webxdc Apps" are not compatible with other "Mini Apps"
however, this is also not the case between "Mini Apps" of other vendors
which also have different focuses.  
so "Mini App" seems to be a broader term and does not imply compatibiliy.