### PR TITLE
Add "All Media" option to global menu

### DIFF
--- a/res/menu/text_secure_normal.xml
+++ b/res/menu/text_secure_normal.xml
@@ -15,6 +15,9 @@
         android:visible="false"
         />
 
+    <item android:title="@string/menu_all_media"
+        android:id="@+id/menu_all_media" />
+
     <item android:title="@string/menu_settings"
           android:id="@+id/menu_settings" />
 

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -341,6 +341,9 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       case android.R.id.home:
         onBackPressed();
         return true;
+      case R.id.menu_all_media:
+        startActivity(new Intent(this, ProfileActivity.class));
+        return true;
     }
 
     return false;

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -97,17 +97,22 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
     setSupportActionBar(this.toolbar);
     ActionBar supportActionBar = getSupportActionBar();
-    supportActionBar.setDisplayHomeAsUpEnabled(false);
-    supportActionBar.setCustomView(R.layout.conversation_title_view);
-    supportActionBar.setDisplayShowCustomEnabled(true);
-    supportActionBar.setDisplayShowTitleEnabled(false);
-    Toolbar parent = (Toolbar) supportActionBar.getCustomView().getParent();
-    parent.setPadding(0,0,0,0);
-    parent.setContentInsetsAbsolute(0,0);
+    if (isGlobalProfile()) {
+      supportActionBar.setDisplayHomeAsUpEnabled(true);
+      supportActionBar.setHomeActionContentDescription(getString(R.string.back));
+    } else {
+      supportActionBar.setDisplayHomeAsUpEnabled(false);
+      supportActionBar.setCustomView(R.layout.conversation_title_view);
+      supportActionBar.setDisplayShowCustomEnabled(true);
+      supportActionBar.setDisplayShowTitleEnabled(false);
+      Toolbar parent = (Toolbar) supportActionBar.getCustomView().getParent();
+      parent.setPadding(0,0,0,0);
+      parent.setContentInsetsAbsolute(0,0);
 
-    titleView = (ConversationTitleView) supportActionBar.getCustomView();
-    titleView.setOnBackClickedListener(view -> onBackPressed());
-    titleView.setOnClickListener(view -> onEnlargeAvatar());
+      titleView = (ConversationTitleView) supportActionBar.getCustomView();
+      titleView.setOnBackClickedListener(view -> onBackPressed());
+      titleView.setOnClickListener(view -> onEnlargeAvatar());
+    }
 
     updateToolbar();
 
@@ -128,7 +133,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public boolean onCreateOptionsMenu(Menu menu) {
-    if (!isSelfProfile()) {
+    if (!isSelfProfile() && !isGlobalProfile()) {
       getMenuInflater().inflate(R.menu.profile_common, menu);
       boolean canReceive = true;
 


### PR DESCRIPTION
add a global profile to browse all media/documents/attachments, games etc. really useful to find attachments when user can't remember in which chat was sent, also useful for quickly reviewing and removing big attachments to save space

(note: most stuff was already in place to support this, thanks to that fellow collaborator from the past!)