### PR TITLE
Revert "add epoll_create fallback which is missing in API<21"

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -7,20 +7,6 @@
 #include "deltachat-core-rust/deltachat-ffi/deltachat.h"
 
 
-#if __ANDROID_API__ < 21
-#include <sys/epoll.h>
-#include <fcntl.h>
-int epoll_create1(int flags) {
-    int fd = epoll_create(1000);
-    if (flags & O_CLOEXEC) { /* EPOLL_CLOEXEC == O_CLOEXEC */
-        int f = fcntl(fd, F_GETFD);
-        fcntl(fd, F_SETFD, f | FD_CLOEXEC);
-    }
-    return fd;
-}
-#endif
-
-
 static dc_msg_t* get_dc_msg(JNIEnv *env, jobject obj);
 
 


### PR DESCRIPTION
This reverts commit e29b6f9974bcad9a1e97493979f261cdb4cf4ea3.

Since update to `mio` 0.8.5, it does not require `epoll_create1()` function to be present on Android anymore.

Closes #2413 