### PR TITLE
preserve system message translations

### DIFF
--- a/res/values-az/strings.xml
+++ b/res/values-az/strings.xml
@@ -409,6 +409,21 @@
     <string name="systemmsg_action_by_me">%1$s məndən. </string>
     <!-- deprecated -->
     <string name="systemmsg_action_by_user">%1$s ilə %2$s.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Qrupun adı \"%1$s\" - dən \"%2$s\" - yə deyişildi məndən. </string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Qrupun adı \"%1$s\" - dən \"%2$s\" - yə deyişildi ilə %3$s.</string>
+    <string name="group_image_changed_by_you">Qrup şəkili dəyişildi məndən. </string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Qrup şəkili dəyişildi ilə %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Üzv %1$s əlavə olundu məndən. </string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Üzv %1$s əlavə olundu ilə %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">%1$s üzv silindi məndən. </string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">%1$s üzv silindi ilə %2$s.</string>
     <string name="qrscan_title">Qr kodu skan edin</string>
     <string name="qrscan_hint">QR kodu kamera ilə izləyin</string>
     <string name="qrscan_ask_join_group">\"%1$s\" qrupa qoşulmaq istəyirsinizmi?</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -719,6 +719,63 @@
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">Защитата на чата е включена.</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Името на групата е променено от \"%1$s\" на \"%2$s\" от мен</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Името на групата е променено от \"%1$s\" на \"%2$s\" от %3$s</string>
+    <string name="group_image_changed_by_you">Изображението на групата е променено от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Изображението на групата е променено от %1$s</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Добавен е членът %1$s от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Добавен е членът %1$s от %2$s</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Членът %1$s е премахнат от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Членът %1$s е премахнат от %2$s</string>
+    <string name="ephemeral_timer_disabled_by_you">Таймерът на изчезващите съобщения е деактивиран от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Таймерът на изчезващите съобщения е деактивиран от %1$s</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Таймерът на изчезващите съобщение е установен на %1$sсек от мен</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Таймерът на изчезващите съобщение е установен на %1$sсек от %2$s</string>
+    <string name="ephemeral_timer_1_minute_by_you">Таймерът на изчезващите съобщения е установен на 1 минута от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Таймерът на изчезващите съобщения е установен на 1 минута от %1$s</string>
+    <string name="ephemeral_timer_1_hour_by_you">Таймерът на изчезващите съобщения е установен на 1 час от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Таймерът на изчезващите съобщения е установен на 1 час от %1$s</string>
+    <string name="ephemeral_timer_1_day_by_you">Таймерът на изчезващите съобщения е установен на 1 ден от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Таймерът на изчезващите съобщения е установен на 1 ден от %1$s</string>
+    <string name="ephemeral_timer_1_week_by_you">Таймерът на изчезващите съобщения е установен на 1 седмица от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Таймерът на изчезващите съобщения е установен на 1 седмица от %1$s</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">Таймерът на изчезващите съобщения е установен на %1$s минути от мен</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">Таймерът на изчезващите съобщения е установен на %1$s минути от %2$s</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">Таймерът на изчезващите съобщения е установен на %1$s часа от мен</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">Таймерът на изчезващите съобщения е установен на %1$s часа от %2$s</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">Таймерът на изчезващите съобщения е установен на %1$s дни от мен</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">Таймерът на изчезващите съобщения е установен на %1$s дни от %2$s</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">Таймерът на изчезващите съобщения е установен на %1$s седмици от мен</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">Таймерът на изчезващите съобщения е установен на %1$s седмици от %2$s</string>
+    <string name="protection_enabled_by_you">Защитата на чата е включена от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">Защитата на чата е включена от %1$s</string>
+    <string name="protection_disabled_by_you">Защитата на чата е изключена от мен</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">Защитата на чата е изключена от %1$s</string>
+
     <string name="devicemsg_self_deleted">Изтрихте чата \"Записани съобщения\".\n\nℹ️ За да използвате възможността \"Записани съобщения\" отново, създайте нов чат със себе си.</string>
     <!-- %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %% -->
     <string name="devicemsg_storage_exceeding">⚠️ Мястото за съхранение, предоставено от Вашия доставчик, скоро ще бъде изчерпано, %1$s%% вече са използвани.\n\nВероятно няма да можете да получавате съобщения, когато 100%% от мястото за съхранение са заети.\n\n👉 Моля, проверете дали не бихте могли да изтриете стари данни през уеб интерфейса на доставчика и обмислете дали да не включите \"Настройки / Изтриване на старите съобщения\". Можете по всяко време да проверите текущо наличното място за съхранение в \"Настройки / Свързаност\".</string>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -602,6 +602,21 @@
     <string name="systemmsg_action_by_me">%1$s per mi.</string>
     <!-- deprecated -->
     <string name="systemmsg_action_by_user">%1$s per %2$s.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Nom del grup \"%1$s\" canviat a \"%2$s\" per mi.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Nom del grup \"%1$s\" canviat a \"%2$s\" per %3$s.</string>
+    <string name="group_image_changed_by_you">Imatge de grup canviada per mi.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Imatge de grup canviada per %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Membre %1$s afegit per mi.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Membre %1$s afegit per %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Membre %1$s eliminat per mi.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Membre %1$s eliminat per %2$s.</string>
     <string name="qrscan_title">Escaneja codi QR</string>
     <string name="qrscan_hint">Poseu la càmera davant del codi QR</string>
     <string name="qrscan_ask_join_group">Voleu unir-vos al grup \"%1$s\"?</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -627,6 +627,63 @@
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">Ochrana rozhovoru zapnuta.</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Názen skupiny změněn z \"%1$s\" na \"%2$s\" ode mě.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Názen skupiny změněn z \"%1$s\" na \"%2$s\" od %3$s.</string>
+    <string name="group_image_changed_by_you">Obrázek skupiny změněn ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Obrázek skupiny změněn od %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Člen %1$s byl přidán ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Člen %1$s byl přidán od %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Člen %1$s byl odebrán ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Člen %1$s byl odebrán od %2$s.</string>
+    <string name="ephemeral_timer_disabled_by_you">Časovač samomazacích zpráv je vypnut ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Časovač samomazacích zpráv je vypnut od %1$s.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Časovač samomazacích zpráv je na %1$s s ode mě.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Časovač samomazacích zpráv je na %1$s s od %2$s.</string>
+    <string name="ephemeral_timer_1_minute_by_you">Časovač samomazacích zpráv na 1 minutu ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Časovač samomazacích zpráv na 1 minutu od %1$s.</string>
+    <string name="ephemeral_timer_1_hour_by_you">Časovač samomazacích zpráv na 1 hodinu ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Časovač samomazacích zpráv na 1 hodinu od %1$s.</string>
+    <string name="ephemeral_timer_1_day_by_you">Časovač samomazacích zpráv na 1 den ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Časovač samomazacích zpráv na 1 den od %1$s.</string>
+    <string name="ephemeral_timer_1_week_by_you">Časovač samomazacích zpráv na 1 týden ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Časovač samomazacích zpráv na 1 týden od %1$s.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">Samomazací zprávy vyprší po %1$s minutách ode mě.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">Samomazací zprávy vyprší po %1$s minutách od %2$s.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">Samomazací zprávy vyprší po %1$s hodinách ode mě.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">Samomazací zprávy vyprší po %1$s hodinách od %2$s.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">Samomazací zprávy vyprší po %1$s dnech ode mě.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">Samomazací zprávy vyprší po %1$s dnech od %2$s.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">Samomazací zprávy vyprší po %1$s týdnech ode mě.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">Samomazací zprávy vyprší po %1$s týdnech od %2$s.</string>
+    <string name="protection_enabled_by_you">Ochrana rozhovoru zapnuta ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">Ochrana rozhovoru zapnuta od %1$s.</string>
+    <string name="protection_disabled_by_you">Ochrana rozhovoru vypnuta ode mě.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">Ochrana rozhovoru vypnuta od %1$s.</string>
+
     <!-- qr code stuff -->
     <string name="qr_code">QR kód</string>
     <string name="load_qr_code_as_image">Nahraj QR kód z obrázku</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -646,6 +646,63 @@
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">Chat-beskyttelse sluttet til.</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Gruppenavn ændret fra \"%1$s\" til \"%2$s\" af mig.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Gruppenavn ændret fra \"%1$s\" til \"%2$s\" af %3$s.</string>
+    <string name="group_image_changed_by_you">Gruppebillede ændret af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Gruppebillede ændret af %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Medlem %1$s tilføjet af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Medlem %1$s tilføjet af %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Medlem %1$s fjernet af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Medlem %1$s fjernet af %2$s.</string>
+    <string name="ephemeral_timer_disabled_by_you">Tidsudløb for beskeder er deaktiveret af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Tidsudløb for beskeder er deaktiveret af %1$s.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Tidsudløb for beskeder sat til %1$s s af mig.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Tidsudløb for beskeder sat til %1$s s af %2$s.</string>
+    <string name="ephemeral_timer_1_minute_by_you">Tidsudløb for beskeder sat til 1 minut af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Tidsudløb for beskeder sat til 1 minut af %1$s.</string>
+    <string name="ephemeral_timer_1_hour_by_you">Tidsudløb for beskeder sat til 1 time af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Tidsudløb for beskeder sat til 1 time af %1$s.</string>
+    <string name="ephemeral_timer_1_day_by_you">Tidsudløb for beskeder sat til 1 dag af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Tidsudløb for beskeder sat til 1 dag af %1$s.</string>
+    <string name="ephemeral_timer_1_week_by_you">Tidsudløb for beskeder sat til 1 uge af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Tidsudløb for beskeder sat til 1 uge af %1$s.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">Beskeder sat til at udløbe efter %1$s minutter af mig.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">Beskeder sat til at udløbe efter %1$s minutter af %2$s.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">Beskeder sat til at udløbe efter %1$s timer af mig.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">Beskeder sat til at udløbe efter %1$s timer af %2$s.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">Beskeder sat til at udløbe efter %1$s dage af mig.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">Beskeder sat til at udløbe efter %1$s dage af %2$s.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">Beskeder sat til at udløbe efter %1$s uger af mig.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">Beskeder sat til at udløbe efter %1$s uger af %2$s.</string>
+    <string name="protection_enabled_by_you">Chat-beskyttelse sluttet til af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">Chat-beskyttelse sluttet til af %1$s.</string>
+    <string name="protection_disabled_by_you">Chat-beskyttelse slået fra af mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">Chat-beskyttelse slået fra af %1$s.</string>
+
     <!-- qr code stuff -->
     <string name="qr_code">QR kode</string>
     <string name="load_qr_code_as_image">Indlæs QR-kode som billede</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -460,6 +460,21 @@
     <string name="systemmsg_action_by_me">Nik: %1$s</string>
     <!-- deprecated -->
     <string name="systemmsg_action_by_user">%2$s(e)k: %1$s</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Nik: Taldearen izena \"%1$s\" izatetik \"%2$s\" izatera aldatu da</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">%3$s(e)k: Taldearen izena \"%1$s\" izatetik \"%2$s\" izatera aldatu da</string>
+    <string name="group_image_changed_by_you">Nik: Taldearen irudia aldatuta</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">%1$s(e)k: Taldearen irudia aldatuta</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Nik: %1$s kidea gehituta</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">%2$s(e)k: %1$s kidea gehituta</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Nik: %1$s kidea kenduta</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">%2$s(e)k: %1$s kidea kenduta</string>
     <!-- qr code stuff -->
     <string name="qr_code">QR kodea</string>
     <string name="qrscan_title">Eskaneatu QR kodea</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -758,6 +758,63 @@
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">Keskustelusuojaus käytössä</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Ryhmän nimi vaihdettu: \"%1$s\" --> \"%2$s\" minun toimestani.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Ryhmän nimi vaihdettu: \"%1$s\" --> \"%2$s\" käyttäjän %3$s toimesta.</string>
+    <string name="group_image_changed_by_you">Ryhmän kuva vaihdettu minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Ryhmän kuva vaihdettu käyttäjän %1$s toimesta.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Jäsen %1$s lisätty minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Jäsen %1$s lisätty käyttäjän %2$s toimesta.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Jäsen %1$s poistettu minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Jäsen %1$s poistettu käyttäjän %2$s toimesta.</string>
+    <string name="ephemeral_timer_disabled_by_you">Katoavien viestien ajastin poistettiin minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Katoavien viestien ajastin poistettiin käyttäjän %1$s toimesta.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Katoavien viestien ajastin asetettu %1$s sekuntiin minun toimestani.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Katoavien viestien ajastin asetettu %1$s sekuntiin käyttäjän %2$s toimesta.</string>
+    <string name="ephemeral_timer_1_minute_by_you">Katoavien viestien ajastin asetettu 1 minuuttiin minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Katoavien viestien ajastin asetettu 1 minuuttiin käyttäjän %1$s toimesta.</string>
+    <string name="ephemeral_timer_1_hour_by_you">Katoavien viestien ajastin asetettu 1 tuntiin minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Katoavien viestien ajastin asetettu 1 tuntiin käyttäjän %1$s toimesta.</string>
+    <string name="ephemeral_timer_1_day_by_you">Katoavien viestien ajastin asetettu 1 päivään minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Katoavien viestien ajastin asetettu 1 päivään käyttäjän %1$s toimesta.</string>
+    <string name="ephemeral_timer_1_week_by_you">Katoavien viestien ajastin asetettu 1 viikkoon minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Katoavien viestien ajastin asetettu 1 viikkoon käyttäjän %1$s toimesta.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">Katoavien viestien ajastin asetettu %1$s minuuttiin minun toimestani.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">Katoavien viestien ajastin asetettu %1$s minuuttiin käyttäjän %2$s toimesta.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">Katoavien viestien ajastin asetettu %1$s tuntiin minun toimestani.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">Katoavien viestien ajastin asetettu %1$s tuntiin käyttäjän %2$s toimesta.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">Katoavien viestien ajastin asetettu %1$s päivään minun toimestani.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">Katoavien viestien ajastin asetettu %1$s päivään käyttäjän %2$s toimesta.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">Katoavien viestien ajastin asetettu %1$s viikkoon minun toimestani.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">Katoavien viestien ajastin asetettu %1$s viikkoon käyttäjän %2$s toimesta.</string>
+    <string name="protection_enabled_by_you">Keskustelusuojaus käytössä minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">Keskustelusuojaus käytössä käyttäjän %1$s toimesta.</string>
+    <string name="protection_disabled_by_you">Keskustelusuojaus poistettu minun toimestani.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">Keskustelusuojaus poistettu käyttäjän %1$s toimesta.</string>
+
     <string name="devicemsg_self_deleted">Poistit \"Tallennetut viestit\" -keskustelun.\n\nℹ️ Käyttääksesi \"Tallennetut viestit\" -ominaisuutta jälleen, aloita uusi keskustelu itsesi kanssa.</string>
     <!-- %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %% -->
     <string name="devicemsg_storage_exceeding">⚠️ Palveluntarjoajasi tallennuskiintiö ylitetään pian, käytössä on jo %1$s / %%.\n\nEt välttämättä enää voi vastaanottaa viestejäsi, kun 100 %% on käytössä.\n\n👉 Kokeile poistaa viestejä palveluntarjoajasi internetkäyttöliittymästä. Kannattaa myös ehkä kytkeä päälle \"Asetukset / Poista vanhat viestit\". Voit tarkistaa tämän hetkisen tallennustilan käytön \"Asetukset / Yhteys\".</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -773,6 +773,63 @@
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">Protection de la discussion activée.</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Nom de groupe modifié de \"%1$s\" en \"%2$s\" par moi.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Nom de groupe modifié de \"%1$s\" en \"%2$s\" sur %3$s.</string>
+    <string name="group_image_changed_by_you">Image de groupe modifiée par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Image de groupe modifiée sur %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Membre %1$s ajouté par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Membre %1$s ajouté sur %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Membre %1$s retiré par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Membre %1$s retiré sur %2$s.</string>
+    <string name="ephemeral_timer_disabled_by_you">Temporisation des messages éphémères désactivée par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Temporisation des messages éphémères désactivée sur %1$s.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Temporisation des messages éphémères réglée à %1$s s par moi.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Temporisation des messages éphémères réglée à %1$s s sur %2$s.</string>
+    <string name="ephemeral_timer_1_minute_by_you">Temporisation des messages éphémères réglée à 1 minute par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Temporisation des messages éphémères réglée à 1 minute sur %1$s.</string>
+    <string name="ephemeral_timer_1_hour_by_you">Temporisation des messages éphémères réglée à 1 heure par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Temporisation des messages éphémères réglée à 1 heure sur %1$s.</string>
+    <string name="ephemeral_timer_1_day_by_you">Temporisation des messages éphémères réglée à 1 journée par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Temporisation des messages éphémères réglée à 1 journée sur %1$s.</string>
+    <string name="ephemeral_timer_1_week_by_you">Temporisation des messages éphémères réglée à 1 semaine par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Temporisation des messages éphémères réglée à 1 semaine sur %1$s.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">Régler le temps d\'affichage des messages éphémères à %1$s minute(s) par moi.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">Régler le temps d\'affichage des messages éphémères à %1$s minute(s) sur %2$s.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">Régler le temps d\'affichage des messages éphémères à %1$s heure(s) par moi.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">Régler le temps d\'affichage des messages éphémères à %1$s heure(s) sur %2$s.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">Régler le temps d\'affichage des messages éphémères à %1$s jour(s) par moi.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">Régler le temps d\'affichage des messages éphémères à %1$s jour(s) sur %2$s.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">Régler le temps d\'affichage des messages éphémères à %1$s semaine(s) par moi.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">Régler le temps d\'affichage des messages éphémères à %1$s semaine(s) sur %2$s.</string>
+    <string name="protection_enabled_by_you">Protection de la discussion activée par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">Protection de la discussion activée sur %1$s.</string>
+    <string name="protection_disabled_by_you">Protection de la discussion désactivée par moi.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">Protection de la discussion désactivée sur %1$s.</string>
+
     <string name="devicemsg_self_deleted">Vous avez supprimé la discussion \"Message enregistrés\".\n\nℹ️ Pour de nouveau utiliser la fonctionnalité \"Message enregistrés\", commencez une nouvelle discussion avec vous-même.</string>
     <!-- %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %% -->
     <string name="devicemsg_storage_exceeding">⚠️ L\'espace de stockage de votre fournisseur va bientôt être excédé, %1$s sur %% est utilisé.\n\nous ne serez peut-être plus capable de recevoir des messages quand l\'espace de stockage est 100%% utilisé.\n\n👉 Vérifier s\'il vous plaît que vous pouvez supprimer d\'ancienne données depuis l\'interface web de votre fournisseur et considérez d\'activer \"Paramètres / Supprimer les messages anciens\". Vous pouvez jetez un coup d\'oeil à l\'utilisation courante de votre espace de stockage à tout moment depuis \"Paramètres / Connectivité\".</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -526,6 +526,21 @@
     <string name="systemmsg_subject_for_new_contact">Pesan dari %1$s</string>
     <string name="systemmsg_failed_sending_to">Gagal mengirim pesan ke %1$s.</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Nama grup diganti dari \"%1$s\" ke \"%2$s\" oleh saya.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Nama grup diganti dari \"%1$s\" ke \"%2$s\" oleh %3$s.</string>
+    <string name="group_image_changed_by_you">Gambar grup telah diubah oleh saya.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Gambar grup telah diubah oleh %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Member %1$s telah ditambahkan oleh saya.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Member %1$s telah ditambahkan oleh %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Member %1$s telah dikeluarkan oleh saya.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Member %1$s telah dikeluarkan oleh %2$s.</string>
     <!-- qr code stuff -->
     <string name="qr_code">Kode QR</string>
     <string name="load_qr_code_as_image">Muat kode QR sebagai gambar</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -604,6 +604,63 @@ https://delta.chat</string>
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">保護が有効です。</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">自分からグループ名を%1$sから%2$sに変更しました。</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">%3$sからグループ名を%1$sから%2$sに変更しました。</string>
+    <string name="group_image_changed_by_you">自分からグループ画像が変わりました。</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">%1$sからグループ画像が変わりました。</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">自分から%1$sが追加されました。</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">%2$sから%1$sが追加されました。</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">自分から%1$sが退会されました。</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">%2$sから%1$sが退会されました。</string>
+    <string name="ephemeral_timer_disabled_by_you">自分から消えるメッセージを無効にしました。</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">%1$sから消えるメッセージを無効にしました。</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">自分から消えるメッセージを%1$s秒にしました。</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">%2$sから消えるメッセージを%1$s秒にしました。</string>
+    <string name="ephemeral_timer_1_minute_by_you">自分から消えるメッセージを1分にしました。</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">%1$sから消えるメッセージを1分にしました。</string>
+    <string name="ephemeral_timer_1_hour_by_you">自分から消えるメッセージを1時間にしました。</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">%1$sから消えるメッセージを1時間にしました。</string>
+    <string name="ephemeral_timer_1_day_by_you">自分から消えるメッセージを1日にしました。</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">%1$sから消えるメッセージを1日にしました。</string>
+    <string name="ephemeral_timer_1_week_by_you">自分から消えるメッセージを1週間にしました。</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">%1$sから消えるメッセージを1週間にしました。</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">自分から消えるメッセージを%1$s分にしました。</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">%2$sから消えるメッセージを%1$s分にしました。</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">自分から消えるメッセージを%1$s時間にしました。</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">%2$sから消えるメッセージを%1$s時間にしました。</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">自分から消えるメッセージを%1$s日にしました。</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">%2$sから消えるメッセージを%1$s日にしました。</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">自分から消えるメッセージを%1$s週間にしました。</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">%2$sから消えるメッセージを%1$s週間にしました。</string>
+    <string name="protection_enabled_by_you">自分から保護が有効です。</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">%1$sから保護が有効です。</string>
+    <string name="protection_disabled_by_you">自分から保護が無効です。</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">%1$sから保護が無効です。</string>
+
     <!-- qr code stuff -->
     <string name="qr_code">QRコード</string>
     <string name="load_qr_code_as_image">QRコードを画像として読み込む</string>

--- a/res/values-km/strings.xml
+++ b/res/values-km/strings.xml
@@ -701,6 +701,63 @@
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">ការការពារសន្ទនាត្រូវបានបើក</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">ឈ្មោះក្រុមត្រូវបានប្តូរពី \"%1$s\" ទៅកាន់ \"%2$s\" ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">ឈ្មោះក្រុមត្រូវបានប្តូរពី \"%1$s\" ទៅកាន់ \"%2$s\" ដោយ %3$s</string>
+    <string name="group_image_changed_by_you">រូបភាពក្រុមត្រូវបានប្តូរ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">រូបភាពក្រុមត្រូវបានប្តូរ ដោយ %1$s</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">សមាជិក %1$s ត្រូវបានបន្ថែម ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">សមាជិក %1$s ត្រូវបានបន្ថែម ដោយ %2$s</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">សមាជិក %1$s ត្រូវបានយកចេញ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">សមាជិក %1$s ត្រូវបានយកចេញ ដោយ %2$s</string>
+    <string name="ephemeral_timer_disabled_by_you">បានបិទបាត់កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">បានបិទបាត់កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈ ដោយ %1$s</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s វិនាទី។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s វិនាទី។ ដោយ %2$s</string>
+    <string name="ephemeral_timer_1_minute_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១នាទី។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១នាទី។ ដោយ %1$s</string>
+    <string name="ephemeral_timer_1_hour_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១ម៉ោង។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១ម៉ោង។ ដោយ %1$s</string>
+    <string name="ephemeral_timer_1_day_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១ថ្ងៃ។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១ថ្ងៃ។ ដោយ %1$s</string>
+    <string name="ephemeral_timer_1_week_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១សប្តាហ៍។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១សប្តាហ៍។ ដោយ %1$s</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s នាទី។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s នាទី។ ដោយ %2$s</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ម៉ោង។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ម៉ោង។ ដោយ %2$s</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ថ្ងៃ។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ថ្ងៃ។ ដោយ %2$s</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ថ្ងៃ។ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ថ្ងៃ។ ដោយ %2$s</string>
+    <string name="protection_enabled_by_you">ការការពារសន្ទនាត្រូវបានបើក ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">ការការពារសន្ទនាត្រូវបានបើក ដោយ %1$s</string>
+    <string name="protection_disabled_by_you">ការការពារសន្ទនាត្រូវបានបិទ ដោយខ្ញុំ</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">ការការពារសន្ទនាត្រូវបានបិទ ដោយ %1$s</string>
+
     <string name="devicemsg_self_deleted">អ្នកបានលុប \"សារដែលបានរក្សាទុក\" សន្ទនា។\n\nℹ️ ដើម្បីប្រើមុខងារ \"សារដែលបានរក្សាទុក\" ជាថ្មីម្តងទៀត សូមបង្កើតសន្ទនាថ្មីជាមួយខ្លួនអ្នក។</string>
     <!-- %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %% -->
     <string name="devicemsg_storage_exceeding">⚠️️ឃ្លាំងផ្ទុករបស់កម្មវិធីផ្តល់សេវាឲ្យអ្នក ជិតអស់ហើយត្រូវបានប្រើ %1$s%% រួចហើយ។\n\n អ្នកប្រហែលជាមិនអាចទទួលបានសារទេនៅពេលប្រើទំហំផ្ទុក ១០០%% ។\n\n👉 សូមពិនិត្យមើលថាតើ អ្នកអាចលុបទិន្នន័យចាស់នៅក្នុងចំណុចប្រទាក់គេហទំព័ររបស់កម្មវិធីផ្តល់សេវាកម្មហើយពិចារណាបើក \"ការកំណត់ / លុបសារចាស់ \"។ អ្នកអាចពិនិត្យមើលការប្រើប្រាស់ទំហំផ្ទុកបច្ចុប្បន្នរបស់អ្នកបានគ្រប់ពេលនៅ \"ការកំណត់ / ការតភ្ជាប់និងសេវាកម្ម\" ។</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -389,6 +389,21 @@
     <string name="systemmsg_action_by_me">%1$s av meg.</string>
     <!-- deprecated -->
     <string name="systemmsg_action_by_user">%1$s av %2$s.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Gruppenavn endret fra \"%1$s\" til \"%2$s\" av meg.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Gruppenavn endret fra \"%1$s\" til \"%2$s\" av %3$s.</string>
+    <string name="group_image_changed_by_you">Gruppebilde endret av meg.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Gruppebilde endret av %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Medlem %1$s lagt til av meg.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Medlem %1$s lagt til av %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Medlem %1$s fjernet av meg.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Medlem %1$s fjernet av %2$s.</string>
     <!-- qr code stuff -->
     <string name="qr_code">QR-kode</string>
     <string name="qrscan_title">Skann QR-kode</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -788,6 +788,63 @@
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">Ochrona czatu włączona.</string>
 
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Zmieniono nazwę grupy z \"%1$s\" na \"%2$s\" przeze mnie.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Zmieniono nazwę grupy z \"%1$s\" na \"%2$s\" przez %3$s.</string>
+    <string name="group_image_changed_by_you">Zmieniono obraz grupy przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Zmieniono obraz grupy przez %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Dodano członka %1$s przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Dodano członka %1$s przez %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Usunięto członka %1$s przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Usunięto członka %1$s przez %2$s.</string>
+    <string name="ephemeral_timer_disabled_by_you">Wyłączono zegar znikających wiadomości przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Wyłączono zegar znikających wiadomości przez %1$s.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Ustawiono zegar znikających wiadomości na %1$s s przeze mnie.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Ustawiono zegar znikających wiadomości na %1$s s przez %2$s.</string>
+    <string name="ephemeral_timer_1_minute_by_you">Ustawiono zegar znikających wiadomości na 1 minutę przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Ustawiono zegar znikających wiadomości na 1 minutę przez %1$s.</string>
+    <string name="ephemeral_timer_1_hour_by_you">Ustawiono zegar znikających wiadomości na 1 godzinę przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Ustawiono zegar znikających wiadomości na 1 godzinę przez %1$s.</string>
+    <string name="ephemeral_timer_1_day_by_you">Ustawiono zegar znikających wiadomości na 1 dzień przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Ustawiono zegar znikających wiadomości na 1 dzień przez %1$s.</string>
+    <string name="ephemeral_timer_1_week_by_you">Ustawiono zegar znikających wiadomości na 1 tydzień przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Ustawiono zegar znikających wiadomości na 1 tydzień przez %1$s.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">Ustawiono zegar znikających wiadomości na czas %1$s minut przeze mnie.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">Ustawiono zegar znikających wiadomości na czas %1$s minut przez %2$s.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">Ustawiono zegar znikających wiadomości na czas %1$s godzin przeze mnie.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">Ustawiono zegar znikających wiadomości na czas %1$s godzin przez %2$s.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">Ustawiono zegar znikających wiadomości na czas %1$s dni przeze mnie.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">Ustawiono zegar znikających wiadomości na czas %1$s dni przez %2$s.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">Ustawiono zegar znikających wiadomości na czas %1$s tygodni przeze mnie.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">Ustawiono zegar znikających wiadomości na czas %1$s tygodni przez %2$s.</string>
+    <string name="protection_enabled_by_you">Ochrona czatu włączona przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">Ochrona czatu włączona przez %1$s.</string>
+    <string name="protection_disabled_by_you">Ochrona czatu wyłączona przeze mnie.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">Ochrona czatu wyłączona przez %1$s.</string>
+
     <string name="devicemsg_self_deleted">Usunięto czat „Zapisane wiadomości”.\n\nℹ️ Aby ponownie użyć funkcji „Zapisane wiadomości”, utwórz nowy czat ze sobą.</string>
     <!-- %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %% -->
     <string name="devicemsg_storage_exceeding">⚠️ Limit pamięci u twojego dostawcy wkrótce zostanie przekroczony, wykorzystano już %1$s%%.\n\nMożesz nie być w stanie otrzymywać wiadomości, gdy pamięć zostanie wykorzystana w 100%%.\n\n👉 Sprawdzić, czy możesz usunąć stare dane w interfejsie internetowym dostawcy i rozważyć włączenie opcji \"Ustawienia » Czaty i media » Usuń stare wiadomości\". W dowolnym momencie możesz sprawdzić swoje bieżące wykorzystanie pamięci w \"Ustawienia » Łączność\".</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -342,6 +342,21 @@
     <string name="systemmsg_action_by_me">%1$s por mim.</string>
     <!-- deprecated -->
     <string name="systemmsg_action_by_user">%1$s por %2$s.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">O nome do grupo mudou de \"%1$s\" para \"%2$s\" por mim.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">O nome do grupo mudou de \"%1$s\" para \"%2$s\" por %3$s.</string>
+    <string name="group_image_changed_by_you">Imagem do grupo modificada por mim.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Imagem do grupo modificada por %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Membro %1$s adicionado por mim.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Membro %1$s adicionado por %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Membro %1$s removido por mim.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Membro %1$s removido por %2$s.</string>
     <string name="qrscan_title">Fazer scan do código QR</string>
     <string name="qrscan_hint">Coloque sua câmera sobre o código QR</string>
     <string name="qrscan_ask_join_group">Quer se juntar-se ao grupo \"%1$s\"?</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -736,7 +736,7 @@
     <!-- deprecated -->
     <string name="systemmsg_action_by_me">%1$s mnou.</string>
     <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$sod%2$s.</string>
+    <string name="systemmsg_action_by_user">%1$s od %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Neznámy odosielateľ pre túto konverzáciu. Ďalšie informácie nájdete v časti „Informácie“.</string>
     <string name="systemmsg_subject_for_new_contact">Správa od %1$s</string>
     <string name="systemmsg_failed_sending_to">Správu sa nepodarilo odoslať %1$s .</string>
@@ -767,6 +767,63 @@
     <string name="systemmsg_chat_protection_disabled">Ochrana konverzácií je vypnutá.</string>
     <!-- deprecated -->
     <string name="systemmsg_chat_protection_enabled">Ochrana konverzácií je zapnutá.</string>
+
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Názov skupiny sa zmenil z „%1$s“ na „%2$s“ mnou.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Názov skupiny sa zmenil z „%1$s“ na „%2$s“ od %3$s.</string>
+    <string name="group_image_changed_by_you">Skupinový obrázok sa zmenil mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Skupinový obrázok sa zmenil od %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Člen %1$s pridaný mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Člen %1$s pridaný od %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Člen %1$s bol odstránený mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Člen %1$s bol odstránený od %2$s.</string>
+    <string name="ephemeral_timer_disabled_by_you">Časovač zmiznutia správ je deaktivovaný mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Časovač zmiznutia správ je deaktivovaný od %1$s.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Časovač zmiznutia správ nastavený na %1$s s mnou.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Časovač zmiznutia správ nastavený na %1$s s od %2$s.</string>
+    <string name="ephemeral_timer_1_minute_by_you">Časovač zmiznutia správ bol nastavený na 1 minútu mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Časovač zmiznutia správ bol nastavený na 1 minútu od %1$s.</string>
+    <string name="ephemeral_timer_1_hour_by_you">Časovač zmiznutia správ bol nastavený na 1 hodinu mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Časovač zmiznutia správ bol nastavený na 1 hodinu od %1$s.</string>
+    <string name="ephemeral_timer_1_day_by_you">Časovač zmiznutia správ nastavený na 1 deň mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Časovač zmiznutia správ nastavený na 1 deň od %1$s.</string>
+    <string name="ephemeral_timer_1_week_by_you">Časovač zmiznutia správ nastavený na 1 týždeň mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Časovač zmiznutia správ nastavený na 1 týždeň od %1$s.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to -->
+    <string name="ephemeral_timer_minutes_by_you">Časovač zmiznutia správ bol nastavený na %1$s minúty mnou.</string>
+    <!-- %1$s will be replaced by the number of minutes (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_minutes_by_other">Časovač zmiznutia správ bol nastavený na %1$s minúty od %2$s.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to -->
+    <string name="ephemeral_timer_hours_by_you">Časovač zmiznutia správ bol nastavený na %1$s hodiny mnou.</string>
+    <!-- %1$s will be replaced by the number of hours (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_hours_by_other">Časovač zmiznutia správ bol nastavený na %1$s hodiny od %2$s.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to -->
+    <string name="ephemeral_timer_days_by_you">Časovač zmiznutia správ nastavený na %1$s dni mnou.</string>
+    <!-- %1$s will be replaced by the number of days (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_days_by_other">Časovač zmiznutia správ nastavený na %1$s dni od %2$s.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to -->
+    <string name="ephemeral_timer_weeks_by_you">Časovač zmiznutia správ nastavený na %1$s týždne mnou.</string>
+    <!-- %1$s will be replaced by the number of weeks (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_weeks_by_other">Časovač zmiznutia správ nastavený na %1$s týždne od %2$s.</string>
+    <string name="protection_enabled_by_you">Ochrana konverzácií je zapnutá mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_enabled_by_other">Ochrana konverzácií je zapnutá od %1$s.</string>
+    <string name="protection_disabled_by_you">Ochrana konverzácií je vypnutá mnou.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="protection_disabled_by_other">Ochrana konverzácií je vypnutá od %1$s.</string>
 
     <string name="devicemsg_self_deleted">Odstránili ste konverzáciu \"Uložené správy\".\n\nℹ️ Aby ste využili funkciu \"Uložené správy\" znova, vytvorte novú konverzáciu so sebou.</string>
     <!-- %1$s will be replaced by the amount of storage already used, sth. as '500 MB'. If you want to use a percentage sign, type in two of them, eg. %1$s %% -->

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -310,6 +310,21 @@
     <string name="systemmsg_action_by_me">%1$s од мене.</string>
     <!-- deprecated -->
     <string name="systemmsg_action_by_user">%1$s од стране %2$s.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Назив групе је измењен из „%1$s“ у „%2$s“ од мене.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Назив групе је измењен из „%1$s“ у „%2$s“ од стране %3$s.</string>
+    <string name="group_image_changed_by_you">Слика групе је промењена од мене.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Слика групе је промењена од стране %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Члан %1$s је додат од мене.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Члан %1$s је додат од стране %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Члан %1$s је уклоњен од мене.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Члан %1$s је уклоњен од стране %2$s.</string>
     <!-- qr code stuff -->
     <string name="qr_code">Бар-кôд</string>
     <string name="qrscan_title">Очитај бар-кôд</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -582,6 +582,40 @@
     <string name="systemmsg_ephemeral_timer_week">Tiduret för meddelandeborttagning är satt till 1 vecka.</string>
     <!-- deprecated -->
     <string name="systemmsg_ephemeral_timer_four_weeks">Tiduret för meddelandeborttagning är satt till 4 veckor.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">Gruppnamnet ändrades från \"%1$s\" till \"%2$s\" av mig.</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">Gruppnamnet ändrades från \"%1$s\" till \"%2$s\" av %3$s.</string>
+    <string name="group_image_changed_by_you">Gruppbilden ändrades av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">Gruppbilden ändrades av %1$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">Medlemmen %1$s lades till av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">Medlemmen %1$s lades till av %2$s.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">Medlemmen %1$s togs bort av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">Medlemmen %1$s togs bort av %2$s.</string>
+    <string name="ephemeral_timer_disabled_by_you">Tiduret för meddelandeborttagning är inaktiverat av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_disabled_by_other">Tiduret för meddelandeborttagning är inaktiverat av %1$s.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to -->
+    <string name="ephemeral_timer_seconds_by_you">Tiduret för meddelandeborttagning är satt till %1$s s av mig.</string>
+    <!-- %1$s will be replaced by the number of seconds (always >1) the timer is set to, %2$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_seconds_by_other">Tiduret för meddelandeborttagning är satt till %1$s s av %2$s.</string>
+    <string name="ephemeral_timer_1_minute_by_you">Tiduret för meddelandeborttagning är satt till 1 minut av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_minute_by_other">Tiduret för meddelandeborttagning är satt till 1 minut av %1$s.</string>
+    <string name="ephemeral_timer_1_hour_by_you">Tiduret för meddelandeborttagning är satt till 1 timma av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_hour_by_other">Tiduret för meddelandeborttagning är satt till 1 timma av %1$s.</string>
+    <string name="ephemeral_timer_1_day_by_you">Tiduret för meddelandeborttagning är satt till 1 dag av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_day_by_other">Tiduret för meddelandeborttagning är satt till 1 dag av %1$s.</string>
+    <string name="ephemeral_timer_1_week_by_you">Tiduret för meddelandeborttagning är satt till 1 vecka av mig.</string>
+    <!-- %1$s will be replaced by name and address of the contact -->
+    <string name="ephemeral_timer_1_week_by_other">Tiduret för meddelandeborttagning är satt till 1 vecka av %1$s.</string>
     <!-- qr code stuff -->
     <string name="qr_code">QR-kod</string>
     <string name="qrscan_title">Skanna QR-kod</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -513,6 +513,21 @@
     <string name="systemmsg_action_by_me">我%1$s</string>
     <!-- deprecated -->
     <string name="systemmsg_action_by_user">%2$s%1$s</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
+    <string name="group_name_changed_by_you">我群組名稱已從 %1$s 更改為 %2$s</string>
+    <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
+    <string name="group_name_changed_by_other">%3$s群組名稱已從 %1$s 更改為 %2$s</string>
+    <string name="group_image_changed_by_you">我已更改群組圖片。</string>
+    <!-- %1$s will be replaced by name and address of the contact who did the action -->
+    <string name="group_image_changed_by_other">%1$s已更改群組圖片。</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group -->
+    <string name="add_member_by_you">我已新增成員 %1$s</string>
+    <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="add_member_by_other">%2$s已新增成員 %1$s</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group -->
+    <string name="remove_member_by_you">我已移除成員 %1$s</string>
+    <!-- %1$s will be replaced by name and address of the contact removed from the group, %2$s will be replaced by name and address of the contact who did the action -->
+    <string name="remove_member_by_other">%2$s已移除成員 %1$s</string>
     <string name="qrscan_title">掃描QR Code</string>
     <string name="qrscan_hint">請將相機對準 QR Code</string>
     <string name="qrscan_ask_join_group">你要參加群組 %1$s 嗎?</string>


### PR DESCRIPTION
by the revamped system messages,
lots of translations would be trashed.
this pr preserves these translations by running a little script (https://gist.github.com/r10s/90e78b425ccc47515a2120952ac13809)

the translation state is not worse than before
https://github.com/deltachat/deltachat-android/pull/2380 and already manually improved translations are not touched.

afterwards, we can finally deleted all the deprecated strings.