### PR TITLE
use less muted color for "recently seen"

### DIFF
--- a/res/drawable/ic_circle_status.xml
+++ b/res/drawable/ic_circle_status.xml
@@ -3,6 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
 
-    <solid android:color="@color/green" />
+    <solid android:color="@color/recently_seen_dot" />
 
 </shape>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -54,6 +54,7 @@
     <color name="MediaOverview_Media_selected_overlay">#88000000</color>
 
     <color name="dummy_avatar_color">#808080</color>
+    <color name="recently_seen_dot">#34c759</color>
     <color name="slidearrow_color">#999999</color>
 
     <color name="universal_overlay">#55444444</color>


### PR DESCRIPTION
with the "connection view",
we already have a green indicating sth. as "online", reuse that. (the green used before is a bit too much of a muted color, this does not reflect "activity" well)

i came over that when [playing around with the layout on ios](https://github.com/deltachat/deltachat-ios/pull/1707); ios uses the same color now.

also many other apps use a similar, less muted green for "activity" or "online".

the difference is not huge on android, on ios it was larger - so this pr is mainly to keep things in sync.

before / after:


<img width=320 src=https://user-images.githubusercontent.com/9800740/193678902-33e10fc8-3ba6-4a67-a560-58f53b93f130.png> <img width=320 src=https://user-images.githubusercontent.com/9800740/193678893-f6bc9592-b4db-4ec5-9006-716a7f390e2e.png>

corresponding ios pr using the same color: https://github.com/deltachat/deltachat-ios/pull/1707

once merged, we should also add the color to the interface-repo and change it on desktop (that appears already "more active" by the white border, however)