### PR TITLE
scripts/ndk-make.sh: export RUSTUP_TOOLCHAIN

### DIFF
--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -62,7 +62,7 @@ export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/aarch64-linux-a
 export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/i686-linux-android16-clang"
 export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/x86_64-linux-android21-clang"
 
-RUSTUP_TOOLCHAIN=$(cat "$(dirname "$0")/rust-toolchain")
+export RUSTUP_TOOLCHAIN=$(cat "$(dirname "$0")/rust-toolchain")
 
 # Check if the argument is a correct architecture:
 if test $1 && echo "armeabi-v7a arm64-v8a x86 x86_64" | grep -vwq $1; then
@@ -115,7 +115,7 @@ if test -z $1 || test $1 = armeabi-v7a; then
     export CFLAGS=-D__ANDROID_API__=16
     TARGET_CC=armv7a-linux-androideabi16-clang \
     TARGET_AR=llvm-ar \
-    cargo "+$RUSTUP_TOOLCHAIN" rustc $RELEASEFLAG --target armv7-linux-androideabi -p deltachat_ffi -- -L "$TMPLIB"
+    cargo rustc $RELEASEFLAG --target armv7-linux-androideabi -p deltachat_ffi -- -L "$TMPLIB"
     cp target/armv7-linux-androideabi/$RELEASE/libdeltachat.a $jnidir/armeabi-v7a
 fi
 
@@ -124,7 +124,7 @@ if test -z $1 || test $1 = arm64-v8a; then
     export CFLAGS=-D__ANDROID_API__=21
     TARGET_CC=aarch64-linux-android21-clang \
     TARGET_AR=llvm-ar \
-    cargo "+$RUSTUP_TOOLCHAIN" rustc $RELEASEFLAG --target aarch64-linux-android -p deltachat_ffi -- -L "$TMPLIB"
+    cargo rustc $RELEASEFLAG --target aarch64-linux-android -p deltachat_ffi -- -L "$TMPLIB"
     cp target/aarch64-linux-android/$RELEASE/libdeltachat.a $jnidir/arm64-v8a
 fi
 
@@ -133,7 +133,7 @@ if test -z $1 || test $1 = x86; then
     export CFLAGS=-D__ANDROID_API__=16
     TARGET_CC=i686-linux-android16-clang \
     TARGET_AR=llvm-ar \
-    cargo "+$RUSTUP_TOOLCHAIN" rustc $RELEASEFLAG --target i686-linux-android -p deltachat_ffi -- -L "$TMPLIB"
+    cargo rustc $RELEASEFLAG --target i686-linux-android -p deltachat_ffi -- -L "$TMPLIB"
     cp target/i686-linux-android/$RELEASE/libdeltachat.a $jnidir/x86
 fi
 
@@ -142,7 +142,7 @@ if test -z $1 || test $1 = x86_64; then
     export CFLAGS=-D__ANDROID_API__=21
     TARGET_CC=x86_64-linux-android21-clang \
     TARGET_AR=llvm-ar \
-    cargo "+$RUSTUP_TOOLCHAIN" rustc $RELEASEFLAG --target x86_64-linux-android -p deltachat_ffi -- -L "$TMPLIB"
+    cargo rustc $RELEASEFLAG --target x86_64-linux-android -p deltachat_ffi -- -L "$TMPLIB"
     cp target/x86_64-linux-android/$RELEASE/libdeltachat.a $jnidir/x86_64
 fi
 


### PR DESCRIPTION
This allows to build the core on systems without rustup. In this case system rust is used,
but there is no error due to `+1.64.0`
being unknown argument to non-rustup cargo.