### PR TITLE
Revert "create adaptive shortcuts"

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -264,7 +264,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
 
       ShortcutInfoCompat shortcutInfoCompat = new ShortcutInfoCompat.Builder(context, "xdc-" + dcContext.getAccountId() + "-" + msgId)
         .setShortLabel(docName.isEmpty() ? xdcName : docName)
-        .setIcon(IconCompat.createWithAdaptiveBitmap(bitmap))
+        .setIcon(IconCompat.createWithBitmap(bitmap))
         .setIntents(getWebxdcIntentWithParentStack(context, msgId))
         .build();
 


### PR DESCRIPTION
This reverts commit 35dd8c905b7ff182c92a1bcfcfe03a97edecbb00.

The cut out is not the largets possible circle inside the square icon (as for group images or avatars, diameter==height) but a much smaller circle (diameter==~0.6*height), resulting in too many information being left out.

Therefore, it is better to leave icon layout to the OS.

to get an idea about the amount of cut out, see a circular logo, eg. the hextris one:

