### PR TITLE
Improve readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/bin
 
 # Install NDK manually. Other SDK parts are installed automatically by gradle.
 #
+# If you change the NDK version here, also change it in `flake.nix`.
 # NDK version r23c LTS aka 23.2.8568313
 RUN sdkmanager --sdk_root=${ANDROID_SDK_ROOT} 'ndk;23.2.8568313'
 

--- a/README.md
+++ b/README.md
@@ -122,12 +122,8 @@ See https://wiki.archlinux.org/index.php/Podman#Rootless_Podman for more informa
 
 To setup build environment manually:
 - _Either_, in Android Studio, go to "Tools / SDK Manager / SDK Tools", enable "Show Package Details",
-  select "CMake" and the desired NDK, hit "Apply".
-- _Or_ read `Dockerfile` and mimic what it does.
-
-Currently ndk20b is the minimum required version.
-Newer versions will likely work, however, changes on the ndk-version should be
-done with care. Too new versions do not support abi16 and cannot be used to target Android 4.3 or lower.
+  select "CMake" and the desired NDK (install the same NDK version as the [Dockerfile](https://github.com/deltachat/deltachat-android/blob/master/Dockerfile)), hit "Apply".
+- _Or_ read [Dockerfile](https://github.com/deltachat/deltachat-android/blob/master/Dockerfile) and mimic what it does.
 
 Then, in both cases, install Rust using [rustup](https://rustup.rs/)
 and Rust toolchains for cross-compilation by executing `scripts/install-toolchains.sh`.


### PR DESCRIPTION
to prevent this problem in the future:
https://support.delta.chat/t/building-instruction-on-github-page-arent-working/2081/27

Supersedes #2285, but
1. doesn't require the Readme to be updated the NDK is updated
2. Adapted to the changes to Dockerfile.