### PR TITLE
add missing strings for webxdc selector and webxdc shortcuts on iOS

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1022,6 +1022,12 @@
     <string name="notifications_avg_minutes">On average every %1$d minutes</string>
     <string name="notifications_avg_hours">On average every %1$d hours</string>
     <string name="last_check_at">Checked at %1$s</string>
+    <!-- iOS webxdc selector -->
+    <string name ="webxdcs">Apps</string>
+    <string name ="webxdc_empty_hint">Received or sent apps will appear here. Tap \"Files\" to select downloaded apps.</string>
+    <!-- iOS webxdc shortcut page -->
+    <string name ="shortcut_share_btn">Click the share button</string>
+    <string name ="shortcut_add_to_home_description">Select - Add to Home Screen - to add the app to your home screen.</string>
     <!-- iOS permissions, copy from "deltachat-ios/Info.plist", which is used on missing translations in "deltachat-ios/LANG.lproj/InfoPlist.strings" -->
     <string name="InfoPlist_NSCameraUsageDescription">Delta Chat uses your camera to take and send photos and videos and to scan QR codes.</string>
     <string name="InfoPlist_NSContactsUsageDescription">Delta Chat uses your contacts to show a list of e-mail addresses you can write to. Delta Chat has no server, your contacts are not sent anywhere.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1025,8 +1025,8 @@
     <!-- iOS webxdc selector -->
     <string name ="webxdc_selector_empty_hint">Private apps received or sent in any chat will appear here. \"Files\" shows private apps just downloaded.</string>
     <!-- iOS webxdc shortcut page -->
-    <string name ="shortcut_share_btn">Click the share button</string>
-    <string name ="shortcut_add_to_home_description">Select - Add to Home Screen - to add the app to your home screen.</string>
+    <string name ="shortcut_step1_tap_share_btn">Click the share button</string>
+    <string name ="shortcut_step2_tap_add_to_home_screen">Select \"Add to Home Screen\" to add the app to your home screen.</string>
     <!-- iOS permissions, copy from "deltachat-ios/Info.plist", which is used on missing translations in "deltachat-ios/LANG.lproj/InfoPlist.strings" -->
     <string name="InfoPlist_NSCameraUsageDescription">Delta Chat uses your camera to take and send photos and videos and to scan QR codes.</string>
     <string name="InfoPlist_NSContactsUsageDescription">Delta Chat uses your contacts to show a list of e-mail addresses you can write to. Delta Chat has no server, your contacts are not sent anywhere.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1023,8 +1023,7 @@
     <string name="notifications_avg_hours">On average every %1$d hours</string>
     <string name="last_check_at">Checked at %1$s</string>
     <!-- iOS webxdc selector -->
-    <string name ="webxdcs">Apps</string>
-    <string name ="webxdc_empty_hint">Received or sent apps will appear here. Tap \"Files\" to select downloaded apps.</string>
+    <string name ="webxdc_selector_empty_hint">Private apps received or sent in any chat will appear here. \"Files\" shows private apps just downloaded.</string>
     <!-- iOS webxdc shortcut page -->
     <string name ="shortcut_share_btn">Click the share button</string>
     <string name ="shortcut_add_to_home_description">Select - Add to Home Screen - to add the app to your home screen.</string>


### PR DESCRIPTION
Depends partly on #2377 being settled. The webxdc selector strings will probably change after the merge of #2377. 
This PR is mainly to not forget about these untranslated strings currently used on iOS. 