### PR TITLE
fix "empty hints" for "all media" view

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -457,6 +457,7 @@
     <string name="tab_video_empty_hint">Videos shared in this chat will appear here.</string>
     <string name="tab_audio_empty_hint">Audio files and voice messages shared in this chat will appear here.</string>
     <string name="tab_webxdc_empty_hint">Private apps shared in this chat will appear here.</string>
+    <string name="tab_all_media_empty_hint">Media shared in any chat will appear here.</string>
     <string name="media_preview">Media Preview</string>
     <string name="send_message">Send Message</string>
     <!-- Placeholder %1$s will be replaced by the name of the contact changing their address. Placeholders %2$s and %3$s will be replaced by old/new email addresses. -->

--- a/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -124,7 +124,9 @@ public class ProfileDocumentsFragment
     ((ProfileDocumentsAdapter) recyclerView.getAdapter()).notifyAllSectionsDataSetChanged();
 
     noMedia.setVisibility(recyclerView.getAdapter().getItemCount() > 0 ? View.GONE : View.VISIBLE);
-    if (showAudio) {
+    if (chatId == 0) {
+      noMedia.setText(R.string.tab_all_media_empty_hint);
+    } else if (showAudio) {
       noMedia.setText(R.string.tab_audio_empty_hint);
     } else if (showWebxdc) {
       noMedia.setText(R.string.tab_webxdc_empty_hint);

--- a/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileGalleryFragment.java
@@ -120,6 +120,9 @@ public class ProfileGalleryFragment
     ((ProfileGalleryAdapter) recyclerView.getAdapter()).notifyAllSectionsDataSetChanged();
 
     noMedia.setVisibility(recyclerView.getAdapter().getItemCount() > 0 ? View.GONE : View.VISIBLE);
+    if (chatId == 0) {
+      noMedia.setText(R.string.tab_all_media_empty_hint);
+    }
     getActivity().invalidateOptionsMenu();
   }
 


### PR DESCRIPTION
this implements (2) of #2498 - a common hint makes things easier,
and also has the advantage, that it is more clear to the user what the
focus of this view is as it picks up the wording from the title.

so, i think, this is good enough.

<img width="310" alt="Screenshot 2023-03-14 at 11 57 38" src="https://user-images.githubusercontent.com/9800740/224995203-a1ad7ae5-0f11-4717-b0a9-520c4e4f3b6b.png">
