### PR TITLE
tweak webxdc

### DIFF
--- a/res/raw/webxdc_wrapper.html
+++ b/res/raw/webxdc_wrapper.html
@@ -129,8 +129,6 @@
           } else {
             loadingDiv.innerHTML = "";
             iframe.src = "index.html";
-            iframe.contentWindow.webxdc_internal = window.webxdc_internal;
-            iframe.contentWindow.webxdc = window.webxdc;
           }
         }
 


### PR DESCRIPTION
remove unused lines; the iframe should include webxdc.js as needed.

they came in by https://github.com/deltachat/deltachat-android/pull/2465/commits/22ae648160df066ad47cdef4db7659e2fc8866ed but i do not see the sense of these lines.

maybe i have overseen sth?