### PR TITLE
let `DynamicLanguage.getLayoutDirection()` work on sdk16/android4.1

### DIFF
--- a/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
@@ -11,6 +11,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import androidx.annotation.RequiresApi;
 import androidx.core.os.ConfigurationCompat;
+import androidx.core.view.ViewCompat;
 
 import android.text.TextUtils;
 import android.util.Log;
@@ -49,10 +50,12 @@ public class DynamicLanguage {
     return currentLocale;
   }
 
-  @RequiresApi(VERSION_CODES.JELLY_BEAN_MR1)
   public static int getLayoutDirection(Context context) {
-    Configuration configuration = context.getResources().getConfiguration();
-    return configuration.getLayoutDirection();
+    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
+      Configuration configuration = context.getResources().getConfiguration();
+      return configuration.getLayoutDirection();
+    }
+    return ViewCompat.LAYOUT_DIRECTION_LTR;
   }
 
   public static void setContextLocale(Context context, Locale selectedLocale) {

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -208,7 +208,7 @@ public class ViewUtil {
   }
 
   public static boolean isLtr(@NonNull Context context) {
-    return context.getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_LTR;
+    return DynamicLanguage.getLayoutDirection(context) == ViewCompat.LAYOUT_DIRECTION_LTR;
   }
 
   public static boolean isRtl(@NonNull View view) {
@@ -216,7 +216,7 @@ public class ViewUtil {
   }
 
   public static boolean isRtl(@NonNull Context context) {
-    return context.getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+    return DynamicLanguage.getLayoutDirection(context) == ViewCompat.LAYOUT_DIRECTION_RTL;
   }
 
   public static int dpToPx(Context context, int dp) {


### PR DESCRIPTION
sdk16/android4.1 does not support RTL fully,
therefore just return LTR in this case
(this is also what `ViewCompat.getLayoutDirection()` and `View.getLayoutDirection()` are doing).

always using `ViewCompat.getLayoutDirection()`, however, causes problems as the layout is based on the content then (see #2422)

supersedes #2422
closes #2420