### PR TITLE
Fix sharing, again

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -158,11 +158,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 {
   private static final String TAG = ConversationActivity.class.getSimpleName();
 
-  public static final String ACCOUNT_ID_EXTRA        = TAG + ".account_id";
-  public static final String CHAT_ID_EXTRA           = TAG + ".chat_id";
-  public static final String FROM_ARCHIVED_CHATS_EXTRA = TAG + ".from_archived";
-  public static final String TEXT_EXTRA              = TAG + ".draft_text";
-  public static final String STARTING_POSITION_EXTRA = TAG + ".starting_position";
+  public static final String ACCOUNT_ID_EXTRA        = "account_id";
+  public static final String CHAT_ID_EXTRA           = "chat_id";
+  public static final String FROM_ARCHIVED_CHATS_EXTRA = "from_archived";
+  public static final String TEXT_EXTRA              = "draft_text";
+  public static final String STARTING_POSITION_EXTRA = "starting_position";
 
   private static final int PICK_GALLERY        = 1;
   private static final int PICK_DOCUMENT       = 2;

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -76,7 +76,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   private static final String OPENPGP4FPR = "openpgp4fpr";
   private static final String NDK_ARCH_WARNED = "ndk_arch_warned";
   public static final String CLEAR_NOTIFICATIONS = "clear_notifications";
-  public static final String ACCOUNT_ID_EXTRA = TAG + ".account_id";
+  public static final String ACCOUNT_ID_EXTRA = "account_id";
 
   private final DynamicTheme    dynamicTheme    = new DynamicNoActionBarTheme();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -261,7 +261,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
     Intent composeIntent;
     if (chatId != -1) {
       composeIntent = getBaseShareIntent(ConversationActivity.class);
-      composeIntent.putExtra(EXTRA_CHAT_ID, chatId);
+      composeIntent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
       RelayUtil.setSharedUris(composeIntent, resolvedExtras);
       startActivity(composeIntent);
     } else {

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -10,11 +10,10 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Util;
 
 public class MarkReadReceiver extends BroadcastReceiver {
-  private static final String TAG = MarkReadReceiver.class.getSimpleName();
   public static final  String MARK_NOTICED_ACTION   = "org.thoughtcrime.securesms.notifications.MARK_NOTICED";
   public static final  String CANCEL_ACTION         = "org.thoughtcrime.securesms.notifications.CANCEL";
-  public static final  String ACCOUNT_ID_EXTRA      = TAG + ".account_id";
-  public static final  String CHAT_ID_EXTRA         = TAG + ".chat_id";
+  public static final  String ACCOUNT_ID_EXTRA      = "account_id";
+  public static final  String CHAT_ID_EXTRA         = "chat_id";
 
   @Override
   public void onReceive(final Context context, Intent intent) {

--- a/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -37,8 +37,8 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
 
   public static final String TAG           = RemoteReplyReceiver.class.getSimpleName();
   public static final String REPLY_ACTION  = "org.thoughtcrime.securesms.notifications.WEAR_REPLY";
-  public static final String ACCOUNT_ID_EXTRA = TAG + ".account_id";
-  public static final String CHAT_ID_EXTRA = TAG + ".chat_id";
+  public static final String ACCOUNT_ID_EXTRA = "account_id";
+  public static final String CHAT_ID_EXTRA = "chat_id";
   public static final String EXTRA_REMOTE_REPLY = "extra_remote_reply";
 
   @SuppressLint("StaticFieldLeak")


### PR DESCRIPTION
Fix #2505 and make the automated tests pass again by simply reverting https://github.com/deltachat/deltachat-android/commit/8962476a21c67fd943a496f759422a4b2e6cd3e3.

The second commits fixes an NPE that somehow sneaked into the tests.

The "manual sharing tests" don't pass again, esp. https://github.com/deltachat/interface/blob/master/user-testing/mailto-links.md#regression-test-for-the-issue-fixed-by-1770 still doesn't work, but this is for another PR.