### PR TITLE
use `ViewCompat.getLayoutDirection()` everywhere

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItemSwipeCallback.java
+++ b/src/org/thoughtcrime/securesms/ConversationItemSwipeCallback.java
@@ -9,6 +9,7 @@ import android.view.MotionEvent;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -199,11 +200,7 @@ class ConversationItemSwipeCallback extends ItemTouchHelper.SimpleCallback {
   }
 
   private static float getSignFromDirection(@NonNull View view) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      return view.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL ? -1f : 1f;
-    } else {
-      return 1f;
-    }
+    return ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL ? -1f : 1f;
   }
 
   private static boolean sameSign(float dX, float sign) {

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -45,6 +45,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Scrubber;
+import org.thoughtcrime.securesms.util.ViewUtil;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -155,6 +156,7 @@ public class LogViewFragment extends Fragment {
 
   private class PopulateLogcatAsyncTask extends AsyncTask<Void,Void,String> {
     private WeakReference<LogViewFragment> weakFragment;
+    private boolean isRtl;
 
     public PopulateLogcatAsyncTask(LogViewFragment fragment) {
       this.weakFragment = new WeakReference<>(fragment);
@@ -166,12 +168,13 @@ public class LogViewFragment extends Fragment {
       if (fragment == null) return null;
 
       return "**This log may contain sensitive information. If you want to post it publicly you may examine and edit it beforehand.**\n\n" +
-          buildDescription(fragment) + "\n" + new Scrubber().scrub(grabLogcat());
+          buildDescription(fragment, isRtl) + "\n" + new Scrubber().scrub(grabLogcat());
     }
 
     @Override
     protected void onPreExecute() {
       super.onPreExecute();
+      this.isRtl = ViewUtil.isRtl(logPreview);
       logPreview.setText(R.string.one_moment);
     }
 
@@ -210,7 +213,7 @@ public class LogViewFragment extends Fragment {
     return activityManager.getMemoryClass() + lowMem;
   }
 
-  private static String buildDescription(LogViewFragment fragment) {
+  private static String buildDescription(LogViewFragment fragment, boolean isRtl) {
     Context context = fragment.getActivity();
 
     PowerManager powerManager = (PowerManager)context.getSystemService(Context.POWER_SERVICE);
@@ -253,11 +256,7 @@ public class LogViewFragment extends Fragment {
 
       Locale locale = fragment.dynamicLanguage.getCurrentLocale();
       builder.append("lang=").append(locale.toString()).append("\n");
-      if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
-        boolean isRtl = DynamicLanguage.getLayoutDirection(context) == View.LAYOUT_DIRECTION_RTL;
-        builder.append("rtl=").append(isRtl).append("\n");
-      }
-
+      builder.append("rtl=").append(isRtl).append("\n");
     } catch (Exception e) {
       builder.append("Unknown\n");
     }

--- a/src/org/thoughtcrime/securesms/components/SendButton.java
+++ b/src/org/thoughtcrime/securesms/components/SendButton.java
@@ -26,21 +26,21 @@ public class SendButton extends ImageButton
   public SendButton(Context context) {
     super(context);
     this.transportOptions = initializeTransportOptions();
-    ViewUtil.mirrorIfRtl(this, getContext());
+    ViewUtil.mirrorIfRtl(this);
   }
 
   @SuppressWarnings("unused")
   public SendButton(Context context, AttributeSet attrs) {
     super(context, attrs);
     this.transportOptions = initializeTransportOptions();
-    ViewUtil.mirrorIfRtl(this, getContext());
+    ViewUtil.mirrorIfRtl(this);
   }
 
   @SuppressWarnings("unused")
   public SendButton(Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
     this.transportOptions = initializeTransportOptions();
-    ViewUtil.mirrorIfRtl(this, getContext());
+    ViewUtil.mirrorIfRtl(this);
   }
 
   private TransportOptions initializeTransportOptions() {

--- a/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
@@ -6,10 +6,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
-import androidx.annotation.RequiresApi;
 import androidx.core.os.ConfigurationCompat;
 
 import android.text.TextUtils;
@@ -47,12 +45,6 @@ public class DynamicLanguage {
 
   public Locale getCurrentLocale() {
     return currentLocale;
-  }
-
-  @RequiresApi(VERSION_CODES.JELLY_BEAN_MR1)
-  public static int getLayoutDirection(Context context) {
-    Configuration configuration = context.getResources().getConfiguration();
-    return configuration.getLayoutDirection();
   }
 
   public static void setContextLocale(Context context, Locale selectedLocale) {

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -16,7 +16,6 @@
  */
 package org.thoughtcrime.securesms.util;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
@@ -185,38 +184,26 @@ public class ViewUtil {
     return (T)(inflater.inflate(layoutResId, parent, false));
   }
 
-  @SuppressLint("RtlHardcoded")
   public static void setTextViewGravityStart(final @NonNull TextView textView, @NonNull Context context) {
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
-      if (DynamicLanguage.getLayoutDirection(context) == View.LAYOUT_DIRECTION_RTL) {
-        textView.setGravity(Gravity.RIGHT);
-      } else {
-        textView.setGravity(Gravity.LEFT);
-      }
+    if (ViewCompat.getLayoutDirection(textView) == ViewCompat.LAYOUT_DIRECTION_RTL) {
+      textView.setGravity(Gravity.RIGHT);
+    } else {
+      textView.setGravity(Gravity.LEFT);
     }
   }
 
-  public static void mirrorIfRtl(View view, Context context) {
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1 &&
-        DynamicLanguage.getLayoutDirection(context) == View.LAYOUT_DIRECTION_RTL) {
+  public static void mirrorIfRtl(View view) {
+    if (ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL) {
       view.setScaleX(-1.0f);
     }
   }
 
   public static boolean isLtr(@NonNull View view) {
-    return isLtr(view.getContext());
-  }
-
-  public static boolean isLtr(@NonNull Context context) {
-    return context.getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_LTR;
+    return ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_LTR;
   }
 
   public static boolean isRtl(@NonNull View view) {
-    return isRtl(view.getContext());
-  }
-
-  public static boolean isRtl(@NonNull Context context) {
-    return context.getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+    return ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
   }
 
   public static int dpToPx(Context context, int dp) {


### PR DESCRIPTION
before there was a mix of
`ViewCompat.getLayoutDirection()`,
`View.getLayoutDirection()`,
`Configuration.getLayoutDirection()` and
`DynamicLanguage.getLayoutDirection()` -
with some of them not working on api16 resp. android4.1

there could be further refactorings by force using `isRtl()`/`isLtr()`, 
however, this pr focuses on streaminging the basic calls to getting layout direction, leaving logic mostly as is.

closes #2420