### PR TITLE
[wip] geckoview experiments

### DIFF
--- a/assets/geckoview/webxdc/background.js
+++ b/assets/geckoview/webxdc/background.js
@@ -1,0 +1,21 @@
+"use strict";
+
+function setupRedirect(fromUrl, redirectUrl) {
+  browser.webRequest.onBeforeRequest.addListener(
+    details => {
+      console.log(`Extension redirects from ${fromUrl} to ${redirectUrl}`);
+      return { redirectUrl };
+    },
+    { urls: [fromUrl] },
+    ["blocking"]
+  );
+}
+
+setupRedirect(
+  "*://*/webxdc.js",
+  browser.runtime.getURL("webxdc.js")
+);
+setupRedirect(
+  "<all_urls>",
+  browser.runtime.getURL("webxdc.html")
+);

--- a/assets/geckoview/webxdc/manifest.json
+++ b/assets/geckoview/webxdc/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "webxdc-extension",
+  "description": "Intercepts requests to XDC resources",
+  "manifest_version": 2,
+  "version": "1",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "webxdc@delta.chat"
+    }
+  },
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "permissions": [
+    "geckoViewAddons",
+    "nativeMessaging",
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>"
+  ],
+  "web_accessible_resources": ["webxdc.js", "webxdc.html"]
+}

--- a/assets/geckoview/webxdc/webxdc.html
+++ b/assets/geckoview/webxdc/webxdc.html
@@ -1,0 +1,1 @@
+Hello from extension!

--- a/assets/geckoview/webxdc/webxdc.js
+++ b/assets/geckoview/webxdc/webxdc.js
@@ -1,0 +1,6 @@
+"use strict";
+
+// TODO inject webxdc API here
+document.body.textContent += ",extension-was-here";
+document.body.style.border = "5px solid red";
+alert("webxdc script loaded");

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ android {
 
     defaultConfig {
         versionCode 651
-        versionName "1.36.2"
+        versionName "1.36.2-geckoview"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ repositories {
         url "https://www.jitpack.io"
         name 'JitPack Github wrapper'
     }
+    maven {
+        url "https://maven.mozilla.org/maven2/"
+    }
     jcenter()
 }
 
@@ -68,6 +71,8 @@ dependencies {
     implementation ('org.maplibre.gl:android-sdk:9.5.2') {
         exclude group: 'com.google.android.gms'
     }
+
+    implementation "org.mozilla.geckoview:geckoview-nightly:112.0.20230303095645"
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.assertj:assertj-core:1.7.1'

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,14 @@ dependencies {
 android {
     flavorDimensions "none"
     compileSdkVersion 32
+
+    // Set NDK version to strip native libraries.
+    // Even though we compile our libraries outside Gradle with `scripts/ndk-make.sh`,
+    // without ndkVersion `./gradlew clean` followed by `./gradlew assembleDebug --warning-mode=all` emits the following warning:
+    //   > Task :stripFatDebugDebugSymbols
+    //   Unable to strip the following libraries, packaging them as they are: libanimation-decoder-gif.so, libmapbox-gl.so, libnative-utils.so.
+    // See <https://issuetracker.google.com/issues/237187538> for details.
+    ndkVersion "23.2.8568313"
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {

--- a/res/layout/webxdc_activity.xml
+++ b/res/layout/webxdc_activity.xml
@@ -6,7 +6,10 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
-    <WebView android:id="@+id/webview"
-        android:layout_width="match_parent" android:layout_height="match_parent"/>
+    <org.mozilla.geckoview.GeckoView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
 </LinearLayout>

--- a/res/layout/webxdc_activity.xml
+++ b/res/layout/webxdc_activity.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
+
+    <WebView android:id="@+id/webview"
+        android:layout_width="match_parent" android:layout_height="match_parent"/>
+
+</LinearLayout>

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -187,6 +187,9 @@ public class ApplicationContext extends MultiDexApplication {
     // MAYBE TODO: i think the ApplicationContext is also created
     // when the app is stated by FetchWorker timeouts.
     // in this case, the normal threads shall not be started.
+
+    /* TODO: make the WorkManager initialisation compatible with Geckoview.
+    (if the following lines are not commented-out, GeckoView crahes with sth. as "WorkManager is not initialized properly.")
     Constraints constraints = new Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build();
@@ -202,6 +205,7 @@ public class ApplicationContext extends MultiDexApplication {
             "FetchWorker",
             ExistingPeriodicWorkPolicy.KEEP,
             fetchWorkRequest);
+     */
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
   }
 


### PR DESCRIPTION
see commit messages for details, this pr does not yet sandboxes xdc or hardens geckoview otherwise.

- [x] Build the thing. EDIT: yeah, it builds (283mb instead of 56mb) 
- [x] Open basic GeckoView. EDIT: after disabling Workmanager for now (see commit messages), it starts
- [ ] Make geckoview get files from .xdc, this required sth. as `shouldInterceptRequest`, cmp. https://github.com/mozilla/geckoview/issues/92, https://bugzilla.mozilla.org/show_bug.cgi?id=1721579 ... puhh, that seems to be quite some work of understanding and research, seems a WebExtension is needed for that. or a server.   
EDIT: there is [onLoadRequest()](https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/GeckoSession.NavigationDelegate.html#onLoadRequest(org.mozilla.geckoview.GeckoSession,org.mozilla.geckoview.GeckoSession.NavigationDelegate.LoadRequest)) ([so](https://stackoverflow.com/questions/55922979/is-there-a-shouldoverrideurlloading-in-geckoview)) - but that seems to allow returning a bool only, not the data 
EDIT: [`onLoadError`](https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/GeckoSession.NavigationDelegate.html#onLoadError(org.mozilla.geckoview.GeckoSession,java.lang.String,org.mozilla.geckoview.WebRequestError)) allows returning an URL, including [`data:text/html`](https://searchfox.org/mozilla-central/rev/c244b16815d1fc827d141472b9faac5610f250e7/mobile/android/geckoview_example/src/main/java/org/mozilla/geckoview_example/GeckoViewActivity.java#2318).
- [ ] sandbox/harden, target TODOs

nb: geckoview documentation is at https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/package-summary.html

