### PR TITLE
add "Add as Second Device" to welcome view

### DIFF
--- a/res/layout/activity_registration_2nd_device_qr.xml
+++ b/res/layout/activity_registration_2nd_device_qr.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    tools:context=".WelcomeActivity">
+
+    <LinearLayout
+        android:id="@+id/top_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:gravity="center_vertical"
+                android:text="➊"
+                android:textColor="?attr/emoji_text_color"
+                android:textSize="16sp"/> <!-- idk - using sightly larger text size moves the next text down -->
+            <TextView
+                android:id="@+id/same_network_hint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:text="@string/multidevice_same_network_hint"
+                android:textColor="?attr/emoji_text_color"
+                android:textSize="16sp"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:gravity="center_vertical"
+                android:text="➋"
+                android:textColor="?attr/emoji_text_color"
+                android:textSize="16sp"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/multidevice_open_settings_on_other_device"
+                android:textColor="?attr/emoji_text_color"
+                android:textSize="16sp"/>
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <androidx.legacy.widget.Space
+        android:layout_weight="1"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"/>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="7"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:orientation="vertical">
+
+        <com.journeyapps.barcodescanner.CompoundBarcodeView
+            android:id="@+id/zxing_barcode_scanner"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_alignParentBottom="true" />
+
+    </RelativeLayout>
+
+    <androidx.legacy.widget.Space
+        android:layout_weight="1"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"/>
+
+</LinearLayout>

--- a/res/layout/activity_registration_qr.xml
+++ b/res/layout/activity_registration_qr.xml
@@ -8,27 +8,9 @@
     tools:context=".WelcomeActivity">
 
     <androidx.legacy.widget.Space
-        android:layout_weight="1"
+        android:layout_weight="2"
         android:layout_width="match_parent"
         android:layout_height="0dp"/>
-
-    <ImageView
-        android:id="@+id/welcome_icon"
-        android:layout_width="128dp"
-        android:layout_height="128dp"
-        android:src="@drawable/intro1"
-        android:padding="8dp"
-        tools:ignore="contentDescription"/>
-
-    <TextView
-        android:id="@+id/welcome_header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:padding="16dp"
-        android:text="@string/qrscan_title"
-        android:textSize="22sp"
-        android:textStyle="bold"/>
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -47,7 +29,7 @@
     </RelativeLayout>
 
     <androidx.legacy.widget.Space
-        android:layout_weight="1"
+        android:layout_weight="2"
         android:layout_width="match_parent"
         android:layout_height="0dp"/>
 

--- a/res/layout/welcome_activity.xml
+++ b/res/layout/welcome_activity.xml
@@ -15,8 +15,8 @@
     <ImageView
         android:id="@+id/welcome_icon"
         android:layout_width="wrap_content"
-        android:layout_height="128dp"
-        android:layout_weight="16"
+        android:layout_height="100dp"
+        android:layout_weight="14"
         android:gravity="bottom"
         android:src="@drawable/intro1"
         android:paddingLeft="32dp"
@@ -29,7 +29,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:padding="8dp"
-        android:layout_marginBottom="24dp"
+        android:layout_marginBottom="20dp"
         android:text="@string/welcome_chat_over_email"
         android:textSize="22sp"
         android:textStyle="bold"/>
@@ -53,13 +53,13 @@
 
         <Button
             style="@style/ButtonSecondary"
-            android:id="@+id/backup_button"
+            android:id="@+id/add_as_second_device_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingLeft="24dp"
             android:paddingRight="24dp"
             android:layout_marginBottom="16dp"
-            android:text="@string/import_backup_title"/>
+            android:text="@string/multidevice_receiver_title"/>
 
         <Button
             style="@style/ButtonSecondary"
@@ -68,14 +68,24 @@
             android:layout_height="wrap_content"
             android:paddingLeft="24dp"
             android:paddingRight="24dp"
-            android:text="@string/qrscan_title"/>
+            android:text="@string/scan_invitation_code"/>
 
     </LinearLayout>
 
     <androidx.legacy.widget.Space
-        android:layout_weight="5"
+        android:layout_weight="3"
         android:layout_width="match_parent"
         android:layout_height="0dp"/>
+
+    <TextView
+        android:id="@+id/backup_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="22dp"
+        android:gravity="center"
+        android:text="@string/import_backup_title"
+        android:textColor="?attr/secondary_button_fg"
+        android:textSize="15sp"/>
 
 </LinearLayout>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -471,7 +471,7 @@
     <string name="multidevice_title">Add Second Device</string>
     <string name="multidevice_same_network_hint">Make sure both devices are on the same Wi-Fi or network</string>
     <string name="multidevice_install_dc_on_other_device">Install Delta Chat 1.36 or newer on your other device (https://get.delta.chat)</string>
-    <string name="multidevice_tap_scan_on_other_device">Start Delta Chat, tap “Scan QR Code” and scan the code shown here</string>
+    <string name="multidevice_tap_scan_on_other_device">Start Delta Chat, tap “Add as Second Device” and scan the code shown here</string>
     <!-- Shown inside a "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by name and/or address eg. "Scan to set up second device for Alice (alice@example.org)" -->
     <string name="multidevice_qr_subtitle">Scan to set up second device for %1$s</string>
     <string name="multidevice_receiver_title">Add as Second Device</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -475,9 +475,11 @@
     <!-- Shown inside a "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by name and/or address eg. "Scan to set up second device for Alice (alice@example.org)" -->
     <string name="multidevice_qr_subtitle">Scan to set up second device for %1$s</string>
     <string name="multidevice_receiver_title">Add as Second Device</string>
+    <string name="multidevice_open_settings_on_other_device">On the first device, go to “Settings / Add Second Device“ and scan the code shown there</string>
     <string name="multidevice_receiver_scanning_ask">Copy the account from the other device to this device?</string>
     <string name="multidevice_abort">Abort setting up second device?</string>
     <string name="multidevice_abort_will_invalidate_copied_qr">This will invalidate the QR code copied to clipboard.</string>
+    <string name="multidevice_experimental_hint">(experimental, version 1.36 required)</string>
     <!-- Shown beside progress bar, stay short -->
     <string name="exporting_account">Exporting account…</string>
     <!-- Shown beside progress bar, stay short -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -470,7 +470,7 @@
     <!-- "Second Device" can also be translated as "Another Device", if that is catchier in the destination language. However, make sure to use the term consistently. -->
     <string name="multidevice_title">Add Second Device</string>
     <string name="multidevice_same_network_hint">Make sure both devices are on the same Wi-Fi or network</string>
-    <string name="multidevice_install_dc_on_other_device">Install Delta Chat 1.36 or newer on your other device (https://get.delta.chat)</string>
+    <string name="multidevice_install_dc_on_other_device">Install Delta Chat on your other device (https://get.delta.chat)</string>
     <string name="multidevice_tap_scan_on_other_device">Start Delta Chat, tap “Add as Second Device” and scan the code shown here</string>
     <!-- Shown inside a "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by name and/or address eg. "Scan to set up second device for Alice (alice@example.org)" -->
     <string name="multidevice_qr_subtitle">Scan to set up second device for %1$s</string>

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -450,7 +450,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                 case DcContext.DC_QR_BACKUP:
                     new AlertDialog.Builder(this)
                             .setTitle(R.string.multidevice_receiver_title)
-                            .setMessage(getString(R.string.multidevice_receiver_scanning_ask) + "\n\n" + getString(R.string.multidevice_same_network_hint))
+                            .setMessage(R.string.multidevice_receiver_scanning_ask)
                             .setPositiveButton(R.string.perm_continue, (dialog, which) -> startQrAccountCreation(qrRaw))
                             .setNegativeButton(R.string.cancel, null)
                             .setCancelable(false)

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -78,7 +78,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         View backupButton = findViewById(R.id.backup_button);
 
         loginButton.setOnClickListener((view) -> startRegistrationActivity());
-        addAsSecondDeviceButton.setOnClickListener((view) -> startAddAsAnotherDeviceActivity());
+        addAsSecondDeviceButton.setOnClickListener((view) -> startAddAsSecondDeviceActivity());
         scanQrButton.setOnClickListener((view) -> startRegistrationQrActivity());
         backupButton.setOnClickListener((view) -> startImportBackup());
 
@@ -156,9 +156,11 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan();
     }
 
-    private void startAddAsAnotherDeviceActivity() {
+    private void startAddAsSecondDeviceActivity() {
         manualConfigure = false;
-        new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan();
+        new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class)
+          .addExtra(RegistrationQrActivity.ADD_AS_SECOND_DEVICE_EXTRA, true)
+          .initiateScan();
     }
 
     @SuppressLint("InlinedApi")

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -73,10 +73,12 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         setContentView(R.layout.welcome_activity);
 
         Button loginButton = findViewById(R.id.login_button);
+        View addAsSecondDeviceButton = findViewById(R.id.add_as_second_device_button);
         View scanQrButton = findViewById(R.id.scan_qr_button);
         View backupButton = findViewById(R.id.backup_button);
 
         loginButton.setOnClickListener((view) -> startRegistrationActivity());
+        addAsSecondDeviceButton.setOnClickListener((view) -> startAddAsAnotherDeviceActivity());
         scanQrButton.setOnClickListener((view) -> startRegistrationQrActivity());
         backupButton.setOnClickListener((view) -> startImportBackup());
 
@@ -147,13 +149,16 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         manualConfigure = true;
         Intent intent = new Intent(this, RegistrationActivity.class);
         startActivity(intent);
-        // no finish() here, the back key should take the user back from RegistrationActivity to WelcomeActivity
     }
 
     private void startRegistrationQrActivity() {
         manualConfigure = false;
         new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan();
-        // no finish() here, the back key should take the user back from RegistrationQrActivity to WelcomeActivity
+    }
+
+    private void startAddAsAnotherDeviceActivity() {
+        manualConfigure = false;
+        new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan();
     }
 
     @SuppressLint("InlinedApi")

--- a/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -92,6 +92,7 @@ public class BackupTransferActivity extends BaseActionBarActivity {
         supportActionBar.setDisplayHomeAsUpEnabled(true);
         supportActionBar.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
         supportActionBar.setTitle(title);
+        supportActionBar.setSubtitle(R.string.multidevice_experimental_hint);
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
@@ -16,12 +16,13 @@ import org.thoughtcrime.securesms.BaseActionBarActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
-import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 
 public class RegistrationQrActivity extends BaseActionBarActivity {
 
-    private final DynamicTheme dynamicTheme = new DynamicNoActionBarTheme();
+    public static final String ADD_AS_SECOND_DEVICE_EXTRA = "add_as_second_device";
+
+    private final DynamicTheme dynamicTheme = new DynamicTheme();
     private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
 
     private CaptureManager capture;
@@ -34,7 +35,15 @@ public class RegistrationQrActivity extends BaseActionBarActivity {
         dynamicTheme.onCreate(this);
         dynamicLanguage.onCreate(this);
 
-        setContentView(R.layout.activity_registration_qr);
+        boolean addAsAnotherDevice = getIntent().getBooleanExtra(ADD_AS_SECOND_DEVICE_EXTRA, false);
+        if (addAsAnotherDevice) {
+            setContentView(R.layout.activity_registration_qr);
+            getSupportActionBar().setTitle(R.string.multidevice_receiver_title);
+        } else {
+            setContentView(R.layout.activity_registration_qr);
+            getSupportActionBar().setTitle(R.string.scan_invitation_code);
+        }
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         barcodeScannerView = findViewById(R.id.zxing_barcode_scanner);
         barcodeScannerView.setStatusText(getString(R.string.qrscan_hint) + "\n ");

--- a/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
@@ -37,8 +37,9 @@ public class RegistrationQrActivity extends BaseActionBarActivity {
 
         boolean addAsAnotherDevice = getIntent().getBooleanExtra(ADD_AS_SECOND_DEVICE_EXTRA, false);
         if (addAsAnotherDevice) {
-            setContentView(R.layout.activity_registration_qr);
+            setContentView(R.layout.activity_registration_2nd_device_qr);
             getSupportActionBar().setTitle(R.string.multidevice_receiver_title);
+            getSupportActionBar().setSubtitle(R.string.multidevice_experimental_hint);
         } else {
             setContentView(R.layout.activity_registration_qr);
             getSupportActionBar().setTitle(R.string.scan_invitation_code);


### PR DESCRIPTION
ppl try already now to set up a second device from the welcome screen. however, end up in logging into their email account again, creating issues with keys and more.  a dedicated "Add as Second Devies" button targets this UX issue by offering a clear path for setting up a second device.

moreover, the string "Scan Invitation Code" is used again (as on all releases), this string is used quite a bit in different handouts, changing that would worsen UX as well.

the "Restore from Backup is moved down,
if you really use this path, finding the button is the smallest issue. the different layout of the button makes clear,
that this is not the preferred way to set up a new account (but sure, to restore a backup :)

moreover, this flags the feature as being "experimental" - this hint and the version hint can easily be removed later on.

successor of #2493

<img width=300 src=https://user-images.githubusercontent.com/9800740/227715538-d1ec5ec2-fdcc-4b58-8c95-c628688062c3.png> &nbsp; <img width=300 src=https://user-images.githubusercontent.com/9800740/227723536-1852dede-f699-4399-a52f-2904096ab683.png>
