### PR TITLE
remove deprecated strings

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -229,4 +229,6 @@
     <string name="remove_desktop">أزِل</string>
     <string name="save_desktop">حفظ</string>
     <string name="name_desktop">الاسم</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-az/strings.xml
+++ b/res/values-az/strings.xml
@@ -391,24 +391,8 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Qrupun adı \"%1$s\" - dən \"%2$s\" - yə deyişildi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Qrup şəkili dəyişildi. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Qrupun şəkili silindi. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Üzv %1$s əlavə olundu. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">%1$s üzv silindi. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Qrup buraxdı.</string>
     <string name="systemmsg_read_receipt_subject">Qəbul olunanları oxuyun</string>
     <string name="systemmsg_cannot_decrypt">Bu mesaj şifresi çözülə bilməz. \n\n • Bu mesaja yalnız cavab vermək və göndərənin mesajı yenidən göndərməsini xahiş edə bilər. \n\n • Bu barədə Delta Chat və ya başqa bir e-poçt proqramını yenidən quraşdırdığınız halda oradan Autocrypt Kurulum Mesajı göndərmək istədiyiniz başqa bir qurğudan istifadə edə bilərsiniz.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s məndən. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s ilə %2$s.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Qrupun adı \"%1$s\" - dən \"%2$s\" - yə deyişildi məndən. </string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -513,4 +497,6 @@
     <string name="menu.view.developer.open.log.folder">Loq mələfini açın</string>
     <string name="menu.view.developer.open.current.log.file">Loq-faylı açın</string>
     <string name="perm_enable_bg_reminder_title">Delta Chat arxa fonda mesajları almaq üçün bura toxunun.</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -669,56 +669,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Името на групата е променено от \"%1$s\" на \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Изображението на групата е променено.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Изображението на глупата е изтрито.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Добавен е членът %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Членът %1$s е премахнат</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Напуснахте групата.</string>
     <string name="systemmsg_read_receipt_subject">Съобщението е отворено</string>
     <string name="systemmsg_read_receipt_body">Съобщението \"%1$s\", което изпратихте, беше показано на екрана на получателя.\n\nТова не е гаранция, че съдържанието му е прочетено.</string>
     <string name="systemmsg_cannot_decrypt">Това съобщение не може да бъде декриптирано.\n\n• Вероятно вече имате средство за помощ - може просто да отговорите на това съобщение и да поискате от подателя да го изпрати отново.\n\n• В случай, че сте преинсталирали Delta Chat или друга програма за електронна поща на това или друго устройство, бихте могли да изпратите съобщение за настройка на Autocrypt от там.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s от мен</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s от %2$s</string>
     <string name="systemmsg_unknown_sender_for_chat">Неизвестен подател за този чат. Вижте \"информация\" за повече подробности.</string>
     <string name="systemmsg_subject_for_new_contact">Съобщение от %1$s</string>
     <string name="systemmsg_failed_sending_to">Неуспешно изпращане на съобщение до %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Таймерът на изчезващите съобщения е деактивиран.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Таймерът на изчезващите съобщение е установен на %1$sсек.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Таймерът на изчезващите съобщения е установен на 1 минута.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Таймерът на изчезващите съобщения е установен на 1 час.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Таймерът на изчезващите съобщения е установен на 1 ден.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Таймерът на изчезващите съобщения е установен на 1 седмица.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Таймерът на изчезващите съобщения е установен на 4 седмици.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Таймерът на изчезващите съобщения е установен на %1$s минути.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Таймерът на изчезващите съобщения е установен на %1$s часа.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Таймерът на изчезващите съобщения е установен на %1$s дни.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Таймерът на изчезващите съобщения е установен на %1$s седмици.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Защитата на чата е изключена.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Защитата на чата е включена.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Името на групата е променено от \"%1$s\" на \"%2$s\" от мен</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -953,4 +909,6 @@ votes
     <string name="perm_enable_bg_already_done">Вече разрешихте Delta Chat да получава съобщения във фонов режим.\n\nАко съобщенията все още не пристигат във фонов режим, моля проверете Вашите системни настройки.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -583,25 +583,9 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Nom del grup \"%1$s\" canviat a \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Imatge de grup canviada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Imatge de grup eliminada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Membre %1$s afegit.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Membre %1$s eliminat.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Deixa el grup.</string>
     <string name="systemmsg_read_receipt_subject">Confirmació de lectura</string>
     <string name="systemmsg_read_receipt_body">Confirmació de lectura del missatge \"%1$s\".\n\nVol dir que el missatge s\'ha mostrat al dispositiu del receptor, no necessàriament que s\'hagi llegit.</string>
     <string name="systemmsg_cannot_decrypt">Aquest missatge no es pot desxifrar.\n\n• Proveu de respondre\'l i demanar-li al remitent que us el torni a enviar.\n\n• Si heu reinstal·lat Delta Chat o un altre gestor de correu en aquest dispositiu o en algun altre, proveu d\'enviar un missatge de configuració Autocrypt des d\'allà.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s per mi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s per %2$s.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Nom del grup \"%1$s\" canviat a \"%2$s\" per mi.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -705,4 +689,6 @@
     <string name="menu.view.developer.open.log.folder">Obre la carpeta de registre</string>
     <string name="menu.view.developer.open.current.log.file">Obre el fitxer de registre actual</string>
     <string name="perm_enable_bg_reminder_title">Prem aquí per rebre missatges mentre Delta Chat és en segon pla.</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-ckb/strings.xml
+++ b/res/values-ckb/strings.xml
@@ -502,52 +502,10 @@
     <string name="autocrypt_continue_transfer_title">پەیامی ڕێکخستنی ئۆتۆکریپت</string>
     <string name="autocrypt_continue_transfer_retry">دیسان هەوڵدانەوە</string>
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">ناوی کۆڕ لە \"%1$s\" گۆڕا بۆ \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">وێنەی کۆڕ گۆڕا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">وێنەی کۆڕ سڕاوە.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">%1$s زیاد کرا بە کۆڕ.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">ئەندامی %1$s سڕدرایەوە.</string>
     <string name="systemmsg_read_receipt_subject">پەیامەکە کرایەوە</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s لەلایەن منەوە.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s لەلایەن %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">پەیامنێری ئەم وتووێژە نەناسراوە. بۆ وردەکاری زۆرتر سەیری \'زانیارییەکان\' بکە.</string>
     <string name="systemmsg_subject_for_new_contact">پەیام لەلایەن %1$s</string>
     <string name="systemmsg_failed_sending_to">هەناردنی پەیام بۆ %1$s سەرنەکەوت</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">دەمژمێری پەیامە خۆشارەوەکان ناچالاک کرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">دەمژمێری پەیام خۆشارەوەکان لەسەر %1$s چرکە ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">دەمژمێری پەیام خۆشارەوەکان لەسەر 1  خولەک ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">دەمژمێری پەیام خۆشارەوەکان لەسەر 1 سەعات ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">دەمژمێری پەیام خۆشارەوەکان لەسەر 1 ڕۆژ ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">دەمژمێری پەیام خۆشارەوەکان لەسەر 1 حەوتە ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">دەمژمێری پەیام خۆشارەوەکان لەسەر 4 ڕۆژ ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">دەمژمێری پەیام خۆشارەوەکان لەسەر%1$s خولەک ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">دەمژمێری پەیام خۆشارەوەکان لەسەر %1$s سەعات ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">دەمژمێری پەیام خۆشارەوەکان لەسەر %1$s ڕۆژ ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">دەمژمێری پەیام خۆشارەوەکان لەسەر %1$s حەوتە ڕێکخرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">پاراستنی وتووێژ ناچالاک کرا.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">پاراستنی وتووێژ چالاک کرا.</string>
-
     <!-- qr code stuff -->
     <string name="qr_code">کۆدی QR</string>
     <string name="load_qr_code_as_image">کۆدی QR وەکوو وێنەیەک بار بکە.</string>
@@ -658,4 +616,6 @@
     <string name="perm_enable_bg_already_done">تۆ ئێستا ڕێگەت بە دێڵتا چات دا کە لە پشتخانەوە پەیامەکان وەربگرێت.\n\n ئەگەر هێشتا لە پشخاندا پەیامەکان نایەن، سەرنجێکیش لە ڕێکخستنەکانی سیستەم بدەوە.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -577,56 +577,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Názen skupiny změněn z \"%1$s\" na \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Obrázek skupiny změněn.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Obrázek skupiny smazán.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Člen %1$s byl přidán.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Člen %1$s byl odebrán.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Skupina opuštěna.</string>
     <string name="systemmsg_read_receipt_subject">Zpráva otevřena</string>
     <string name="systemmsg_read_receipt_body">Odeslaná zpráva \"%1$s\" byla příjemci zobrazena na jeho přístroji.\n\nNicméně přečtení obsahu není zaručeno.</string>
     <string name="systemmsg_cannot_decrypt">Zprávu nelze dešifrovat.\n\n• Může pomoct jednoduchá odpověď odesílateli s požadavkem o znovuzaslání zprávy.\n\n• Pokud jde o novou instalaci Delta Chatu či jiného e-mailového programu na tomto nebo jiném zařízení, může být nutné poslat si z nich Nastavení Autocryptu.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s ode mě.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s od %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Neznámý odesilatel v tomto hovoru. Více najdeš v Popisu.</string>
     <string name="systemmsg_subject_for_new_contact">Zpráva od %1$s</string>
     <string name="systemmsg_failed_sending_to">Odeslání zprávy pro %1$s selhalo.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Časovač samomazacích zpráv je vypnut.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Časovač samomazacích zpráv je na %1$s s. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Časovač samomazacích zpráv na 1 minutu.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Časovač samomazacích zpráv na 1 hodinu.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Časovač samomazacích zpráv na 1 den.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Časovač samomazacích zpráv na 1 týden.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Časovač samomazacích zpráv na 4 týdny.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Samomazací zprávy vyprší po %1$s minutách.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Samomazací zprávy vyprší po %1$s hodinách.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Samomazací zprávy vyprší po %1$s dnech.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Samomazací zprávy vyprší po %1$s týdnech.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Ochrana rozhovoru vypnuta.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Ochrana rozhovoru zapnuta.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Názen skupiny změněn z \"%1$s\" na \"%2$s\" ode mě.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -822,4 +778,6 @@
     <string name="perm_enable_bg_already_done">Přijímání zpráv na pozadí je Delta Chatu již povoleno.\n\nV případě nepřicházení nových zpráv si prosím zkontroluj své systémové nastavení.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -596,56 +596,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Gruppenavn ændret fra \"%1$s\" til \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Gruppebillede ændret.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Gruppebillede slettet.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Medlem %1$s tilføjet.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Medlem %1$s fjernet.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Gruppe forladt.</string>
     <string name="systemmsg_read_receipt_subject">Besked åbnet</string>
     <string name="systemmsg_read_receipt_body">Beskeden \"%1$s\" du har sendt blev vist på modtagerens skærm.\n\nDette er ikke en garanti for at indholdet blev læst.</string>
     <string name="systemmsg_cannot_decrypt">Denne besked kan ikke dekrypteres.\n\n• Det kan måske hjælpe at svare på beskeden og bede afsender sende beskeden igen.\n\n• I tilfælde at Delta Chat eller andet e-mail program på denne enhed eller en anden er blevet gen-installeret bør der sendes en Autocrypt opsætning besked derfra.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s af mig.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s af %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Ukent afsender af denne chat. Se \'info\' for flere detaljer.</string>
     <string name="systemmsg_subject_for_new_contact">Besked fra %1$s</string>
     <string name="systemmsg_failed_sending_to">Mislykket forsøg på afsendelse af besked til %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Tidsudløb for beskeder er deaktiveret.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Tidsudløb for beskeder sat til %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Tidsudløb for beskeder sat til 1 minut.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Tidsudløb for beskeder sat til 1 time.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Tidsudløb for beskeder sat til 1 dag.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Tidsudløb for beskeder sat til 1 uge.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Tidsudløb for beskeder sat til 4 uger.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Beskeder sat til at udløbe efter %1$s minutter.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Beskeder sat til at udløbe efter %1$s timer.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Beskeder sat til at udløbe efter %1$s dage.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Beskeder sat til at udløbe efter %1$s uger.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Chat-beskyttelse slået fra.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Chat-beskyttelse sluttet til.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Gruppenavn ændret fra \"%1$s\" til \"%2$s\" af mig.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -846,4 +802,6 @@
     <string name="perm_enable_bg_already_done">Du har allerede tilladt Delta Chat at modtage beskeder i baggrunden.\n\nHvis beskeder ikke ankommer i baggrunden, undersøg dine systemindstillinger.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -717,56 +717,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Gruppenname von \"%1$s\" zu \"%2$s\" geändert.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Gruppenbild geändert.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Gruppenbild gelöscht.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">%1$s hinzugefügt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">%1$s entfernt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Gruppe verlassen.</string>
     <string name="systemmsg_read_receipt_subject">Empfangsbestätigung</string>
     <string name="systemmsg_read_receipt_body">Ihre Nachricht \"%1$s\" wurde auf dem Empfangsgerät angezeigt.\n\nDas ist keine Garantie dafür, dass sie auch gelesen wurde.</string>
     <string name="systemmsg_cannot_decrypt">Diese Nachricht kann nicht entschlüsselt werden.\n\n• Es könnte bereits helfen, einfach auf diese Nachricht zu antworten und die/den AbsenderIn zu bitten, die Nachricht erneut zu senden.\n\n• Falls Delta Chat oder ein anderes E-Mail-Programm auf diesem oder einem anderen Gerät neu installiert wurde, kann von dort aus eine Autocrypt Setup-Nachricht gesendet werden.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s von mir.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s von %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Absender ist für diesen Chat unbekannt. Siehe \"Info\" für weitere Details,</string>
     <string name="systemmsg_subject_for_new_contact">Nachricht von %1$s</string>
     <string name="systemmsg_failed_sending_to">Nachricht senden an %1$s fehlgeschlagen.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Verschwindende Nachrichten ausgeschaltet.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Ablaufzeit verschwindender Nachrichten auf %1$s s festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Ablaufzeit verschwindender Nachrichten auf 1 Minute festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Ablaufzeit verschwindender Nachrichten auf 1 Stunde festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Ablaufzeit verschwindender Nachrichten auf 1 Tag festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Ablaufzeit verschwindender Nachrichten auf 1 Woche festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Ablaufzeit verschwindender Nachrichten auf 4 Wochen festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Ablaufzeit verschwindender Nachrichten auf %1$s Minuten festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Ablaufzeit verschwindender Nachrichten auf %1$s Stunden festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Ablaufzeit verschwindender Nachrichten auf %1$s Tage festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Ablaufzeit verschwindender Nachrichten auf %1$s Wochen festgelegt.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Chat-Absicherung ausgeschaltet.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Chat-Absicherung eingeschaltet.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Sie haben den Gruppennamen von \"%1$s\" zu \"%2$s\" geändert.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1058,6 +1014,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Schneller. Stabiler.\n\nFür die Version 1.30 haben wir uns auf Geschwindigkeit und Zuverlässigkeit konzentriert und Dutzende Fehler behoben. Ist Ihr Lieblingsfehler dabei? Details im Changelog: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-eo/strings.xml
+++ b/res/values-eo/strings.xml
@@ -382,4 +382,6 @@
     <string name="timestamp_format_m_desktop">MMM D</string>
     <string name="remove_desktop">Forviŝi</string>
     <string name="save_desktop">Konservi</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -732,56 +732,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Nombre de grupo cambiado de \"%1$s\" a \"%2$s\"</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Imagen de grupo cambiada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Imagen de grupo eliminada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Miembro %1$s añadido.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Miembro %1$s eliminado.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Grupo abandonado.</string>
     <string name="systemmsg_read_receipt_subject">Recibo de lectura</string>
     <string name="systemmsg_read_receipt_body">El mensaje \"%1$s\" que enviaste se mostró en la pantalla del destinatario.\n\nEsto no garantiza que el contenido haya sido leído.</string>
     <string name="systemmsg_cannot_decrypt">Este mensaje no puede ser descifrado.\n\n• Es posible que sea útil simplemente responderlo y pedirle al remitente que lo envíe nuevamente.\n\n• En caso de que haya reinstalado Delta Chat u otro programa de correo en este u otro dispositivo, puede que quiera enviar un Mensaje de Configuración de Autocrypt desde allí.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s por mi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s por %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Remitente desconocido. Mira \"info\" para más detalles.</string>
     <string name="systemmsg_subject_for_new_contact">Mensaje de %1$s</string>
     <string name="systemmsg_failed_sending_to">Falla en enviar el mensaje a %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Temporizador de mensajes borrados desactivado.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Temporizador del borrado de mensajes dispuesto en %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Temporizador de borrado de mensaje dispuesto en 1 minuto.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Temporizador de borrado de mensaje dispuesto en 1 hora.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Temporizador de borrado de mensaje dispuesto en 1 día.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Temporizador de borrado de mensaje dispuesto en 1 semana.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Temporizador de borrado de mensaje dispuesto en 4 semanas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Temporizador de mensajes borrados dispuesto en %1$s minutos.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Temporizador de mensajes borrados dispuesto a %1$s horas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Temporizador de mensajes borrados dispuestos en %1$s días.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Temporizador de mensajes borrados dispuestos para %1$s semanas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Protección de chat desactivada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Protección de chat activada.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Cambiaste el nombre del grupo de \"%1$s\" a \"%2$s\".</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1064,6 +1020,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Más rápido. Más estable.\n\nPara las versiones 1.30, nos enfocamos en la velocidad y la confiabilidad, solucionando docenas de errores. Consulte nuestros registros de cambios para ver si su favorito está arreglado: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -441,25 +441,9 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Taldearen izena \"%1$s\" izatetik \"%2$s\" izatera aldatu da.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Taldearen irudia aldatuta.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Taldearen irudia ezabatuta.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">%1$s kidea gehituta.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">%1$s kidea kenduta.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Taldetik aterata.</string>
     <string name="systemmsg_read_receipt_subject">Irakurragiria</string>
     <string name="systemmsg_read_receipt_body">Hau \"%1$s\" mezuaren irakurragiri bat da.\n\nHonek mezua jasotzailearen gailuan bistaratu dela esan nahi du, ez edukia irakurri dela.</string>
     <string name="systemmsg_cannot_decrypt">Ezin da mezu hau deszifratu.\n\n• Mezuari erantzun diezaiokezu eta berriro bidaltzea eskatu.\n\n• Delta Chat berrinstalatu baduzu edo beste posta programa bat instalatu baduzu gailu honetan edo beste batean, AutoCrypt ezarpen mezua handik hona birbidaltzen saiatu zaitezke.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">Nik: %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%2$s(e)k: %1$s</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Nik: Taldearen izena \"%1$s\" izatetik \"%2$s\" izatera aldatu da</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -596,4 +580,6 @@ Kideak beste kide batzuek egiatzen dituzte bigarren faktore batekin eta mezuak b
     <string name="perm_enable_bg_already_done">Dagoeneko baimendu diozu Delta Chat aplikazioari bigarren planoan mezuak jasotzea,\n\nOraindik ere mezuak heltzen ez badira, egiaztatu ere zure sistemaren ezarpenak.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -730,56 +730,12 @@ https://meet.jit.si/$ROOM
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">اسم گروه از \"%1$s\" به \"%2$s\" تغییر کرد. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">تصویر گروه تغییر کرد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">تصویر گروه حذف شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">%1$s عضو شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">عضویت %1$sحذف شد. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">گروه ترک شد. </string>
     <string name="systemmsg_read_receipt_subject">پیام باز شد</string>
     <string name="systemmsg_read_receipt_body">پیام\"%1$s\" که ارسال کرده بودید در ثفحه گیرنده نمایش داده شد\n\n. تضمینی وجود ندارد که محتوای پیام را خوانده باشد. </string>
     <string name="systemmsg_cannot_decrypt">این پیام را نمی‌توان رمزگشایی کرد.\n\n• ممکن است بهتر باشد که به همین پیام پاسخ داده و از ارسال کننده بخواهید دوباره آن را بفرستد. \n\n• اگر دوباره دلتاچت را نصب کرده‌اید یا از یک ایمیل دیگر هم روی این دستگاه یا دستگاه دیگر استفاده می‌کنید ممکن است لازم باشد یک پیام تنظیمات خودرمز از آن دستگاه ارسال کنید. </string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$sتوسط من</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$sتوسط%2$s</string>
     <string name="systemmsg_unknown_sender_for_chat">فرستنده در این گفت و گو ناشناس است. برای جزئیات بیشتر به \"اطلاعات\" مراجعه کنید.</string>
     <string name="systemmsg_subject_for_new_contact">پیام از%1$s</string>
     <string name="systemmsg_failed_sending_to">ارسال ناموفق پیام به %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">زمان سنج پیام های ناپدید شونده غیرفعال شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">زمان‌سنج پیام ناپدید شونده روی %1$sثانیه تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">زمان سنج پیام های ناپدید شونده برای 1 دقیقه تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">زمان سنج پیام های ناپدید شونده برای 1 ساعت تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">زمان سنج پیام های ناپدید شونده برای 1 روز تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">زمان سنج پیام های ناپدید شونده برای 1 هفته تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">زمان سنج پیام های ناپدید شونده برای 4 هفته تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">زمان‌سنج پیام‌های ناپدید شونده روی %1$s دقیقه تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">زمان‌سنج پیام ناپدید شونده روی %1$s ساعت تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">زمان‌سنج پیام ناپدید شونده روی %1$s روز تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">زمان‌سنج پیام ناپدید شونده روی %1$s هفته تنظیم شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">محافظت از گفنگو غیرفعال شد.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">محافظت از گفتگو فعال شد.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">شما نام گروه را از «%1$s» به «%2$s»  تغییر دادید. </string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1047,9 +1003,5 @@ GNU GPL ورژن ۳
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">سریع‌تر و پایدارتر
-
-در نسخه‌های ۱.۳۰ بر سرعت، قابلیت اطمینان و بر طرف کردن ده‌ها اشکال تمرکز کرده‌ایم. اگر می‌خواهید ببینید یکی از مشکلات شما رفع شده است به شرح تغییرات مراجعه کنید:
-https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -708,56 +708,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Ryhmän nimi vaihdettu: \"%1$s\" --> \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Ryhmän kuva vaihdettu.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Ryhmän kuva poistettu</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Jäsen %1$s lisätty</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Jäsen %1$s poistettu</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Poistuttiin ryhmästä.</string>
     <string name="systemmsg_read_receipt_subject">Viesti avattu</string>
     <string name="systemmsg_read_receipt_body">Lähettämäsi viesti \"%1$s\" näytettiin vastaanottajan näytöllä.\n\nTämä ei takaa, että sisältö luettiin.</string>
     <string name="systemmsg_cannot_decrypt">Viestin salausta ei voi purkaa.\n\n• Pyydä lähettäjää lähettämään viesti uudelleen.\n\n• Jos asensit Delta Chatin tai toisen sähköpostisovelluksen uudelleen tälle tai toiselle laitteelle, Autocrypt-asetusviestin lähettäminen siitä sovelluksesta voi auttaa.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s minun toimestani.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s käyttäjän %2$s toimesta.</string>
     <string name="systemmsg_unknown_sender_for_chat">Tuntematon lähettäjä. Katso \"lisätietoja\".</string>
     <string name="systemmsg_subject_for_new_contact">Viesti lähettäjältä %1$s</string>
     <string name="systemmsg_failed_sending_to">Viestin lähettäminen kohteeseen %1$s epäonnistui.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Katoavien viestien ajastin poistettiin.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Katoavien viestien ajastin asetettu %1$s sekuntiin.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Katoavien viestien ajastin asetettu 1 minuuttiin.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Katoavien viestien ajastin asetettu 1 tuntiin.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Katoavien viestien ajastin asetettu 1 päivään.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Katoavien viestien ajastin asetettu 1 viikkoon.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Katoavien viestien ajastin asetettu 4 viikkoon.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Katoavien viestien ajastin asetettu %1$s minuuttiin.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Katoavien viestien ajastin asetettu %1$s tuntiin.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Katoavien viestien ajastin asetettu %1$s päivään.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Katoavien viestien ajastin asetettu %1$s viikkoon.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Keskustelusuojaus poistettu</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Keskustelusuojaus käytössä</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Ryhmän nimi vaihdettu: \"%1$s\" --> \"%2$s\" minun toimestani.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1034,6 +990,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Nopeampi. Vakaampi.\n\n1.30-versioissa keskityimme nopeuteen ja luotettavuuteen, ja korjasimme kasan bugeja ja virheitä. Tarkista muutoslokistamme korjasimmeko sinusta tärkeimmän: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -723,56 +723,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Nom de groupe modifié de \"%1$s\" en \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Image de groupe modifiée.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Image de groupe effacée.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Membre %1$s ajouté.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Membre %1$s retiré.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Groupe quitté.</string>
     <string name="systemmsg_read_receipt_subject">Accusé de lecture</string>
     <string name="systemmsg_read_receipt_body">Ceci est un accusé de lecture pour le message \"%1$s\".\n\nCela signifie que le message a été affiché sur l\'appareil du destinataire, pas forcément que le contenu ait été lu.</string>
     <string name="systemmsg_cannot_decrypt">Ce message ne peut pas être déchiffré.\n\n• Il peut déjà être utile de simplement répondre à ce message et demander à l\'expéditeur de l\'envoyer à nouveau.\n\n• Au cas où vous auriez réinstallé Delta Chat ou un autre programme de messagerie sur cet appareil ou un autre, vous voudrez peut-être envoyer un message de configuration d\'Autocrypt depuis ce dernier.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s par moi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s sur %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Expéditeur inconnu de cette discussion. Voir « Info » pour plus de détails.</string>
     <string name="systemmsg_subject_for_new_contact">Message de %1$s</string>
     <string name="systemmsg_failed_sending_to">Échec de l\'envoi du message à %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Temporisation des messages éphémères désactivée.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Temporisation des messages éphémères réglée à %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Temporisation des messages éphémères réglée à 1 minute.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Temporisation des messages éphémères réglée à 1 heure.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Temporisation des messages éphémères réglée à 1 journée.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Temporisation des messages éphémères réglée à 1 semaine.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Temporisation des messages éphémères réglée à 4 semaines.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Régler le temps d\'affichage des messages éphémères à %1$s minute(s).</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Régler le temps d\'affichage des messages éphémères à %1$s heure(s).</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Régler le temps d\'affichage des messages éphémères à %1$s jour(s).</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Régler le temps d\'affichage des messages éphémères à %1$s semaine(s).</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Protection de la discussion désactivée.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Protection de la discussion activée.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Nom de groupe modifié de \"%1$s\" en \"%2$s\" par moi.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1049,6 +1005,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Plus rapide. Plus stable.\n\nPour la version 1.30, nous avons focalisés sur la vitesse et la fiabilité, en réglant des douzaines de bogues. Vérifiez dans notre journal des changements si votre bogue favori était corrigé : https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -717,56 +717,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Nome do grupo cambiado de \"%1$s\" a \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Cambiouse a imaxe do grupo.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Imaxe do grupo borrada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Engadeuse a %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Eliminouse a %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Saír do Grupo.</string>
     <string name="systemmsg_read_receipt_subject">Mensaxe aberta</string>
     <string name="systemmsg_read_receipt_body">A mensaxe \"%1$s\" que enviaches mostrouse na pantalla do correspondente.\n\nNon hai garantía de que o contido fose lido.</string>
     <string name="systemmsg_cannot_decrypt">Esta mensaxe non se pode descifrar.\n\n• Podería axudar que respondas a mensaxe pedindo ao remitente que a volte a enviar.\n\n• En caso dunha reinstalación Delta Chat ou outro programa de correo en este ou outro dispositivo igual debes enviar unha Mensaxe de Configuración Autocrypt desde alí.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s por min.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s por %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Remitente descoñecido para esta convers. Mira en \'info\' para saber máis.</string>
     <string name="systemmsg_subject_for_new_contact">Mensaxe de %1$s</string>
     <string name="systemmsg_failed_sending_to">Fallou o envío para %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Desactivada a caducidade para as mensaxes.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">As mensaxes desparecerán após %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">As mensaxes desparecerán após 1 minuto.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">As mensaxes desparecerán após 1 hora.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">As mensaxes desaparecerán após 1 día.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">As mensaxes desaparecerán após 1 semana.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">As mensaxes desaparecerán após 4 semanas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">As mensaxes desaparecerán após %1$s minutos.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">As mensaxes desaparecerán após %1$s horas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">As mensaxes desaparecerán após %1$s días.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">As mensaxes desaparecerán após %1$s semanas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Protección do chat desactivada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Protección do chat activada.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Cambiaches o nome do grupo de \"%1$s\" a \"%2$s\".</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1012,6 +968,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Máis rápido. Máis estable.\n\nNa versión 1.30 poñemos o foco na velocidade e fiabilidade, arranxando dúcias de problemiñas. Mira o rexistro de cambios se algún que ti vises foi arranxado: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -221,12 +221,6 @@
     <string name="pref_show_emails_all">Sve</string>
     <string name="pref_background_default">Zadana pozadina</string>
     <string name="pref_background_default_color">Zadana boja</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Član %1$s dodan.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Član %1$s uklonjen.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s od %2$s.</string>
     <!-- qr code stuff -->
     <string name="qr_code">QR kod</string>
     <string name="qrscan_fingerprint_label">Otisak prsta</string>
@@ -261,4 +255,6 @@
     <string name="name_desktop">Ime</string>
     <string name="message_detail_sent_desktop">poslano</string>
     <string name="message_detail_received_desktop">primljeno</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -267,16 +267,6 @@
     <string name="pref_background_btn_gallery">Galériából</string>
     <string name="pref_show_emails_all">Mind</string>
     <string name="autocrypt_continue_transfer_retry">Újra</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">A csoportkép megváltozott.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">A csoportkép törölve.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">%1$s hozzáadva a csoporthoz.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">%1$s eltávolítva a csoportból.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Kiléptél a csoportból.</string>
     <!-- qr code stuff -->
     <string name="qr_code">QR-kód</string>
     <string name="qrscan_title">QR-kód olvasása</string>
@@ -321,4 +311,6 @@
     <string name="export_backup_desktop">Biztonsági mentés exportálása</string>
     <string name="menu.view.developer.open.log.folder">Naplófájlok könyvtárának megnyitása</string>
     <string name="menu.view.developer.open.current.log.file">Jelenlegi naplófájl megnyitása</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -505,27 +505,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Nama grup diganti dari \"%1$s\" ke \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Gambar grup telah diubah.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Gambar grup telah dihapus.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Member %1$s telah ditambahkan.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Member %1$s telah dikeluarkan.</string>
     <string name="systemmsg_read_receipt_subject">Pesan dibuka</string>
     <string name="systemmsg_read_receipt_body">Pesan \"%1$s\" yang Anda kirimkan tampak di layar penerima.\n\nIni bukan jaminan kalau isinya dibaca.</string>
     <string name="systemmsg_cannot_decrypt">Pesan ini tidak bisa dienkripsi.\n\n• Ada baiknya menjawab pesan ini dan meminta pengirimnya untuk kirim ulang.\n\n• Dalam kasus Anda menginstal ulang Delta Chat atau program surel lain di perangkat ini atau perangkat lain, sebaiknya Anda mengirim Pengaturan Pesan Autocrypt dari sana.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s oleh saya.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s oleh %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Pengirim tidak dikenal untuk obrolan ini. Lihat \'info\' untuk lebih jelasnya.</string>
     <string name="systemmsg_subject_for_new_contact">Pesan dari %1$s</string>
     <string name="systemmsg_failed_sending_to">Gagal mengirim pesan ke %1$s.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Nama grup diganti dari \"%1$s\" ke \"%2$s\" oleh saya.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -655,4 +640,6 @@
     <string name="InfoPlist_NSPhotoLibraryAddUsageDescription">Delta Chat ingin menyimpan gambar ke kumpulan foto anda.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -732,56 +732,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Nome del gruppo modificato da \"%1$s\" a \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Immagine gruppo cambiata.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Immagine gruppo eliminata.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Membro %1$s aggiunto.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Membro %1$s rimosso.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Gruppo abbandonato.</string>
     <string name="systemmsg_read_receipt_subject">Ricevuta di lettura</string>
     <string name="systemmsg_read_receipt_body">Questa è una ricevuta di lettura del messaggio \"%1$s\".\n\nCiò significa che il messaggio è stato mostrato nel dispositivo del destinatario, ma non necessariamente che il contenuto è stato letto.</string>
     <string name="systemmsg_cannot_decrypt">Questo messaggio non può essere decrittato.\n\n• Potrebbe essere sufficiente rispondere a questo messaggio e chiedere al mittente di rispedirlo.\n\n• Se hai reinstallato Delta Chat o usi un altro client email dovresti inviare un Messaggio di configurazione Autocrypt dal dispositivo originario.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s da me.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s da %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Mittente sconosciuto per questa chat. Vedi \'info\' per maggiori dettagli.</string>
     <string name="systemmsg_subject_for_new_contact">Messaggio da %1$s</string>
     <string name="systemmsg_failed_sending_to">Impossibile inviare il messaggio a %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Timer messaggi a scomparsa disabilitato.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Timer messaggi a scomparsa impostato su %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Timer messaggi a scomparsa impostato su 1 minuto.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Timer messaggi a scomparsa impostato su 1 ora.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Timer messaggi a scomparsa impostato su 1 giorno.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Timer messaggi a scomparsa impostato su 1 settimana.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Timer messaggi a scomparsa impostato su 4 settimane.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Timer messaggi a scomparsa impostato su %1$s minuti.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Timer messaggi a scomparsa impostato su %1$s ore.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Timer messaggi a scomparsa impostato su %1$s giorni.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Timer messaggi a scomparsa impostato su %1$s settimane.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Protezione chat disattivata.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Protezione chat abilitata.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Hai cambiato il nome del gruppo da \"%1$s\" a \"%2$s\".</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1073,6 +1029,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Più veloce. Più stabile.\n\nPer la versione 1.30 abbiamo puntato su velocità e affidabilità, risolvendo decine di problemi. Controlla nei nostri elenchi delle modifiche se il tuo preferito è risolto: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -557,53 +557,9 @@ https://delta.chat</string>
     <string name="autocrypt_continue_transfer_title">自動暗号化設定用ﾒｯｾｰｼﾞ</string>
     <string name="autocrypt_continue_transfer_retry">再試行</string>
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">グループ名を%1$sから%2$sに変更しました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">グループ画像が変わりました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">グループ画像を削除しました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">%1$sが追加されました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">%1$sが退会されました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">グループを退会しました。</string>
     <string name="systemmsg_read_receipt_subject">既読</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">自分から%1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%2$sから%1$s</string>
     <string name="systemmsg_subject_for_new_contact">%1$sさんからのメッセージ</string>
     <string name="systemmsg_failed_sending_to">%1$sさんへのメッセージ送信に失敗しました。</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">消えるメッセージを無効にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">消えるメッセージを%1$s秒にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">消えるメッセージを1分にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">消えるメッセージを1時間にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">消えるメッセージを1日にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">消えるメッセージを1週間にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">消えるメッセージを4週間にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">消えるメッセージを%1$s分にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">消えるメッセージを%1$s時間にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">消えるメッセージを%1$s日にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">消えるメッセージを%1$s週間にしました。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">保護が無効です。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">保護が有効です。</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">自分からグループ名を%1$sから%2$sに変更しました。</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -759,4 +715,6 @@ https://delta.chat</string>
     <string name="a11y_delivery_status_invalid">不明な送信状態</string>
     <string name="a11y_disappearing_messages_activated">消えるメッセージを有効にしました。</string>
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-km/strings.xml
+++ b/res/values-km/strings.xml
@@ -651,56 +651,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">ឈ្មោះក្រុមត្រូវបានប្តូរពី \"%1$s\" ទៅកាន់ \"%2$s\"</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">រូបភាពក្រុមត្រូវបានប្តូរ</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">រូបភាពក្រុមត្រូវបានលុប</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">សមាជិក %1$s ត្រូវបានបន្ថែម</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">សមាជិក %1$s ត្រូវបានយកចេញ</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">អ្នកត្រូវបានចាកចេញពីក្រុម</string>
     <string name="systemmsg_read_receipt_subject">សារត្រូវបានបើក</string>
     <string name="systemmsg_read_receipt_body">\"%1$s\" សារដែលអ្នកបានផ្ញើត្រូវបានបង្ហាញនៅលើ អេក្រង់របស់អ្នកទទួល\n\nនេះមិនមែនជាការធានាថា មាតិកាត្រួវបានអានទេ។</string>
     <string name="systemmsg_cannot_decrypt">សារនេះមិនអាចត្រូវបានឌិគ្រីប\n\n• វាអាចជួយឆ្លើយតបជំនួសសារនេះ និងសួរអ្នកផ្ញើដើម្បីផ្ញើសារម្តងទៀត\n\n• ក្នុងករណីអ្នកបានតម្លើងសា Delta Chat ម្តងទៀត ឬកម្មវិធីអុីម៉េលមួយទៀត លើឧបករណ៍នេះ ឬឧបករណ៍មួយផ្សេងទៀត អ្នកប្រហែលជាចង់ផ្ញើ សារការតម្លើងអ៊ិនគ្រីបស្វ័យប្រវត្តិ  (ផ្ញើនិងទទួលដោយសម្ងាត់) ពីទីនោះ។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s ដោយខ្ញុំ</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s ដោយ %2$s</string>
     <string name="systemmsg_unknown_sender_for_chat">មិនស្គាល់អ្នកផ្ញើការសន្ទនានេះ។ មើល \'ពត៌មាន\' សម្រាប់ពត៌មានលំអិត</string>
     <string name="systemmsg_subject_for_new_contact">សារពី %1$s</string>
     <string name="systemmsg_failed_sending_to">បានបរាបានក្នុងការផ្ញើសារទៅ %1$s</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">បានបិទបាត់កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈ</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s វិនាទី។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១នាទី។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១ម៉ោង។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១ថ្ងៃ។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ១សប្តាហ៍។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ ៤សប្តាហ៍</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s នាទី។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ម៉ោង។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ថ្ងៃ។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">កម្មវិធីសារដែលនឹងបាត់បន្ទាប់ពីមួយរយៈបាន កំណត់ទៅ %1$s ថ្ងៃ។</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">ការការពារសន្ទនាត្រូវបានបិទ</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">ការការពារសន្ទនាត្រូវបានបើក</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">ឈ្មោះក្រុមត្រូវបានប្តូរពី \"%1$s\" ទៅកាន់ \"%2$s\" ដោយខ្ញុំ</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -930,4 +886,6 @@
     <string name="perm_enable_bg_already_done">អ្នកបានអនុញ្ញាតរួចរាល់ហើយឲ្យសា Delta Chat ដើម្បីទទួលសារនៅផ្ទៃខាងក្រោយ\n\nប្រសិនបើ សារនៅតែមិនមកដល់ផ្ទៃខាងក្រោយ សូមពិនិត្យការការកំណត់ប្រពន្ធ័របស់អ្នកផងដែរ។</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -423,37 +423,8 @@
     <!-- autocrypt -->
     <string name="autocrypt">자동암호화</string>
     <string name="autocrypt_send_asm_title">자동 암호화 설정된 메시지 전송</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">그룹 이미지 변경</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">그룹 이미지 삭제</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">그룹이 남았습니다.</string>
     <string name="systemmsg_unknown_sender_for_chat">이 채팅의 발신자를 알 수 없습니다. 자세한 내용은 \'info\'를 확인하세요.</string>
     <string name="systemmsg_failed_sending_to">%1$s에게 메시지를 보내지 못했습니다.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">메시지 타이머를 사용할 수 없습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">메시지 타이머가 %1$s초로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">메시지 타이머가 1분으로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">메시지 타이머가 1시간으로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">메시지 타이머가 1일로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">메시지 타이머가 1주로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">메시지 타이머가 4주로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">메시지 타이머가 %1$s분으로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">메시지 타이머가 %1$s시간으로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">메시지 타이머가 %1$s일로 설정되었습니다.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">메시지 타이머가 %1$s주로 설정되었습니다.</string>
     <string name="qrscan_title">QR코드를 스캔하세요</string>
     <string name="qrscan_ask_join_group">\"%1$s\" 그룹에 참여하시겠습니까?</string>
     <string name="qrshow_join_contact_no_connection_toast">인터넷에 연결되어 있지 않아 QR 코드 설정을 수행할 수 없습니다.</string>
@@ -496,4 +467,6 @@
     <string name="select_group_image_desktop">그룹 이미지 선택</string>
     <string name="autocrypt_incorrect_desktop">잘못된 설정 코드입니다. 다시 시도하십시오.</string>
     <string name="create_chat_error_desktop">대화를 만들 수 없습니다.</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -623,49 +623,10 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Grupės pavadinimas pasikeitė iš \"%1$s\" į \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Grupės paveikslas pakeistas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Grupės paveikslas ištrintas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Dalyvis %1$s pridėtas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Dalyvis %1$s pašalintas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Išeita iš grupės.</string>
     <string name="systemmsg_read_receipt_subject">Pranešimas apie skaitymą</string>
     <string name="systemmsg_read_receipt_body">Tai yra pranešimas apie žinutės \"%1$s\" skaitymą.\n\nTai reiškia, kad žinutė buvo atvaizduota gavėjo įrenginyje, tačiau neužtikrina, kad jos turinys buvo perskaitytas.</string>
     <string name="systemmsg_cannot_decrypt">Nepavyksta iššifruoti šios žinutės.\n\n• Galima, tiesiog, atsakyti į šią žinutę ir paprašyti siuntėjo dar kartą išsiųsti šią žinutę.\n\n• Tuo atveju, jeigu iš naujo įdiegėte Delta Chat ar kitą el. pašto programą šiame ar kitame įrenginyje, jūs galite pageidauti išsiųsti Autocrypt sąrankos žinutę iš to įrenginio.</string>
     <string name="systemmsg_subject_for_new_contact">Žinutė nuo %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Išnykstančių žinučių laikmatis išjungtas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Išnykstančių žinučių laikmatis nustatytas į %1$s sek.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Išnykstančių žinučių laikmatis nustatytas į 1 minutę.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Išnykstančių žinučių laikmatis nustatytas į 1 valandą.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Išnykstančių žinučių laikmatis nustatytas į 1 dieną.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Išnykstančių žinučių laikmatis nustatytas į 1 savaitę.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Išnykstančių žinučių laikmatis nustatytas į 4 savaites.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Išnykstančių žinučių laikmatis nustatytas į %1$s min.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Išnykstančių žinučių laikmatis nustatytas į %1$s val.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Išnykstančių žinučių laikmatis nustatytas į %1$s d.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Išnykstančių žinučių laikmatis nustatytas į %1$s sav.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Pokalbio apsauga išjungta.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Pokalbio apsauga įjungta.</string>
-
     <string name="group_image_deleted_by_you">Jūs ištrynėte grupės paveikslą.</string>
     <!-- %1$s will be replaced by name and address of the contact -->
     <string name="group_image_deleted_by_other">%1$s ištrynė grupės paveikslą.</string>
@@ -811,4 +772,6 @@
     <string name="perm_enable_bg_already_done">Jūs jau leidote Delta Chat gauti žinutes fone.\n\nJei žinutės vis tiek nepristatomos fone, patikrinkite taip pat savo sistemos nustatymus.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -370,25 +370,9 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Gruppenavn endret fra \"%1$s\" til \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Gruppebilde endret.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Gruppebilde slettet.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Medlem %1$s lagt til.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Medlem %1$s fjernet.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Gruppe oppløst.</string>
     <string name="systemmsg_read_receipt_subject">Meldingskvittering</string>
     <string name="systemmsg_read_receipt_body">Dette er en meldingskvittering for meldingen \"%1$s\".\n\nDenne meldingskvitteringen bekrefter bare at meldingen ble vist på mottakerens enhet. Det finnes ingen garanti for at mottakeren har lest meldingsinnholdet.</string>
     <string name="systemmsg_cannot_decrypt">Denne meldingen kan ikke dekrypteres.\n\n• Det kan hjelpe å svare på denne meldingen og spørre avsenderen om å sende den igjen.\n\n• I fall du har reinstallert Delta Chat eller et annet e-postprogram på denne eller en annen enhet, kan du sende en Autocrypt-oppsettsmelding derfra.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s av meg.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s av %2$s.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Gruppenavn endret fra \"%1$s\" til \"%2$s\" av meg.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -458,4 +442,6 @@
     <string name="autocrypt_key_transfer_desktop">Autocrypt-nøkkeloverføring</string>
     <string name="initiate_key_transfer_desktop">The Autocrypt-nøkkeloverføring krever at e-postklienten på den andre enheten er Autocrypt-kompatibel.\n\nDu kan så sende din hemmelige nøkkel til deg selv. Nøkkelen vil bli kryptert av en oppsettskode som vises her og må skrives inn på den andre enheten.</string>
     <string name="export_backup_desktop">Eksporter sikkerhetskopi</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -717,56 +717,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Groepsnaam gewijzigd van \"%1$s\" in \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Groepsafbeelding gewijzigd.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Groepsafbeelding verwijderd.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">‘%1$s’ is toegevoegd.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">‘%1$s’ is verwijderd.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Groep verlaten.</string>
     <string name="systemmsg_read_receipt_subject">Leesbevestiging</string>
     <string name="systemmsg_read_receipt_body">Het door jou verstuurde bericht, “%1$s”, heeft het scherm van de ontvanger bereikt.\n\nDit betekent echter niet dat het ook gelezen is.</string>
     <string name="systemmsg_cannot_decrypt">Dit bericht kan niet worden ontsleuteld.\n\n• Het kan helpen dit bericht te beantwoorden en de afzender te vragen het opnieuw te versturen.\n\n• Als je Delta Chat of een andere e-mailapp opnieuw hebt geïnstalleerd op dit of een ander apparaat, verstuur het instelbericht dan opnieuw.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s door mij.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s door %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Dit gesprek bevat een onbekende afzender. Zie ‘Informatie’ voor meer informatie.</string>
     <string name="systemmsg_subject_for_new_contact">Bericht van %1$s</string>
     <string name="systemmsg_failed_sending_to">Het bericht kan niet worden verstuurd aan %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">De tijdklok van verdwijnende berichten is uitgeschakeld.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">De tijdklok van verdwijnende berichten is ingesteld op %1$s sec.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">De tijdklok van verdwijnende berichten is ingesteld op 1 minuut.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">De tijdklok van verdwijnende berichten is ingesteld op 1 uur.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">De tijdklok van verdwijnende berichten is ingesteld op 1 dag.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">De tijdklok van verdwijnende berichten is ingesteld op 1 week.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">De tijdklok van verdwijnende berichten is ingesteld op 4 weken.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">De tijdklok van verdwijnende berichten is ingesteld op %1$s minuten.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">De tijdklok van verdwijnende berichten is ingesteld op %1$s uur.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">De tijdklok van verdwijnende berichten is ingesteld op %1$s dagen.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">De tijdklok van verdwijnende berichten is ingesteld op %1$s weken.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Gespreksbeveiliging is uitgeschakeld.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Gespreksbeveiliging is ingeschakeld.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Je hebt de groepsnaam gewijzigd. Oude naam: “%1$s” - Nieuwe naam: “%2$s”</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1058,6 +1014,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Sneller en stabieler. Dát zijn de kernpunten van versie 1.30.\n\n We hebben ruim 15 bugs opgelost. Neem het wijzigingslog door om te zien of er eentje tussenstaat waar je last van had: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -738,56 +738,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Zmieniono nazwę grupy z \"%1$s\" na \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Zmieniono obraz grupy.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Usunięto obraz grupy.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Dodano członka %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Usunięto członka %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Grupa opuszczona.</string>
     <string name="systemmsg_read_receipt_subject">Potwierdzenie odczytu</string>
     <string name="systemmsg_read_receipt_body">To jest potwierdzenie odczytu dla wiadomości ”%1$s„.\n\nTo potwierdzenie odczytu tylko informuje, że wiadomość została wyświetlona na urządzeniu odbiorcy. Nie ma gwarancji, że odbiorca przeczytał treść wiadomości.</string>
     <string name="systemmsg_cannot_decrypt">Tej wiadomości nie można odszyfrować.\n\n• Możesz teraz pomóc odpowiadając po prostu na tą wiadomość i poprosić nadawcę o ponowne wysłanie wiadomości.\n\n• W przypadku ponownego zainstalowania Delta Chat lub innego programu mailowego na tym lub innym urządzeniu, może być konieczne wysłanie stąd klucza automatycznego szyfrowania.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s przeze mnie.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s przez %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Nieznany nadawca tego czatu. Więcej szczegółów znajdziesz w sekcji „Informacje”.</string>
     <string name="systemmsg_subject_for_new_contact">Wiadomość od %1$s</string>
     <string name="systemmsg_failed_sending_to">Nie udało się wysłać wiadomości do %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Wyłączono zegar znikających wiadomości.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Ustawiono zegar znikających wiadomości na %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Ustawiono zegar znikających wiadomości na 1 minutę.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Ustawiono zegar znikających wiadomości na 1 godzinę.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Ustawiono zegar znikających wiadomości na 1 dzień.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Ustawiono zegar znikających wiadomości na 1 tydzień.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Ustawiono zegar znikających wiadomości na 4 tygodnie.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Ustawiono zegar znikających wiadomości na czas %1$s minut.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Ustawiono zegar znikających wiadomości na czas %1$s godzin.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Ustawiono zegar znikających wiadomości na czas %1$s dni.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Ustawiono zegar znikających wiadomości na czas %1$s tygodni.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Ochrona czatu wyłączona.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Ochrona czatu włączona.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Zmieniono nazwę grupy z \"%1$s\" na \"%2$s\" przeze mnie.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1064,7 +1020,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Szybciej. Bardziej stabilnie.\n\nW wersji 1.30 skupiliśmy się na szybkości i niezawodności, naprawiając dziesiątki błędów. Sprawdź nasze dzienniki zmian, może twój najważniejszy został naprawiony:
-https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -732,56 +732,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Nome do grupo alterado de \"%1$s\" para \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Avatar do grupo modificado.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Avatar do grupo apagado.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Participante %1$s adicionado.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Participante %1$s removido.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Grupo abandonado.</string>
     <string name="systemmsg_read_receipt_subject">Confirmação de leitura</string>
     <string name="systemmsg_read_receipt_body">Confirmação de recebimento da mensagem \"%1$s\".\n\nEsta confirmação somente assegura que a mensagem foi exibida no aparelho do destinatário, mas não há garantia de que ele tenha lido o seu conteúdo.</string>
     <string name="systemmsg_cannot_decrypt">Impossível descriptografar esta mensagem.\n\n• Pode resolver pedir que ela seja reenviada.\n\n• Caso você tenha reinstalado o Delta Chat ou outro programa de e-mail, neste ou noutro dispositivo, será necessário enviar uma \"mensagem de configuração do Autocrypt\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s por mim.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s por %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Remetente desconhecido para esta conversa. Veja \'informações\' para mais detalhes.</string>
     <string name="systemmsg_subject_for_new_contact">Mensagem de %1$s</string>
     <string name="systemmsg_failed_sending_to">Falha ao enviar mensagem para %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Temporizador de desaparecimento de mensagens desativado.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Temporizador de desaparecimento de mensagens definido para %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Temporizador de desaparecimento de mensagens definido para 1 minuto.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Temporizador de desaparecimento de mensagens definido para 1 hora.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Temporizador de desaparecimento de mensagens definido para 1 dia.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Temporizador de desaparecimento de mensagens definido para 1 semana.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Temporizador de desaparecimento de mensagens definido para 4 semanas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Temporizador de mensagens que desaparecem definido para %1$s minutos.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Temporizador de mensagens que desaparecem definido para %1$s horas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Temporizador de mensagens que desaparecem definido para %1$s dias.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Temporizador de mensagens que desaparecem definido para %1$s semanas.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Proteção da conversa desligada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Proteção da conversa ligada.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Você mudou o nome do grupo de \"%1$s\" para \"%2$s\".</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1064,7 +1020,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Mais rápido. Mais estável.\n\nPara as versões 1.30, nos concentramos em velocidade e confiabilidade, corrigindo dezenas de bugs. Verifique nossos changelogs para ver se o seu bug favorito foi corrigido: https://get.delta.chat/#changelogs 🚀
-</string>
 
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -323,25 +323,9 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">O nome do grupo mudou de \"%1$s\" para \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Imagem do grupo modificada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Imagem do grupo apagada.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Membro %1$s adicionado.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Membro %1$s removido.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Saíu do grupo.</string>
     <string name="systemmsg_read_receipt_subject">Ler recibos</string>
     <string name="systemmsg_read_receipt_body">Este é um recibo de confirmação de leitura da mensagem \"%1$s\".\n\nEsta mensagem foi exibida no dispositivo do destinatário, não necessariamente que o conteúdo foi lido.</string>
     <string name="systemmsg_cannot_decrypt">Esta mensagem não pode ser descriptada.\n\n • Talvez seja útil simplesmente responder a esta mensagem e solicitar que o remetente envie a mensagem novamente.\n\n • Caso você tenha re-instalado o Delta Chat ou outro programa de e-mail neste ou noutro dispositivo poderá querer enviar uma mensagem de configuração Autocrypt do dispositvo.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s por mim.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s por %2$s.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">O nome do grupo mudou de \"%1$s\" para \"%2$s\" por mim.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -444,4 +428,6 @@
     <string name="menu.view.developer.open.log.folder">Abrir pasta de Log</string>
     <string name="menu.view.developer.open.current.log.file">Abrir o aqrquio do log actual</string>
     <string name="perm_enable_bg_reminder_title">Toque aqui para receber mensagens mesmo que o Delta Chat esteja em segundo plano.</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -741,56 +741,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Название группы изменено с «%1$s» на «%2$s».</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Изображение группы изменено.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Изображение группы удалено.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Добавлен участник %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Участник %1$s удалён.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Группа покинута.</string>
     <string name="systemmsg_read_receipt_subject">Уведомление о прочтении</string>
     <string name="systemmsg_read_receipt_body">Это подтверждение того, что сообщение \"%1$s\" было открыто на устройстве получателя. Данное подтверждение не означает, что сообщение было прочитано.</string>
     <string name="systemmsg_cannot_decrypt">Это сообщение не может быть расшифровано.\n\n• Возможно, поможет просто ответить на это сообщение и попросить отправителя отправить сообщение еще раз.\n\n • В случае, если вы переустановили Delta Chat или другую почтовую программу на этом или другом устройстве, возможно, вы захотите отправить сообщение с параметрами Autocrypt оттуда.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s мной.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s пользователем %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Неизвестный отправитель для данного чата. Смотрите \"информацию\" для подробностей.</string>
     <string name="systemmsg_subject_for_new_contact">Сообщение от %1$s</string>
     <string name="systemmsg_failed_sending_to">Не удалось отправить сообщение %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Таймер исчезающих сообщений отключён.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Таймер исчезающих сообщений установлен на %1$s с.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Таймер исчезающих сообщений установлен на 1 минуту.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Таймер исчезающих сообщений установлен на 1 час.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Таймер исчезающих сообщений установлен на 1 день.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Таймер исчезающих сообщений установлен на 1 неделю.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Таймер исчезающих сообщений установлен на 4 недели.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Таймер исчезающих сообщений установлен на %1$s минут.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Таймер исчезающих сообщений установлен на %1$s часов.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Таймер исчезающих сообщений установлен на %1$s дней.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Таймер исчезающих сообщений установлен на %1$s недель.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Защита чата отключена.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Защита чата включена</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Вы изменили название группы с «%1$s» на «%2$s».</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1074,6 +1030,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Быстрее. Стабильнее.\n\nВ релизах 1.30 мы сфокусировались на скорости и надежности, исправили десятки ошибок. Подробнее смотрите в списках изменений: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-sc/strings.xml
+++ b/res/values-sc/strings.xml
@@ -502,4 +502,6 @@
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Connessione de isfundu de fide</string>
     <string name="pref_reliable_service_explain">Tenet bisòngiu de una notìfica permanente</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -718,56 +718,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Názov skupiny sa zmenil z „%1$s“ na „%2$s“.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Skupinový obrázok sa zmenil.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Skupinový obrázok bol odstránený.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Člen %1$s pridaný.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Člen %1$s bol odstránený.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Skupina odišla.</string>
     <string name="systemmsg_read_receipt_subject">Správa otvorená</string>
     <string name="systemmsg_read_receipt_body">%1$s Správa, ktorú ste poslali, sa zobrazila na obrazovke príjemcu.\n\nZaručujeme, že obsah nebol prečítaný.</string>
     <string name="systemmsg_cannot_decrypt">Túto správu nie je možné dešifrovať.\n\n• Už by mohlo pomôcť jednoducho odpovedať na túto správu a požiadať odosielateľa, aby správu odoslal znova.\n\n• V prípade, že ste na ňu znova nainštalovali program Delta Chat alebo iný e-mailový program alebo iné zariadenie, z ktorého budete pravdepodobne chcieť odoslať správu o nastavení automatického šifrovania.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s mnou.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s od %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Neznámy odosielateľ pre túto konverzáciu. Ďalšie informácie nájdete v časti „Informácie“.</string>
     <string name="systemmsg_subject_for_new_contact">Správa od %1$s</string>
     <string name="systemmsg_failed_sending_to">Správu sa nepodarilo odoslať %1$s .</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Časovač zmiznutia správ je deaktivovaný.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Časovač zmiznutia správ nastavený na %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Časovač zmiznutia správ bol nastavený na 1 minútu.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Časovač zmiznutia správ bol nastavený na 1 hodinu.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Časovač zmiznutia správ nastavený na 1 deň.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Časovač zmiznutia správ nastavený na 1 týždeň.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Časovač zmiznutia správ nastavený na 4 týždne.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Časovač zmiznutia správ bol nastavený na %1$s minúty.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Časovač zmiznutia správ bol nastavený na %1$s hodiny.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Časovač zmiznutia správ nastavený na %1$s dni.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Časovač zmiznutia správ nastavený na %1$s týždne.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Ochrana konverzácií je vypnutá.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Ochrana konverzácií je zapnutá.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Názov skupiny sa zmenil z „%1$s“ na „%2$s“ mnou.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1032,6 +988,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Rýchlejší. Stabilnejší.\n\nVo vydaní 1.30 sme sa zamerali na rýchlosť a spoľahlivosť, opravili sme desiatky chýb. Prečítajte si prehľad o zmenách a pozrite sa, či sme opravili vašu obľúbenú chybu: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-sq/strings.xml
+++ b/res/values-sq/strings.xml
@@ -714,56 +714,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Emri i grupit u ndryshua nga \"%1$s\" në \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Figura e grupit ndryshoi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Figura e grupit u fshi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">U shtua anëtari %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">U hoq anëtari %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">U braktis grupi.</string>
     <string name="systemmsg_read_receipt_subject">Dëftesë leximi</string>
     <string name="systemmsg_read_receipt_body">Kjo është dëftesë leximi për mesazhin \"%1$s\".\n\nDo të thotë që mesazhi u shfaq te pajisja e marrësit, jo domosdo që lënda u lexua.</string>
     <string name="systemmsg_cannot_decrypt">Ky mesazh s\’mund të shfshehtëzohet.\n\n• Mundet që të ndihmojë dërgimi thjesht i një përgjigjeje këtij mesazhi dhe t\’i kërkohet dërguesit ta ridërgojë mesazhin.\n\n• Në rast se ri-instaluat Delta Chat-in apo një tjetër program email-esh në këtë apo në një tjetër pajisje, mund të donit të dërgonit një Mesazh Rregullimi Autocrypt-i që prej andej.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s nga unë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s nga %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Dërgues i panjohur për këtë fjalosje. Për më tepër hollësi, shihni \'info\'.</string>
     <string name="systemmsg_subject_for_new_contact">Mesazh nga %1$s</string>
     <string name="systemmsg_failed_sending_to">S’u arrit të dërgohej mesazh te %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Kohëmatësi për mesazhe që zhduken është i çaktivizuar.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Kohëmatësi i zhdukjes së mesazheve është vënë në %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Kohëmatësi për mesazhe që zhduken është vënë në 1 minutë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Kohëmatësi për mesazhe që zhduken është vënë në 1 orë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Kohëmatësi për mesazhe që zhduken është vënë në 1 ditë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Kohëmatësi për mesazhe që zhduken është vënë në 1 javë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Kohëmatësi për mesazhe që zhduken është vënë në 4 javë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Kohëmatësi për mesazhe që zhduken është vënë në %1$s minuta.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Kohëmatësi për mesazhe që zhduken është vënë në %1$s orë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Kohëmatësi i zhdukjes së mesazheve është vënë në %1$s ditë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Kohëmatësi për mesazhe që zhduken është vënë në %1$s javë.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Mbrojtja e fjalosjes u çaktivizua.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Mbrojtja e fjalosjes u aktivizua.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">E ndryshuat emrin e grupit nga “%1$s” në “%2$s”.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1053,6 +1009,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Më shpejtë. Me më tepër qëndrueshmëri.\n\nPër hedhjet në qarkullim të serisë 1.30, u përqendruam në shpejtësinë dhe qëndrueshmërinë, duke ndrequr dhjetëra. Shihni regjistrat tanë të ndryshimeve, për të parë nëse e juaja është ndrequr: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -293,23 +293,6 @@
     <string name="autocrypt_asm_subject">Порука поставки за аутошфровање</string>
     <string name="autocrypt_continue_transfer_title">Порука поставки за аутошфровање</string>
     <string name="autocrypt_continue_transfer_retry">Покушај поново</string>
-    <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Назив групе је измењен из „%1$s“ у „%2$s“.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Слика групе је промењена.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Слика групе је обрисана.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Члан %1$s је додат.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Члан %1$s је уклоњен.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Група напуштена.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s од мене.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s од стране %2$s.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Назив групе је измењен из „%1$s“ у „%2$s“ од мене.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -368,4 +351,6 @@
     <string name="save_desktop">Сачувај</string>
     <string name="name_desktop">Име</string>
     <string name="export_backup_desktop">Извези резервну копију</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -545,43 +545,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Gruppnamnet ändrades från \"%1$s\" till \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Gruppbilden ändrades.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Gruppbilden togs bort.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Medlemmen %1$s lades till.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Medlemmen %1$s togs bort.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Grupp lämnade.</string>
     <string name="systemmsg_read_receipt_subject">Meddelande öppnat</string>
     <string name="systemmsg_read_receipt_body">\"%1$s\" meddelandet du skickade visades på mottagarens skärm.\n\nDet är ingen garanti för att innehållet har lästs.</string>
     <string name="systemmsg_cannot_decrypt">Meddelandet kan inte avkrypteras.\n\n• Det kanske kan hjälpa, att svara på detta meddelande och be avsändaren skicka det igen.\n\n• Ifall du har ominstallerat Delta Chat eller något annat e-postprogram på denna eller någon annan enhet, kanske du behöver skicka ett nytt Autocryp inställningsmeddelande därifrån.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s av mig.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s av %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Okänd avsändare för denna chatt. Se info för fler detaljer.</string>
     <string name="systemmsg_subject_for_new_contact">Meddelande från %1$s</string>
     <string name="systemmsg_failed_sending_to">Kunde inte skicka meddelande till %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Tiduret för meddelandeborttagning är inaktiverat.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Tiduret för meddelandeborttagning är satt till %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Tiduret för meddelandeborttagning är satt till 1 minut.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Tiduret för meddelandeborttagning är satt till 1 timma.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Tiduret för meddelandeborttagning är satt till 1 dag.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Tiduret för meddelandeborttagning är satt till 1 vecka.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Tiduret för meddelandeborttagning är satt till 4 veckor.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Gruppnamnet ändrades från \"%1$s\" till \"%2$s\" av mig.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -746,4 +715,6 @@
     <string name="perm_enable_bg_already_done">Du har redan gett Delta Chatt tillstånd att ta emot meddelanden i bakgrunden.\n\nKontrollera dina systeminställningar också, om det fortfarande inte kommer några meddelanden i bakgrunden.</string>
 
 
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -221,16 +221,6 @@
     <string name="pref_background">அரட்டை பின்புலம்</string>
     <string name="autocrypt_continue_transfer_please_enter_code">மற்ற சாதனத்தில் காணப்படும் அமைப்பு குறியீடை தயவு செய்து உள்ளீடவும்</string>
     <string name="autocrypt_continue_transfer_retry">மீண்டும் முயற்சி செய்யவும்</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">குழு படம் மாற்றப்பட்டது.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">குழு படம் நீக்கப்பட்டது</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added"> %1$s உறுப்பினராக சேர்க்கப்பட்டார்</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">உறுப்பினர் %1$s நீக்கப்பட்டார்</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">குழுவில் இருந்து வெளியேறினது</string>
     <string name="qrscan_fingerprint_label">கைரேகைகள்</string>
     <string name="notify_reply_button">மறுமொழி</string>
     <string name="notify_new_message">புதிய செய்தி</string>
@@ -258,4 +248,6 @@
     <string name="remove_desktop">நீக்கு</string>
     <string name="save_desktop">சேமி</string>
     <string name="name_desktop">பெயர்</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-te/strings.xml
+++ b/res/values-te/strings.xml
@@ -188,10 +188,6 @@
     <string name="pref_backup">బ్యాకప్</string>
     <string name="pref_managekeys_export_secret_keys">రహస్య కీలను ఎగుమతి చెయి</string>
     <string name="pref_background">చాట్ నేపధ్యం</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s నా‌ ద్వరా</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s చే %2$s.</string>
     <string name="qrscan_fingerprint_label">ఫింగర్‌ప్రింట్స్</string>
     <string name="notify_reply_button">జవాబు</string>
     <string name="notify_new_message">కొత్త సందేశం</string>
@@ -218,4 +214,6 @@
     <string name="remove_desktop">తొలగించు</string>
     <string name="save_desktop">భద్రపరుచు</string>
     <string name="export_backup_desktop">బ్యాకప్ ఎగుమతి చెయి</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -717,56 +717,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">\"%1$s\" grup adı \"%2$s\" olarak değiştirildi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Grup görseli değiştirildi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Grup görseli silindi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">%1$s üyesi eklendi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">%1$s üyesi kaldırıldı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Gruptan ayrılındı.</string>
     <string name="systemmsg_read_receipt_subject">İleti açıldı</string>
     <string name="systemmsg_read_receipt_body">Gönderdiğiniz \"%1$s\" iletisi alıcının ekranında görüntülendi.\n\nBu, içeriğin okunduğunun güvencesi değildir.</string>
     <string name="systemmsg_cannot_decrypt">Bu iletinin şifresi çözülemiyor.\n\n• Bu iletiye basitçe yanıt vermek ve gönderene iletiyi yeniden gönderip gönderemeyeceğini sormak zaten yardımcı olabilir.\n\n• Delta Chat\'i ya da başka bir e-posta programını bu ya da başka bir aygıta yeniden kurduysanız, oradan bir Autocrypt Ayarlama İletisi göndermek isteyebilirsiniz.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">Benim tarafımdan %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%2$s tarafından %1$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Bu sohbet için bilinmeyen gönderen. Daha fazla ayrıntı için \'bilgi\'ye bakın.</string>
     <string name="systemmsg_subject_for_new_contact">%1$s kişisinden gelen ileti</string>
     <string name="systemmsg_failed_sending_to">%1$s kişisine ileti gönderme başarısız.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Kaybolan iletiler zamanlayıcısı etkisizleştirildi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Kaybolan iletiler zamanlayıcısı %1$s sn olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Kaybolan iletiler zamanlayıcısı 1 dakika olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Kaybolan iletiler zamanlayıcısı 1 saat olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Kaybolan iletiler zamanlayıcısı 1 gün olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Kaybolan iletiler zamanlayıcısı 1 hafta olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Kaybolan iletiler zamanlayıcısı 4 hafta olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Kaybolan iletiler zamanlayıcısı %1$s dakika olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Kaybolan iletiler zamanlayıcısı %1$s saat olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Kaybolan iletiler zamanlayıcısı %1$s gün olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Kaybolan iletiler zamanlayıcısı %1$s hafta olarak ayarlandı.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Sohbet koruması etkisizleştirildi.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Sohbet koruması etkinleştirildi.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">\"%1$s\" grup adını \"%2$s\" olarak değiştirdiniz.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1058,6 +1014,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Daha hızlı. Daha kararlı.\n\n1.30 sürümleri için hıza ve güvenilirliğe odaklandık, düzinelerce hata düzeltildi. Favorilerinizden biri düzeltildiyse değişiklik günlüklerimizi denetleyin: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -747,56 +747,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Назву групи змінено з «%1$s» на «%2$s».</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Зображення групи змінено.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Зображення групи видалено.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Додано учасника %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Видалено учасника %1$s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Ви залишили групу.</string>
     <string name="systemmsg_read_receipt_subject">Сповіщення про прочитання.</string>
     <string name="systemmsg_read_receipt_body">Це підтвердження того, що повідомлення «%1$s» було відкрито на пристрої одержувача. Дане підтвердження не означає, що повідомлення було прочитано.</string>
     <string name="systemmsg_cannot_decrypt">Це повідомлення не може бути розшифроване.\n\n• Можливо, має сенс просто відповісти на нього і попросити відправника повторно відправити повідомлення.\n\n• У випадку, якщо Ви переустановили Delta Chat або іншу поштову програму на цьому або іншому пристрої, Ви, можливо, захочете відправити повідомлення з параметрами Autocrypt звідти.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s мною.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s користувачем %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Невідомий відправник для цього чату. Дивіться \"Інформацію\" для деталей.</string>
     <string name="systemmsg_subject_for_new_contact">Повідомлення від %1$s</string>
     <string name="systemmsg_failed_sending_to">Неможлива надіслати повідомлення до %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Вимкнено таймер зникнення повідомлень</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Таймер зникнення повідомлень встановлено на %1$s с.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Таймер зникнення повідомлень встановлено на 1 хвилину.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Таймер зникнення повідомлень встановлено на 1 годину.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Таймер зникнення повідомлень встановлено на 1 день.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Таймер зникнення повідомлень встановлено на 1 тиждень.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Таймер зникнення повідомлень встановлено на 4 тижні.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Таймер повідомлень, що зникають встановлено на %1$s хвилин.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Таймер повідомлень, що зникають встановлено на %1$s годин.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Таймер повідомлень, що зникають встановлено на %1$s днів.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Таймер повідомлень, що зникають встановлено на %1$s тижнів.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Захист чату вимкнено.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Захист чату увімкнено.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Ви змінили назву групи з «%1$s» на «%2$s».</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1084,6 +1040,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Швидший. Стабільніший.\n\nДля релізів 1.30, ми зосередилися на швидкості та надійності, виправивши десятки помилок. Перегляньте наші журнали змін: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -702,56 +702,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">已更改群组名称：从“%1$s”更改为\"%2$s\"</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">已更改群组图像</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">已删除群组图像</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">已添加成员 %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">已移除成员 %1$s </string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">已离开群组</string>
     <string name="systemmsg_read_receipt_subject">消息已被打开</string>
     <string name="systemmsg_read_receipt_body">您发送的“%1$s”消息已在接收者的屏幕上显示过。\n\n这并不保证内容已被阅读。</string>
     <string name="systemmsg_cannot_decrypt">此消息无法解密。\n\n• 简单回复此消息并要求发送者重发该消息可能会有所帮助。\n\n• 如果您在此设备或其他设备上重新安装了 Delta Chat 或其他电子邮件程序，则可能需要从别处发送 Autocrypt 设置消息。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">我 %1$s。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%2$s %1$s。</string>
     <string name="systemmsg_unknown_sender_for_chat">此聊天发送者未知。查看“信息”来获取更多详情。</string>
     <string name="systemmsg_subject_for_new_contact">来自 %1$s 的消息</string>
     <string name="systemmsg_failed_sending_to">发送消息给 %1$s 失败。</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">已禁用消息定时销毁计时器</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">设置消息定时销毁计时器为 %1$s 秒</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">设置消息定时销毁计时器为 1 分钟</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">设置消息定时销毁计时器为 1 小时</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">设置消息定时销毁计时器为 1 天</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">设置消息定时销毁计时器为 1 周</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">设置消息定时销毁计时器为 4 周</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">设置消息定时销毁计时器为 %1$s 分钟</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">设置消息定时销毁计时器为 %1$s 小时</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">设置消息定时销毁计时器为 %1$s 天</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">设置消息定时销毁计时器为 %1$s 周</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">已禁用聊天保护</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">已启用聊天保护</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">你将群名称从 \"%1$s\"改为了\"%2$s\"。</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -1043,6 +999,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">更快。更稳定。\n\n对于 1.30 版本，我们专注于速度和可靠性，修复了几十个 bug。查看我们的更新记录，了解你曾遇到的 bug 是否已经修复： https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -494,25 +494,9 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">群組名稱已從 %1$s 更改為 %2$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">已更改群組圖片。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">已刪除群組圖片。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">已新增成員 %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">已移除成員 %1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">已退出群組。</string>
     <string name="systemmsg_read_receipt_subject">收執回條</string>
     <string name="systemmsg_read_receipt_body">這是訊息 %1$s 的收執回條，表示本訊息已經顯示在收件人的裝置上了，但不代表收件人已讀。</string>
     <string name="systemmsg_cannot_decrypt">本訊息無法解密。\n\n請試著回覆本訊息，並請發送者重發一遍。\n\n如果你曾經在本裝置或其它裝置重新安裝 Delta Chat 或其它郵件軟體的話，請重新發送AutoCrypt設定訊息。</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">我%1$s</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%2$s%1$s</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">我群組名稱已從 %1$s 更改為 %2$s</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->
@@ -537,4 +521,6 @@
     <!-- This text is shown inside the "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by name and address eg. "Scan to chat with Alice (alice@example.org)" -->
     <string name="qrshow_join_contact_hint">掃描 QRCode 以新增 %1$s</string>
     <string name="forget_login_confirmation_desktop">確定要刪除這裡的登入嗎? 所有的設定都會被刪除，包括端到端加密設定、聯絡人、對話、訊息、媒體檔案等。本動作不能復原。</string>
-    </resources>
+    <!-- device messages for updates -->
+
+</resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -717,56 +717,12 @@
 
 
     <!-- system messages -->
-    <!-- deprecated -->
-    <string name="systemmsg_group_name_changed">Group name changed from \"%1$s\" to \"%2$s\".</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_changed">Group image changed.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_image_deleted">Group image deleted.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_added">Member %1$s added.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_member_removed">Member %1$s removed.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_group_left">Group left.</string>
     <string name="systemmsg_read_receipt_subject">Message opened</string>
     <string name="systemmsg_read_receipt_body">The \"%1$s\" message you sent was displayed on the screen of the recipient.\n\nThis is no guarantee the content was read.</string>
     <string name="systemmsg_cannot_decrypt">This message cannot be decrypted.\n\n• It might already help to simply reply to this message and ask the sender to send the message again.\n\n• In case you re-installed Delta Chat or another e-mail program on this or another device you may want to send an Autocrypt Setup Message from there.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_me">%1$s by me.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_action_by_user">%1$s by %2$s.</string>
     <string name="systemmsg_unknown_sender_for_chat">Unknown sender for this chat. See \'info\' for more details.</string>
     <string name="systemmsg_subject_for_new_contact">Message from %1$s</string>
     <string name="systemmsg_failed_sending_to">Failed to send message to %1$s.</string>
-
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_disabled">Disappearing messages timer disabled.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_enabled">Disappearing messages timer set to %1$s s.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minute">Disappearing messages timer set to 1 minute.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hour">Disappearing messages timer set to 1 hour.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_day">Disappearing messages timer set to 1 day.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_week">Disappearing messages timer set to 1 week.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_four_weeks">Disappearing messages timer set to 4 weeks.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_minutes">Disappearing messages timer set to %1$s minutes.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_hours">Disappearing messages timer set to %1$s hours.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_days">Disappearing messages timer set to %1$s days.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_ephemeral_timer_weeks">Disappearing messages timer set to %1$s weeks.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_disabled">Chat protection disabled.</string>
-    <!-- deprecated -->
-    <string name="systemmsg_chat_protection_enabled">Chat protection enabled.</string>
-
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">You changed the group name from \"%1$s\" to \"%2$s\".</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1014,6 +1014,5 @@
 
 
     <!-- device messages for updates -->
-    <string name="update_1_30">Faster. More stable.\n\nFor 1.30 releases, we focused on speed and reliability, fixing dozens of bugs. Check our changelogs if your favorite one is fixed: https://get.delta.chat/#changelogs 🚀</string>
 
 </resources>


### PR DESCRIPTION
all systems use the new strings introduced by https://github.com/deltachat/deltachat-android/pull/2380 now; the old strings can be removed, esp. as they add quite some work and/or confusion to the translators.