### PR TITLE
Quoted message in email 

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -311,8 +311,11 @@ public class NotificationCenter {
         Util.runOnAnyBackgroundThread(() -> {
 
             DcChat dcChat = dcContext.getChat(chatId);
+            DcMsg dcMsg = dcContext.getMsg(msgId);
+            DcMsg quotedMsg = dcMsg.getQuotedMsg();
+            boolean isGroupMention = quotedMsg != null && dcChat.isGroup() && quotedMsg.isOutgoing();
 
-            if (!Prefs.isNotificationsEnabled(context) || dcChat.isMuted()) {
+            if (!Prefs.isNotificationsEnabled(context) || (!isGroupMention &&  dcChat.isMuted())) {
                 return;
             }
 
@@ -328,7 +331,6 @@ public class NotificationCenter {
             // get notification text as a single line
             NotificationPrivacyPreference privacy = Prefs.getNotificationPrivacy(context);
 
-            DcMsg dcMsg = dcContext.getMsg(msgId);
             String line = privacy.isDisplayMessage()? dcMsg.getSummarytext(2000) : context.getString(R.string.notify_new_message);
             if (dcChat.isGroup() && privacy.isDisplayContact()) {
                 line = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId()), false) + ": " + line;


### PR DESCRIPTION
Hi everybody!

I am not a developer but a simple user.

I really like Delta Chat app. And I would like to use it in a daily basis. But while having a conversation with someone using a simple email app there is something not going on well.

The way that the replied messages appearing in the email inbox page does not relly leave a good impression. I personally would prefer that the quoted part appears under the message not above and is separated by a line from the initial text inatead of the symbol ' > '.

Example of the quotes in the gmail inbox:

![resim](https://user-images.githubusercontent.com/78855052/215297664-29d121b6-a884-4b5d-b588-958f6b2d8139.png)

How they actually look in the Delta chat app:

![image_2023-01-29_00-39-00](https://user-images.githubusercontent.com/78855052/215297675-99e2d893-e5f0-4757-90f4-1462354adbf1.jpg)

So I'd like to know if others feel the same way and if there will be an update on this?

But even if not, I really appreciate your work so far :)

