### PR TITLE
show used wifi already before scanning

### DIFF
--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -90,7 +90,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
             });
         }).start();
 
-        getTransferActivity().appendSSID(view.findViewById(R.id.same_network_hint));
+        BackupTransferActivity.appendSSID(getActivity(), view.findViewById(R.id.same_network_hint));
 
         return view;
     }

--- a/src/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
@@ -57,7 +57,7 @@ public class BackupReceiverFragment extends Fragment implements DcEventCenter.Dc
             Log.i(TAG, "##### receiveBackup() done with result: "+res);
         }).start();
 
-        getTransferActivity().appendSSID(sameNetworkHint);
+        BackupTransferActivity.appendSSID(getActivity(), sameNetworkHint);
 
         return view;
     }

--- a/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.qr;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.wifi.WifiInfo;
@@ -14,6 +15,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 
+import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.BaseActionBarActivity;
 import org.thoughtcrime.securesms.ConversationListActivity;
@@ -211,13 +213,13 @@ public class BackupTransferActivity extends BaseActionBarActivity {
           .show();
     }
 
-    public void appendSSID(final TextView textView) {
+    public static void appendSSID(Activity activity, final TextView textView) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             new Thread(() -> {
                 try {
                     // depending on the android version, getting the SSID requires none, all or one of
                     // ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE, ACCESS_NETWORK_STATE and maybe even more.
-                    final WifiManager wifiManager = (WifiManager)getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+                    final WifiManager wifiManager = (WifiManager)activity.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                     if (wifiManager.isWifiEnabled()) {
                         final WifiInfo info = wifiManager.getConnectionInfo();
                         final String ssid = info.getSSID();

--- a/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.MenuItem;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 
@@ -48,6 +49,11 @@ public class RegistrationQrActivity extends BaseActionBarActivity {
 
         barcodeScannerView = findViewById(R.id.zxing_barcode_scanner);
         barcodeScannerView.setStatusText(getString(R.string.qrscan_hint) + "\n ");
+
+        View sameNetworkHint = findViewById(R.id.same_network_hint);
+        if (sameNetworkHint != null) {
+            BackupTransferActivity.appendSSID(this, findViewById(R.id.same_network_hint));
+        }
 
         if (savedInstanceState != null) {
             init(barcodeScannerView, getIntent(), savedInstanceState);


### PR DESCRIPTION
this adds the used wifi to the "same wifi hint" already before scanning.

there is a pretty low likelihood that we really get that information on a new installation, but still.

successor of #2511 and #2493

<img width=300 src=https://user-images.githubusercontent.com/9800740/227729452-a9dc788d-10f5-4e34-9a0d-897aedb18cae.png>
