### PR TITLE
use conversation-list-adapter more carefully

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -393,13 +393,16 @@ public class ConversationFragment extends MessageSelectorFragment
     }
 
     void setLastSeen(long lastSeen) {
-        getListAdapter().setLastSeen(lastSeen);
-        if (lastSeenDecoration != null) {
-            list.removeItemDecoration(lastSeenDecoration);
-        }
-        if (lastSeen > 0) {
-            lastSeenDecoration = new ConversationAdapter.LastSeenHeader(getListAdapter());
-            list.addItemDecoration(lastSeenDecoration);
+        ConversationAdapter adapter = getListAdapter();
+        if (adapter != null) {
+            adapter.setLastSeen(lastSeen);
+            if (lastSeenDecoration != null) {
+                list.removeItemDecoration(lastSeenDecoration);
+            }
+            if (lastSeen > 0) {
+                lastSeenDecoration = new ConversationAdapter.LastSeenHeader(adapter);
+                list.addItemDecoration(lastSeenDecoration);
+            }
         }
     }
 


### PR DESCRIPTION
we're also checking for null at some other critical code positions, so this seems reasonable also here.
this might fix a recently reported crash,
maybe caused by a race condition.