### PR TITLE
hide "leave group" option from menu for mailing list chats

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -482,7 +482,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
 
     if (isMultiUser()) {
-      if (dcChat.canSend() && !dcChat.isBroadcast()) {
+      if (dcChat.canSend() && !dcChat.isBroadcast() && !dcChat.isMailingList()) {
         inflater.inflate(R.menu.conversation_push_group_options, menu);
       }
     }


### PR DESCRIPTION
that option did nothing since you can't leave a mailing list in Delta Chat, at least not yet ;)