### PR TITLE
no automatic remote content loading for contact requests

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -847,6 +847,7 @@ public class ConversationFragment extends MessageSelectorFragment
       public void onShowFullClicked(DcMsg messageRecord) {
         Intent intent = new Intent(getActivity(), FullMsgActivity.class);
         intent.putExtra(FullMsgActivity.MSG_ID_EXTRA, messageRecord.getId());
+        intent.putExtra(FullMsgActivity.IS_CONTACT_REQUEST, getListAdapter().getChat().isContactRequest());
         startActivity(intent);
         getActivity().overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
       }

--- a/src/org/thoughtcrime/securesms/FullMsgActivity.java
+++ b/src/org/thoughtcrime/securesms/FullMsgActivity.java
@@ -115,16 +115,21 @@ public class FullMsgActivity extends WebViewActivity
         // would be required as well - probably as the leftmost button which is not that usable in
         // not-always-mode where the dialog is used more often. Or [Ok] would mean "Once" as well as "Change checkbox setting",
         // which is also a bit weird. Anyway, let's give the three buttons a try :)
-        final String checkmarkPrefix = DynamicTheme.getCheckmarkEmoji(this) + " ";
+        final String checkmark = DynamicTheme.getCheckmarkEmoji(this) + " ";
+        String alwaysCheckmark = "";
+        String onceCheckmark = "";
+        String neverCheckmark = "";
         if (Prefs.getAlwaysLoadRemoteContent(this)) {
-          builder.setNeutralButton(checkmarkPrefix + getString(R.string.always), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ALWAYS));
-          builder.setNegativeButton(R.string.never, (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.NEVER));
-          builder.setPositiveButton(R.string.once, (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ONCE));
+          alwaysCheckmark = checkmark;
+        } else if (loadRemoteContent) {
+          onceCheckmark = checkmark;
         } else {
-          builder.setNeutralButton(R.string.always, (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ALWAYS));
-          builder.setNegativeButton((loadRemoteContent? "" : checkmarkPrefix) + getString(R.string.never), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.NEVER));
-          builder.setPositiveButton((loadRemoteContent? checkmarkPrefix : "") + getString(R.string.once), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ONCE));
+          neverCheckmark = checkmark;
         }
+
+        builder.setNeutralButton(alwaysCheckmark + getString(R.string.always), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ALWAYS));
+        builder.setNegativeButton(neverCheckmark + getString(R.string.never), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.NEVER));
+        builder.setPositiveButton(onceCheckmark + getString(R.string.once), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ONCE));
 
         builder.show();
         return true;


### PR DESCRIPTION
loading remote content in contact requests
now always require explicit consent of the user.
moreover, contact request do not alter
the otherwise used never/once/always settings.

iirc, this was also the original gist (contact requests needed to be confirmed to really use the message that time), however, contact requests have  changed since then and behave mostly like normal messages.

we have a similar thing also for webxdc, where webxdc contact requests also cannot send updates.

these improvements are the result of discussions with @Simon-Laux who is just adding html-view to desltop \o/

counterpart of https://github.com/deltachat/deltachat-ios/pull/1804