### PR TITLE
use more modern methods to track connectivity changes

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -58,6 +58,11 @@ public class ApplicationContext extends MultiDexApplication {
   public NotificationCenter     notificationCenter;
   private JobManager            jobManager;
 
+  private int                   debugOnAvailableCount;
+  private int                   debugOnBlockedStatusChangedCount;
+  private int                   debugOnCapabilitiesChangedCount;
+  private int                   debugOnLinkPropertiesChangedCount;
+
   public static ApplicationContext getInstance(@NonNull Context context) {
     return (ApplicationContext)context.getApplicationContext();
   }
@@ -124,36 +129,35 @@ public class ApplicationContext extends MultiDexApplication {
 
     new ForegroundDetector(ApplicationContext.getInstance(this));
 
-    if (Build.VERSION.SDK_INT >= 24) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       ConnectivityManager connectivityManager =
         (ConnectivityManager) this.getSystemService(Context.CONNECTIVITY_SERVICE);
       connectivityManager.registerDefaultNetworkCallback(new ConnectivityManager.NetworkCallback() {
         @Override
         public void onAvailable(@NonNull android.net.Network network) {
-          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onAvailable() ++++++++++++++++++");
+          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onAvailable() #" + debugOnAvailableCount++);
           dcAccounts.maybeNetwork();
         }
 
         @Override
         public void onBlockedStatusChanged(@NonNull android.net.Network network, boolean blocked) {
-          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onBlockedStatusChanged() ++++++++++++++++++");
+          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onBlockedStatusChanged() #" + debugOnBlockedStatusChangedCount++);
         }
 
         @Override
         public void onCapabilitiesChanged(@NonNull android.net.Network network, NetworkCapabilities networkCapabilities) {
           // usually called after onAvailable(), so a maybeNetwork seems contraproductive
-          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onCapabilitiesChanged() ++++++++++++++++++");
+          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onCapabilitiesChanged() #" + debugOnCapabilitiesChangedCount++);
         }
 
         @Override
         public void onLinkPropertiesChanged(@NonNull android.net.Network network, LinkProperties linkProperties) {
-          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onLinkPropertiesChanged() ++++++++++++++++++");
+          Log.i("DeltaChat", "++++++++++++++++++ NetworkCallback.onLinkPropertiesChanged() #" + debugOnLinkPropertiesChangedCount++);
         }
       });
-    } else {
-      BroadcastReceiver networkStateReceiver = new NetworkStateReceiver();
-      registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
-    }
+    } // no else: use old method for debugging
+    BroadcastReceiver networkStateReceiver = new NetworkStateReceiver();
+    registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
 
     KeepAliveService.maybeStartSelf(this);
 

--- a/src/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
+++ b/src/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
@@ -5,11 +5,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
 import android.util.Log;
 
 import com.b44t.messenger.DcContext;
 
 public class NetworkStateReceiver extends BroadcastReceiver {
+
+    private int debugConnectedCount;
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -19,8 +22,9 @@ public class NetworkStateReceiver extends BroadcastReceiver {
             NetworkInfo ni = manager.getActiveNetworkInfo();
 
             if (ni != null && ni.getState() == NetworkInfo.State.CONNECTED) {
-                Log.i("DeltaChat", "++++++++++++++++++ Connected ++++++++++++++++++");
-                new Thread(() -> {
+                Log.i("DeltaChat", "++++++++++++++++++ Connected #" + debugConnectedCount++);
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                  new Thread(() -> {
                     // call dc_maybe_network() from a worker thread.
                     // theoretically, dc_maybe_network() can be called from the main thread and returns at once,
                     // however, in reality, it does currently halt things for some seconds.
@@ -28,7 +32,8 @@ public class NetworkStateReceiver extends BroadcastReceiver {
                     Log.i("DeltaChat", "calling maybeNetwork()");
                     DcHelper.getAccounts(context).maybeNetwork();
                     Log.i("DeltaChat", "maybeNetwork() returned");
-                }).start();
+                  }).start();
+                }
             }
         }
         catch (Exception e) {


### PR DESCRIPTION
use [`registerDefaultNetworkCallback()`](https://developer.android.com/reference/android/net/ConnectivityManager#registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback)) instead of [deprecated CONNECTIVITY_ACTION](https://developer.android.com/reference/android/net/ConnectivityManager#CONNECTIVITY_ACTION).

- there is also a [`registerNetworkCallback()`](https://developer.android.com/reference/android/net/ConnectivityManager#registerNetworkCallback(android.net.NetworkRequest,%20android.app.PendingIntent)) but according to [SO](https://stackoverflow.com/questions/53863034/difference-between-registerdefaultnetworkcallback-and-registernetworkcallback) , that is for less broader usage and won't catch "more".

- it is a bit unclear to me, if the other callbacks are needed, for now, we just log a line. just calling maybe_network everywhere would be too much, as eg. [`onCapabilitiesChanged()`](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#onCapabilitiesChanged(android.net.Network,%20android.net.NetworkCapabilities)) is called after [`onAvailable()`](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#onAvailable(android.net.Network)) ... but only since API 26.

there should be a review APK build by this pr - maybe this is sufficient for testing? cc @gerryfrancis @Gh0stz0x @link2xt - if not i can also build a "regular" APK tomorrow.

all in all, i am not sure if that fixes the issue. CONNECTIVITY_ACTION is deprecated - but it is still available. and it seems to be still in use by Signal as well. we'll see :)

targets #2400