### PR TITLE
restricted webxdc internet access

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -48,6 +48,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   private DcMsg dcAppMsg;
   private String baseURL;
   private String sourceCodeUrl = "";
+  private boolean internetAccess = false;
 
   public static void openWebxdcActivity(Context context, DcMsg instance) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -114,11 +115,12 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     this.baseURL = "https://acc" + dcContext.getAccountId() + "-msg" + appMessageId + ".localhost";
 
     final JSONObject info = this.dcAppMsg.getWebxdcInfo();
+    internetAccess = JsonUtils.optBoolean(info, "internet_access");
 
     WebSettings webSettings = webView.getSettings();
     webSettings.setJavaScriptEnabled(true);
     webSettings.setAllowFileAccess(false);
-    webSettings.setBlockNetworkLoads(!JsonUtils.optBoolean(info, "internet_access"));
+    webSettings.setBlockNetworkLoads(!internetAccess);
     webSettings.setAllowContentAccess(false);
     webSettings.setGeolocationEnabled(false);
     webSettings.setAllowFileAccessFromFileURLs(false);
@@ -194,6 +196,9 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       } else {
         byte[] blob = this.dcAppMsg.getWebxdcBlob(path);
         if (blob == null) {
+          if (internetAccess) {
+            return null; // do not intercept request
+          }
           throw new Exception("\"" + path + "\" not found");
         }
         String ext = MediaUtil.getFileExtensionFromUrl(path);

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -49,8 +49,6 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   private String baseURL;
   private String sourceCodeUrl = "";
 
-
-
   public static void openWebxdcActivity(Context context, DcMsg instance) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       if (Prefs.isDeveloperModeEnabled(context)) {
@@ -115,10 +113,12 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     // also a random-id is not that useful for debugging)
     this.baseURL = "https://acc" + dcContext.getAccountId() + "-msg" + appMessageId + ".localhost";
 
+    final JSONObject info = this.dcAppMsg.getWebxdcInfo();
+
     WebSettings webSettings = webView.getSettings();
     webSettings.setJavaScriptEnabled(true);
     webSettings.setAllowFileAccess(false);
-    webSettings.setBlockNetworkLoads(true);
+    webSettings.setBlockNetworkLoads(!JsonUtils.optBoolean(info, "internet_access"));
     webSettings.setAllowContentAccess(false);
     webSettings.setGeolocationEnabled(false);
     webSettings.setAllowFileAccessFromFileURLs(false);
@@ -128,7 +128,13 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     webView.addJavascriptInterface(new InternalJSApi(), "InternalJSApi");
 
     webView.loadUrl(this.baseURL + "/index.html");
-    updateTitleAndMenu();
+
+    Util.runOnAnyBackgroundThread(() -> {
+      final DcChat chat = dcContext.getChat(dcAppMsg.getChatId());
+      Util.runOnMain(() -> {
+        updateTitleAndMenu(info, chat);
+      });
+    });
   }
 
   @Override
@@ -216,26 +222,25 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       Log.i(TAG, "handleEvent");
       webView.loadUrl("javascript:window.__webxdcUpdate();");
     } else if ((eventId == DcContext.DC_EVENT_MSGS_CHANGED && event.getData2Int() == dcAppMsg.getId())) {
-      updateTitleAndMenu();
+      Util.runOnAnyBackgroundThread(() -> {
+        final JSONObject info = dcAppMsg.getWebxdcInfo();
+        final DcChat chat = dcContext.getChat(dcAppMsg.getChatId());
+        Util.runOnMain(() -> {
+          updateTitleAndMenu(info, chat);
+        });
+      });
     }
   }
 
-  private void updateTitleAndMenu() {
-    Util.runOnAnyBackgroundThread(() -> {
-      final JSONObject info = this.dcAppMsg.getWebxdcInfo();
+  private void updateTitleAndMenu(JSONObject info, DcChat chat) {
       final String docName = JsonUtils.optString(info, "document");
       final String xdcName = JsonUtils.optString(info, "name");
-      final String chatName =  WebxdcActivity.this.dcContext.getChat(WebxdcActivity.this.dcAppMsg.getChatId()).getName();
       final String currSourceCodeUrl = JsonUtils.optString(info, "source_code_url");
-
-      Util.runOnMain(() -> {
-        getSupportActionBar().setTitle((docName.isEmpty() ? xdcName : docName) + " – " + chatName);
-        if (!sourceCodeUrl.equals(currSourceCodeUrl)) {
-          sourceCodeUrl = currSourceCodeUrl;
-          invalidateOptionsMenu();
-        }
-      });
-    });
+      getSupportActionBar().setTitle((docName.isEmpty() ? xdcName : docName) + " – " + chat.getName());
+      if (!sourceCodeUrl.equals(currSourceCodeUrl)) {
+        sourceCodeUrl = currSourceCodeUrl;
+        invalidateOptionsMenu();
+      }
   }
 
   public static void addToHomeScreen(Activity activity, int msgId) {

--- a/src/org/thoughtcrime/securesms/util/JsonUtils.java
+++ b/src/org/thoughtcrime/securesms/util/JsonUtils.java
@@ -54,6 +54,14 @@ public class JsonUtils {
     }
   }
 
+  public static boolean optBoolean(JSONObject obj, String name) {
+    try {
+      return obj.optBoolean(name);
+    } catch(Exception e) {
+      return false;
+    }
+  }
+
   public static class SaneJSONObject {
 
     private final JSONObject delegate;


### PR DESCRIPTION
~~this requires https://github.com/deltachat/deltachat-core-rust/pull/3516 to be on master first.~~ EDIT: done

we we need to know the `internet_access` flag before creation of the html view, this pr moves `getWebxdcInfo()` to the main thread on webxdc creation. doing things in background would be more complicated and error prone (i can easily imagine races if we move html-view-creation to a background thread or change the flag after creation, that would need additional code to be targeted etc.). however, `getWebxdcInfo()` is also called at other places (message list!) from the main thread, so that is probably good enough.

all other things are left in background threads as before.

see https://github.com/deltachat/deltachat-core-rust/pull/3516 for further information.

here is a little demo:

<img width=240 src=https://user-images.githubusercontent.com/9800740/188471433-ec8923b5-8f33-4286-9bea-a36611728488.png>

**Download .xdc:** https://github.com/r10s/maps/releases/download/0.0.1/maps.xdc ([source](https://github.com/r10s/maps)) - you need to copy this to the "Saved Messages" chat of a build using this pr - otherwise, you will not see the map.