### PR TITLE
check translation for bad lineends

### DIFF
--- a/scripts/check-translations.sh
+++ b/scripts/check-translations.sh
@@ -15,3 +15,6 @@ grep --include='strings.xml' -r "\\\\[^n\"'’]" .
 
 # check for usage of a single `&` - this has to be an `&amp;`
 grep --include='strings.xml' -r "&[^a]" .
+
+# single <br> is not needed - and not allowed in xml, leading to error "matching end tag missing"
+grep --include='strings.xml' -r "<br" .


### PR DESCRIPTION
`<br>` lineends are not allowed in strings.xml
and lead to compile errors as "terminating tag missing".

(adding these checks as this pop up from time to time and is easily overseen)