### PR TITLE
don't allow to reveal proxy password 

### DIFF
--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -173,6 +173,8 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             passwordLayout.setPasswordVisibilityToggleEnabled(false);
             TextInputLayout smtpPasswordLayout = findViewById(R.id.smtp_password);
             smtpPasswordLayout.setPasswordVisibilityToggleEnabled(false);
+            TextInputLayout proxyPasswordLayout = findViewById(R.id.socks5_password);
+            proxyPasswordLayout.setPasswordVisibilityToggleEnabled(false);
 
             TextInputEditText imapLoginInput = findViewById(R.id.imap_login_text);
 


### PR DESCRIPTION
when editing the settings after account was successfully configured.

missed to do this in #2452 