### PR TITLE
fix "use SOCKS5" switch style

### DIFF
--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -396,7 +396,6 @@
             android:paddingTop="16dp"
             android:paddingBottom="10dp"
             android:text="@string/login_socks5_use_socks5"
-            android:theme="@style/SwitchTheme"
             app:layout_constraintEnd_toEndOf="@id/guideline_root_end"
             app:layout_constraintStart_toStartOf="@id/guideline_root_start"
             app:layout_constraintTop_toBottomOf="@id/cert_check" />


### PR DESCRIPTION
I initially copied the switch markup for the "use SOCKS5" from "show location traces" switch in the map view, but that switch forces Light mode