### PR TITLE
fix leaving Delta Chat during backup transfer

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -144,6 +144,8 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
     Intent intent = new Intent(this, BackupTransferActivity.class);
     intent.putExtra(BackupTransferActivity.TRANSFER_MODE, BackupTransferActivity.TransferMode.SENDER_SHOW_QR.getInt());
     startActivity(intent);
+    overridePendingTransition(0, 0); // let the activity appear in the same way as the other pages (which are mostly fragments)
+    finishAffinity(); // see comment (**2) in BackupTransferActivity.doFinish()
   }
 
   public static class ApplicationPreferenceFragment extends CorrectedPreferenceFragment implements DcEventCenter.DcEventDelegate {

--- a/src/org/thoughtcrime/securesms/service/NotificationController.java
+++ b/src/org/thoughtcrime/securesms/service/NotificationController.java
@@ -58,8 +58,12 @@ public final class NotificationController {
   }
 
   public void close() {
-    GenericForegroundService.stopForegroundTask(context, id);
-    context.unbindService(serviceConnection);
+    try {
+      GenericForegroundService.stopForegroundTask(context, id);
+      context.unbindService(serviceConnection);
+    } catch(Exception e) {
+      e.printStackTrace();
+    }
   }
 
   public void setIndeterminateProgress() {


### PR DESCRIPTION
this fixes leaving Delta Chat during backup transfer by removing other activities that would abort BackupTransfer by getting called with onNewIntent() otherwise.

moreover, the permantent notification is removed more reliably and possible crashes in  the permantent notification closing (races ...) are catched.

see code + comments for details.

successor of #2508 and #2493

closes #2507