### PR TITLE
bump targetSdkVersion to 32

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -63,7 +63,8 @@
               android:launchMode="singleTask"
               android:taskAffinity=""
               android:windowSoftInputMode="stateHidden"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+              android:exported="false">
 
         <intent-filter>
             <action android:name="android.intent.action.SEND" />
@@ -175,7 +176,8 @@
     <activity android:name=".NewConversationActivity"
               android:theme="@style/TextSecure.LightNoActionBar"
               android:windowSoftInputMode="stateHidden"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+              android:exported="false">
 
         <intent-filter>
             <data android:scheme="mailto"/>
@@ -197,7 +199,8 @@
     <activity android:name=".WelcomeActivity"
               android:launchMode="singleTask"
               android:theme="@style/TextSecure.LightNoActionBar"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+              android:exported="false">
         <intent-filter>
             <action android:name="android.intent.action.VIEW"/>
             <category android:name="android.intent.category.DEFAULT"/>
@@ -217,7 +220,8 @@
     <activity android:name=".RegistrationActivity"
               android:launchMode="singleTask"
               android:windowSoftInputMode="stateUnchanged"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+              android:exported="false">
         <intent-filter>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
@@ -367,7 +371,8 @@
         android:exported="false">
     </provider>
 
-    <receiver android:name=".service.BootReceiver">
+    <receiver android:name=".service.BootReceiver"
+        android:exported="false">
         <intent-filter>
             <action android:name="android.intent.action.BOOT_COMPLETED"/>
             <action android:name="org.thoughtcrime.securesms.RESTART"/>

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,16 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation 'androidx.preference:preference:1.2.0'
+    implementation ('androidx.preference:preference:1.2.0') {
+        exclude group: 'androidx.lifecycle', module:'lifecycle-viewmodel'
+        exclude group: 'androidx.lifecycle', module:'lifecycle-viewmodel-ktx'
+    }
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.5'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     implementation 'androidx.work:work-runtime:2.7.1'
     implementation 'com.google.android.exoplayer:exoplayer-core:2.9.6' // plays video and audio
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.6'

--- a/build.gradle
+++ b/build.gradle
@@ -22,21 +22,21 @@ repositories {
 }
 
 dependencies {
-    implementation 'androidx.sharetarget:sharetarget:1.1.0'
-    implementation 'androidx.webkit:webkit:1.4.0'
+    implementation 'androidx.sharetarget:sharetarget:1.2.0'
+    implementation 'androidx.webkit:webkit:1.5.0'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.5'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
-    implementation 'androidx.work:work-runtime:2.4.0'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.5.1'
+    implementation 'androidx.work:work-runtime:2.7.1'
     implementation 'com.google.android.exoplayer:exoplayer-core:2.9.6' // plays video and audio
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.6'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.journeyapps:zxing-android-embedded:3.4.0' // QR Code scanner
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.2' // used as JSON library
     implementation "me.leolin:ShortcutBadger:1.1.16" // display messagecount on the home screen icon.
@@ -46,7 +46,7 @@ dependencies {
     implementation 'com.caverock:androidsvg-aar:1.4' // SVG support.
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
-    annotationProcessor 'androidx.annotation:annotation:1.1.0'
+    annotationProcessor 'androidx.annotation:annotation:1.5.0'
     implementation 'com.makeramen:roundedimageview:2.1.0' // crops the avatars to circles
     implementation 'com.pnikosis:materialish-progress:1.5' // used only in the "Progress Wheel" in Share Activity.
     implementation 'com.soundcloud.android:android-crop:0.9.10@aar' // used in Group Select Avatar, should be unified with profie
@@ -73,11 +73,11 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.1'
     testImplementation 'org.powermock:powermock-classloading-xstream:1.6.1'
 
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'com.android.support:support-annotations:24.0.0'
 
     androidTestImplementation ('org.assertj:assertj-core:1.7.1') {

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 
 android {
     flavorDimensions "none"
-    compileSdkVersion 30
+    compileSdkVersion 32
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
@@ -99,7 +99,7 @@ android {
         multiDexEnabled true
 
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 32
 
         vectorDrawables.useSupportLibrary = true
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 
@@ -210,10 +210,10 @@ android {
             java.srcDirs = ['androidTest']
         }
     }
-
-     lintOptions {
+    lint {
         abortOnError false
     }
+
 }
 
 String buildConfigProperty(String name) {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.5.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.2.0'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation ('androidx.preference:preference:1.2.0') {
         exclude group: 'androidx.lifecycle', module:'lifecycle-viewmodel'
@@ -43,7 +43,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.6'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.journeyapps:zxing-android-embedded:3.4.0' // QR Code scanner
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.2' // used as JSON library
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1' // used as JSON library
     implementation "me.leolin:ShortcutBadger:1.1.16" // display messagecount on the home screen icon.
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9' // used in the emoji selector for the tab selection.
     implementation 'com.github.chrisbanes:PhotoView:2.1.3' // does the zooming on photos / media
@@ -69,8 +69,7 @@ dependencies {
         exclude group: 'com.google.android.gms'
     }
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.assertj:assertj-core:1.7.1'
     testImplementation 'org.mockito:mockito-core:1.9.5'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.1'
@@ -83,7 +82,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'com.android.support:support-annotations:24.0.0'
+    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
 
     androidTestImplementation ('org.assertj:assertj-core:1.7.1') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'

--- a/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
+++ b/src/org/thoughtcrime/securesms/connect/KeepAliveService.java
@@ -18,6 +18,7 @@ import android.util.Log;
 import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
+import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.Prefs;
 
 public class KeepAliveService extends Service {
@@ -92,7 +93,7 @@ public class KeepAliveService extends Service {
     private Notification createNotification()
     {
         Intent intent = new Intent(this, ConversationListActivity.class);
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
         // a notification _must_ contain a small icon, a title and a text, see https://developer.android.com/guide/topics/ui/notifiers/notifications.html#Required
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -37,6 +37,7 @@ import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.preferences.widgets.NotificationPrivacyPreference;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.BitmapUtil;
+import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -103,7 +104,7 @@ public class NotificationCenter {
     private PendingIntent getOpenChatlistIntent() {
         Intent intent = new Intent(context, ConversationListActivity.class);
         intent.putExtra(ConversationListActivity.CLEAR_NOTIFICATIONS, true);
-        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
 
     private PendingIntent getOpenChatIntent(int chatId) {
@@ -112,7 +113,7 @@ public class NotificationCenter {
         intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
         return TaskStackBuilder.create(context)
                 .addNextIntentWithParentStack(intent)
-                .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+                .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
 
     private PendingIntent getRemoteReplyIntent(int chatId) {
@@ -121,7 +122,7 @@ public class NotificationCenter {
         intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
         intent.putExtra(RemoteReplyReceiver.CHAT_ID_EXTRA, chatId);
         intent.setPackage(context.getPackageName());
-        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
 
     private PendingIntent getMarkAsReadIntent(int chatId, boolean markNoticed) {
@@ -130,7 +131,7 @@ public class NotificationCenter {
         intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
         intent.putExtra(MarkReadReceiver.CHAT_ID_EXTRA, chatId);
         intent.setPackage(context.getPackageName());
-        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
 
 

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -21,6 +21,7 @@ import androidx.core.content.ContextCompat;
 import org.thoughtcrime.securesms.DummyActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
+import org.thoughtcrime.securesms.util.IntentUtils;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -117,7 +118,7 @@ public final class GenericForegroundService extends Service {
                                                            .setTicker(active.contentText)
                                                            .setContentText(active.contentText)
                                                            .setProgress(active.progressMax, active.progress, active.indeterminate)
-                                                           .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, DummyActivity.class), 0))
+                                                           .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, DummyActivity.class), IntentUtils.FLAG_MUTABLE()))
                                                            .build());
   }
 

--- a/src/org/thoughtcrime/securesms/util/IntentUtils.java
+++ b/src/org/thoughtcrime/securesms/util/IntentUtils.java
@@ -1,10 +1,13 @@
 package org.thoughtcrime.securesms.util;
 
 
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 
 import java.util.List;
@@ -21,4 +24,11 @@ public class IntentUtils {
     context.startActivity(browserIntent);
   }
 
+  public static int FLAG_MUTABLE() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      return PendingIntent.FLAG_MUTABLE;
+    } else {
+      return 0;
+    }
+  }
 }


### PR DESCRIPTION
using `targetSdkVersion  32` is required for gplay **from Nov 2022** and requires some adaptions, see https://developer.android.com/google/play/requirements/target-sdk#pre12 ; some notes on the steps mentioned there:

- [x] bluetooth: we are not using bluetooth permissions at all
- [x] request the ACCESS_COARSE_LOCATION permission any time you request ACCESS_FINE_LOCATION: we are already doing this this way
- [x] set `android:exported` explicitly for indent filters in the manifest: done by a commit in this pr
- [x] hibernation (what happens if the app is not used for months): should be fine at a first glance
- [x] pending intent mutability: we set the flag with a helper function, see corresponding commit message for details

moreover, this PR updates gradle (i got weird errors with the old version) and androidx, at least the old sharetarget does not compile for API 32 (see https://developer.android.com/jetpack/androidx/releases/appcompat for androidx changelogs (select package on the left))

the updated androidx compat dependencies may also help on https://github.com/deltachat/deltachat-android/issues/2400

once this pr is merged, we can rebase and merge #2406 and do a release.