### PR TITLE
fix crash in share-to-delta and similar issues

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -177,7 +177,7 @@
               android:theme="@style/TextSecure.LightNoActionBar"
               android:windowSoftInputMode="stateHidden"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
-              android:exported="false">
+              android:exported="true">
 
         <intent-filter>
             <data android:scheme="mailto"/>
@@ -200,7 +200,7 @@
               android:launchMode="singleTask"
               android:theme="@style/TextSecure.LightNoActionBar"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
-              android:exported="false">
+              android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.VIEW"/>
             <category android:name="android.intent.category.DEFAULT"/>
@@ -221,7 +221,7 @@
               android:launchMode="singleTask"
               android:windowSoftInputMode="stateUnchanged"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
-              android:exported="false">
+              android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
@@ -372,7 +372,7 @@
     </provider>
 
     <receiver android:name=".service.BootReceiver"
-        android:exported="false">
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.BOOT_COMPLETED"/>
             <action android:name="org.thoughtcrime.securesms.RESTART"/>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -64,7 +64,7 @@
               android:taskAffinity=""
               android:windowSoftInputMode="stateHidden"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
-              android:exported="false">
+              android:exported="true">
 
         <intent-filter>
             <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
this issue was reported by the testing group, thanks a lot for all the testers and their great job they're doing 🙏

the [crash](https://gist.github.com) was introduced by 1.34.2 that was released for testing only. 

reason is a wrong `exported` flag - it makes sense to have `exported="true"` here.

the flag was added in https://github.com/deltachat/deltachat-android/pull/2407 as needed for android12 - and i was assuming that the old default was `false` and set that value to all missing ones.  
that assumption seems to be wrong, so we should double-check all flags changed by https://github.com/deltachat/deltachat-android/pull/2407

EDIT: according to https://stackoverflow.com/questions/9274742/is-androidexported-true-really-necessary-for-an-authentication-service , it defaulted to `false` only if there were no intent-filters, otherwise it defaulted to `true`. so we should adapt the other flags as well.