### PR TITLE
cleanup base activities

### DIFF
--- a/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -9,17 +9,22 @@ import android.view.MenuItem;
 import android.view.ViewConfiguration;
 import android.view.WindowManager;
 
+import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
 
 import org.thoughtcrime.securesms.util.Prefs;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 
 
 public abstract class BaseActionBarActivity extends AppCompatActivity {
 
   private static final String TAG = BaseActionBarActivity.class.getSimpleName();
+  public static final String LOCALE_EXTRA = "locale_extra";
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -89,5 +94,37 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
         item.setVisible(!visible); // if search is shown, other items are hidden - and the other way round
       }
     }
+  }
+
+  protected <T extends Fragment> T initFragment(@IdRes int target,
+                                                @NonNull T fragment)
+  {
+    return initFragment(target, fragment, null);
+  }
+
+  protected <T extends Fragment> T initFragment(@IdRes int target,
+                                                @NonNull T fragment,
+                                                @Nullable Locale locale)
+  {
+    return initFragment(target, fragment, locale, null);
+  }
+
+  protected <T extends Fragment> T initFragment(@IdRes int target,
+                                                @NonNull T fragment,
+                                                @Nullable Locale locale,
+                                                @Nullable Bundle extras)
+  {
+    Bundle args = new Bundle();
+    args.putSerializable(LOCALE_EXTRA, locale);
+
+    if (extras != null) {
+      args.putAll(extras);
+    }
+
+    fragment.setArguments(args);
+    getSupportFragmentManager().beginTransaction()
+      .replace(target, fragment)
+      .commitAllowingStateLoss();
+    return fragment;
   }
 }

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -4,20 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 
-import androidx.annotation.IdRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.service.GenericForegroundService;
 
-import java.util.Locale;
-
 public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarActivity {
   private static final String TAG = PassphraseRequiredActionBarActivity.class.getSimpleName();
-
-  public static final String LOCALE_EXTRA = "locale_extra";
 
   @Override
   protected final void onCreate(Bundle savedInstanceState) {
@@ -48,36 +39,4 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
 
   protected void onPreCreate() {}
   protected void onCreate(Bundle savedInstanceState, boolean ready) {}
-
-  protected <T extends Fragment> T initFragment(@IdRes int target,
-                                                @NonNull T fragment)
-  {
-    return initFragment(target, fragment, null);
-  }
-
-  protected <T extends Fragment> T initFragment(@IdRes int target,
-                                                @NonNull T fragment,
-                                                @Nullable Locale locale)
-  {
-    return initFragment(target, fragment, locale, null);
-  }
-
-  protected <T extends Fragment> T initFragment(@IdRes int target,
-                                                @NonNull T fragment,
-                                                @Nullable Locale locale,
-                                                @Nullable Bundle extras)
-  {
-    Bundle args = new Bundle();
-    args.putSerializable(LOCALE_EXTRA, locale);
-
-    if (extras != null) {
-      args.putAll(extras);
-    }
-
-    fragment.setArguments(args);
-    getSupportFragmentManager().beginTransaction()
-                               .replace(target, fragment)
-                               .commitAllowingStateLoss();
-    return fragment;
-  }
 }

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -49,24 +49,6 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
   protected void onPreCreate() {}
   protected void onCreate(Bundle savedInstanceState, boolean ready) {}
 
-  @Override
-  protected void onResume() {
-    Log.i(TAG, "onResume()");
-    super.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    Log.i(TAG, "onPause()");
-    super.onPause();
-  }
-
-  @Override
-  protected void onDestroy() {
-    Log.i(TAG, "onDestroy()");
-    super.onDestroy();
-  }
-
   protected <T extends Fragment> T initFragment(@IdRes int target,
                                                 @NonNull T fragment)
   {

--- a/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -1,7 +1,5 @@
 package org.thoughtcrime.securesms.qr;
 
-import static org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity.LOCALE_EXTRA;
-
 import android.content.Context;
 import android.content.Intent;
 import android.net.wifi.WifiInfo;
@@ -12,12 +10,9 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
 
-import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.Fragment;
 
 import org.thoughtcrime.securesms.BaseActionBarActivity;
 import org.thoughtcrime.securesms.ConversationListActivity;
@@ -30,8 +25,6 @@ import org.thoughtcrime.securesms.service.NotificationController;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.Util;
-
-import java.util.Locale;
 
 public class BackupTransferActivity extends BaseActionBarActivity {
 
@@ -220,20 +213,5 @@ public class BackupTransferActivity extends BaseActionBarActivity {
                 }
             }).start();
         }
-    }
-
-    protected <T extends Fragment> T initFragment(@IdRes int target,
-                                                  @NonNull T fragment,
-                                                  @Nullable Locale locale,
-                                                  @Nullable Bundle extras)
-    {
-        Bundle args = new Bundle();
-        args.putSerializable(LOCALE_EXTRA, locale);
-        if (extras != null) {
-            args.putAll(extras);
-        }
-        fragment.setArguments(args);
-        getSupportFragmentManager().beginTransaction().replace(target, fragment).commitAllowingStateLoss();
-        return fragment;
     }
 }


### PR DESCRIPTION
this pr removes superfluous overwrites from `PassphraseRequiredActionBarActivity` and moves the `initFragment()` functions from `PassphraseRequiredActionBarActivity` to its parent,`BaseTitleBarActivity`.

this makes `initFragment()`  accessible from all activities.

successor of #2493 

targets https://github.com/deltachat/deltachat-android/pull/2493#discussion_r1145984223 and some cleanup for finally fixing #2507 