### PR TITLE
Remove ndk-make.sh symlink to scripts/ndk-make.sh

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -7,7 +7,7 @@ on the command-line:
    depending on how much you trust in rust, you might want to do a
    ./scripts/clean-core.sh before building
 
-2. $ ./ndk-make.sh
+2. $ ./scripts/ndk-make.sh
 
 this will take some time - meanwhile we're doing some housekeeping:
 
@@ -35,7 +35,7 @@ in Android Studio:
    documentation.
    Add `metadata/en-US/changelogs/4564.txt` file with a changelog for F-Droid.
 
-7. if `./ndk-make.sh` from step 2. is finished successfully:
+7. if `./scripts/ndk-make.sh` from step 2. is finished successfully:
    a) select "Build / Generate Signed Bundle or APK" and then "APK"
       (not: App Bundle as this would require uploading the signing key)
    b) select flavor `gplayRelease` with V1 signature enabled

--- a/ndk-make.sh
+++ b/ndk-make.sh
@@ -1,1 +1,0 @@
-scripts/ndk-make.sh

--- a/scripts/install-toolchains.sh
+++ b/scripts/install-toolchains.sh
@@ -4,6 +4,6 @@
 #
 set -e
 TARGETS="armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android"
-RUSTUP_TOOLCHAIN=$(cat "$(dirname $(realpath "$0"))/rust-toolchain")
+RUSTUP_TOOLCHAIN=$(cat "$(dirname "$0")/rust-toolchain")
 rustup install "$RUSTUP_TOOLCHAIN"
 rustup target add $TARGETS --toolchain "$RUSTUP_TOOLCHAIN"

--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -62,7 +62,7 @@ export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/aarch64-linux-a
 export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/i686-linux-android16-clang"
 export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/x86_64-linux-android21-clang"
 
-RUSTUP_TOOLCHAIN=$(cat "$(dirname $(realpath "$0"))/rust-toolchain")
+RUSTUP_TOOLCHAIN=$(cat "$(dirname "$0")/rust-toolchain")
 
 # Check if the argument is a correct architecture:
 if test $1 && echo "armeabi-v7a arm64-v8a x86 x86_64" | grep -vwq $1; then

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -131,7 +131,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   }
 
   /**
-   * If the build script is invoked with a specific architecture (e.g.`./ndk-make.sh arm64-v8a`), it
+   * If the build script is invoked with a specific architecture (e.g.`ndk-make.sh arm64-v8a`), it
    * will compile the core only for this arch. This method checks if the arch was correct.
    *
    * In order to do this, `ndk-make.sh` writes its argument into the file `ndkArch`.


### PR DESCRIPTION
If scripts are always called directly without symlink, there is no need to use `realpath` which is not available on some systems.

F-Droid builds already use scripts/ndk-make.sh:
<https://gitlab.com/fdroid/fdroiddata/blob/master/metadata/com.b44t.messenger.yml>

Same for nightly builds running on Concourse CI.