### PR TITLE
send backup progress tweaks

### DIFF
--- a/res/layout/activity_registration_2nd_device_qr.xml
+++ b/res/layout/activity_registration_2nd_device_qr.xml
@@ -91,6 +91,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/multidevice_experimental_hint"
+        android:gravity="center"
         android:textColor="?attr/emoji_text_color"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"

--- a/res/layout/activity_registration_2nd_device_qr.xml
+++ b/res/layout/activity_registration_2nd_device_qr.xml
@@ -68,7 +68,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="7"
+        android:layout_weight="10"
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
         android:orientation="vertical">
@@ -85,5 +85,16 @@
         android:layout_weight="1"
         android:layout_width="match_parent"
         android:layout_height="0dp"/>
+
+    <TextView
+        android:id="@+id/bottom_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/multidevice_experimental_hint"
+        android:textColor="?attr/emoji_text_color"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
+        android:textSize="16sp" />
 
 </LinearLayout>

--- a/res/layout/backup_provider_fragment.xml
+++ b/res/layout/backup_provider_fragment.xml
@@ -113,6 +113,7 @@
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:text="@string/multidevice_experimental_hint"
+		android:gravity="center"
 		android:textColor="?attr/emoji_text_color"
 		android:layout_marginLeft="16dp"
 		android:layout_marginRight="16dp"

--- a/res/layout/backup_provider_fragment.xml
+++ b/res/layout/backup_provider_fragment.xml
@@ -108,4 +108,17 @@
 		android:layout_marginBottom="16dp"
 		android:contentDescription="@string/qrscan_title" />
 
+	<TextView
+		android:id="@+id/bottom_text"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:text="@string/multidevice_experimental_hint"
+		android:textColor="?attr/emoji_text_color"
+		android:layout_marginLeft="16dp"
+		android:layout_marginRight="16dp"
+		android:layout_marginBottom="16dp"
+		android:textSize="16sp"
+		android:visibility="gone"
+		tools:visibility="visible"/>
+
 </LinearLayout>

--- a/res/layout/backup_receiver_fragment.xml
+++ b/res/layout/backup_receiver_fragment.xml
@@ -30,9 +30,9 @@
 		android:layout_height="0dp"
 		android:layout_margin="16dp"
 		android:layout_weight="1"
-		android:gravity="bottom"
+		android:gravity="bottom|center"
 		android:text="@string/multidevice_same_network_hint"
-		android:textColor="@color/gray50"
+		android:textColor="?attr/emoji_text_color"
 		android:textSize="16sp"/>
 
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -481,11 +481,7 @@
     <string name="multidevice_abort_will_invalidate_copied_qr">This will invalidate the QR code copied to clipboard.</string>
     <string name="multidevice_experimental_hint">(experimental, version 1.36 required)</string>
     <!-- Shown beside progress bar, stay short -->
-    <string name="exporting_account">Exporting account…</string>
-    <!-- Shown beside progress bar, stay short -->
     <string name="preparing_account">Preparing account…</string>
-    <!-- Shown beside progress bar, stay short -->
-    <string name="account_prepared">Account prepared.</string>
     <!-- Shown beside progress bar, stay short -->
     <string name="waiting_for_receiver">Waiting for receiver…</string>
     <!-- Shown beside progress bar, stay short -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -470,6 +470,7 @@
     <!-- "Second Device" can also be translated as "Another Device", if that is catchier in the destination language. However, make sure to use the term consistently. -->
     <string name="multidevice_title">Add Second Device</string>
     <string name="multidevice_same_network_hint">Make sure both devices are on the same Wi-Fi or network</string>
+    <string name="multidevice_this_creates_a_qr_code">This creates a QR code that the second device can scan to copy the account.</string>
     <string name="multidevice_install_dc_on_other_device">Install Delta Chat on your other device (https://get.delta.chat)</string>
     <string name="multidevice_tap_scan_on_other_device">Start Delta Chat, tap “Add as Second Device” and scan the code shown here</string>
     <!-- Shown inside a "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by name and/or address eg. "Scan to set up second device for Alice (alice@example.org)" -->

--- a/src/com/b44t/messenger/DcBackupProvider.java
+++ b/src/com/b44t/messenger/DcBackupProvider.java
@@ -16,7 +16,7 @@ public class DcBackupProvider {
     }
 
     public void unref() {
-        if (backupProviderCPtr == 0) {
+        if (backupProviderCPtr != 0) {
             unrefBackupProviderCPtr();
             backupProviderCPtr = 0;
         }

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -29,6 +29,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.fragment.app.Fragment;
@@ -275,8 +276,17 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
           fragment = new ChatsPreferenceFragment();
           break;
         case PREFERENCE_CATEGORY_MULTIDEVICE:
-          if (!ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.multidevice_title), ScreenLockUtil.REQUEST_CODE_CONFIRM_CREDENTIALS)) {
-            ((ApplicationPreferencesActivity)getActivity()).showBackupProvider();
+          if (!ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.multidevice_title),
+              getString(R.string.multidevice_this_creates_a_qr_code) + "\n\n" + getString(R.string.enter_system_secret_to_continue),
+              ScreenLockUtil.REQUEST_CODE_CONFIRM_CREDENTIALS)) {
+            new AlertDialog.Builder(getActivity())
+              .setTitle(R.string.multidevice_title)
+              .setMessage(R.string.multidevice_this_creates_a_qr_code)
+              .setPositiveButton(R.string.perm_continue,
+                (dialog, which) -> ((ApplicationPreferencesActivity)getActivity()).showBackupProvider())
+              .setNegativeButton(R.string.cancel, null)
+              .show();
+            ;
           }
           break;
         case PREFERENCE_CATEGORY_ADVANCED:

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -300,7 +300,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   private class ManageKeysListener implements Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_manage_keys), REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS);
+      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_manage_keys), getString(R.string.enter_system_secret_to_continue), REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS);
       if (!result) {
         exportKeys();
       }

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -257,7 +257,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   private class BackupListener implements Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_backup), REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP);
+      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_backup), getString(R.string.enter_system_secret_to_continue), REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP);
       if (!result) {
         performBackup();
       }

--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -152,7 +152,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
             } else if (permille < 1000) {
                 percent = (permille-450)/5;
                 percentMax = 100;
-                statusLineText = getString(R.string.transferring) + String.format(Locale.getDefault(), " %d%%", percent);
+                statusLineText = getString(R.string.transferring);
                 hideQrCode = true;
             } else if (permille == 1000) {
                 statusLineText = getString(R.string.done) + " \uD83D\uDE00";

--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -28,8 +28,6 @@ import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Util;
 
-import java.util.Locale;
-
 public class BackupProviderFragment extends Fragment implements DcEventCenter.DcEventDelegate {
 
     private final static String TAG = BackupProviderFragment.class.getSimpleName();
@@ -70,10 +68,14 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
             dcBackupProvider = dcContext.newBackupProvider();
             Log.i(TAG, "##### newBackupProvider() returned");
             Util.runOnMain(() -> {
+                BackupTransferActivity activity = getTransferActivity();
+                if (activity == null || activity.isFinishing()) {
+                    return;
+                }
                 progressBar.setVisibility(View.GONE);
                 if (!dcBackupProvider.isOk()) {
-                    getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_ERROR);
-                    getTransferActivity().showLastErrorAlert("Cannot create backup provider");
+                    activity.setTransferState(BackupTransferActivity.TransferState.TRANSFER_ERROR);
+                    activity.showLastErrorAlert("Cannot create backup provider");
                     return;
                 }
                 statusLine.setVisibility(View.GONE);
@@ -101,7 +103,9 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
     @Override
     public void onDestroyView() {
         dcContext.stopOngoingProcess();
-        dcBackupProvider.unref();
+        if (dcBackupProvider != null) {
+            dcBackupProvider.unref();
+        }
         super.onDestroyView();
         DcHelper.getEventCenter(getActivity()).removeObservers(this);
     }

--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -57,7 +57,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
         qrImageView = view.findViewById(R.id.qrImage);
         setHasOptionsMenu(true);
 
-        statusLine.setText(R.string.one_moment);
+        statusLine.setText(R.string.preparing_account);
         progressBar.setIndeterminate(true);
 
         dcContext = DcHelper.getContext(getActivity());
@@ -140,12 +140,8 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
                 getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_ERROR);
                 getTransferActivity().showLastErrorAlert("Sending Error");
                 hideQrCode = true;
-            } else if(permille <= 100) {
-                statusLineText = getString(R.string.exporting_account);
-            } else if(permille <= 300) {
-                statusLineText = getString(R.string.preparing_account);
             } else if(permille <= 350) {
-                statusLineText = getString(R.string.account_prepared);
+                statusLineText = getString(R.string.preparing_account);
             } else if(permille <= 400) {
                 statusLineText = getString(R.string.waiting_for_receiver);
             } else if(permille <= 450) {

--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -41,6 +41,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
     private ProgressBar      progressBar;
     private View             topText;
     private SVGImageView     qrImageView;
+    private View             bottomText;
 
     @Override
     public void onCreate(Bundle bundle) {
@@ -55,6 +56,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
         progressBar = view.findViewById(R.id.progress_bar);
         topText = view.findViewById(R.id.top_text);
         qrImageView = view.findViewById(R.id.qrImage);
+        bottomText = view.findViewById(R.id.bottom_text);
         setHasOptionsMenu(true);
 
         statusLine.setText(R.string.preparing_account);
@@ -82,6 +84,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
                 } catch (SVGParseException e) {
                     e.printStackTrace();
                 }
+                bottomText.setVisibility(View.VISIBLE);
                 new Thread(() -> {
                     Log.i(TAG, "##### waitForReceiver() with qr: "+dcBackupProvider.getQr());
                     dcBackupProvider.waitForReceiver();
@@ -174,6 +177,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
             if (hideQrCode && qrImageView.getVisibility() != View.GONE) {
                 qrImageView.setVisibility(View.GONE);
                 topText.setVisibility(View.GONE);
+                bottomText.setVisibility(View.GONE);
                 statusLine.setVisibility(View.VISIBLE);
                 progressBar.setVisibility(permille == 1000 ? View.GONE : View.VISIBLE);
             }

--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -143,6 +143,8 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
             } else if(permille <= 350) {
                 statusLineText = getString(R.string.preparing_account);
             } else if(permille <= 400) {
+                statusLine.setVisibility(View.GONE);
+                progressBar.setVisibility(View.GONE);
                 statusLineText = getString(R.string.waiting_for_receiver);
             } else if(permille <= 450) {
                 statusLineText = getString(R.string.receiver_connected);

--- a/src/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
@@ -82,11 +82,8 @@ public class BackupReceiverFragment extends Fragment implements DcEventCenter.Dc
             if (permille == 0) {
                 getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_ERROR);
                 getTransferActivity().showLastErrorAlert("Receiving Error");
-            } else if (permille <= 50) {
-                statusLineText = getString(R.string.preparing_account); // "Connected"
-                hideSameNetworkHint = true;
             } else if (permille <= 100) {
-                statusLineText = getString(R.string.account_prepared);
+                statusLineText = getString(R.string.preparing_account);
                 hideSameNetworkHint = true;
             } else if (permille <= 950 ) {
                 percent = ((permille-100)*100)/850;

--- a/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -94,7 +94,6 @@ public class BackupTransferActivity extends BaseActionBarActivity {
         supportActionBar.setDisplayHomeAsUpEnabled(true);
         supportActionBar.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
         supportActionBar.setTitle(title);
-        supportActionBar.setSubtitle(R.string.multidevice_experimental_hint);
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
@@ -40,7 +40,6 @@ public class RegistrationQrActivity extends BaseActionBarActivity {
         if (addAsAnotherDevice) {
             setContentView(R.layout.activity_registration_2nd_device_qr);
             getSupportActionBar().setTitle(R.string.multidevice_receiver_title);
-            getSupportActionBar().setSubtitle(R.string.multidevice_experimental_hint);
         } else {
             setContentView(R.layout.activity_registration_qr);
             getSupportActionBar().setTitle(R.string.scan_invitation_code);

--- a/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -255,6 +255,7 @@ public final class GenericForegroundService extends Service {
              progressMax == entry.progressMax &&
              indeterminate == entry.indeterminate &&
              title.equals(entry.title) &&
+             contentText.equals(entry.contentText) &&
              channelId.equals(entry.channelId);
     }
 

--- a/src/org/thoughtcrime/securesms/util/ScreenLockUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ScreenLockUtil.java
@@ -11,11 +11,11 @@ public class ScreenLockUtil {
 
     public static final int REQUEST_CODE_CONFIRM_CREDENTIALS = 1001;
 
-    public static boolean applyScreenLock(Activity activity, String title, int requestCode) {
+    public static boolean applyScreenLock(Activity activity, String title, String descr, int requestCode) {
         KeyguardManager keyguardManager = (KeyguardManager) activity.getSystemService(Context.KEYGUARD_SERVICE);
         Intent intent;
         if (keyguardManager != null && isScreenLockAvailable()) {
-            intent = keyguardManager.createConfirmDeviceCredentialIntent(title, activity.getString(R.string.enter_system_secret_to_continue));
+            intent = keyguardManager.createConfirmDeviceCredentialIntent(title, descr);
             if (intent != null) {
                 activity.startActivityForResult(intent, requestCode);
                 return true;


### PR DESCRIPTION
this pr fixes some things wrt progress bars and crashes when the activity is left during preparing, see commits for details.

moreover, there was a recent request to add a confirmation dialog before the qr code is shown: not sure, how important that really is, however, it turns out, that we already show such a dialog for probably most security-aware ppl using a system-screen-lock (i added that, but have disabled it for testing :)
so, this pr adds a more on-point message to the screen-lock dialog  - and, if the system screen lock is disabled, we show the same message in an alert (that could be made nicer, but that is sth. post 1.36 - also, i assume most ppl use a screen lock)

<img width="300" alt="Screenshot 2023-03-26 at 18 59 33" src="https://user-images.githubusercontent.com/9800740/227792259-2a2d2713-bde5-4a4e-82ce-858809823bf2.png"> &nbsp; <img width="300" alt="Screenshot 2023-03-26 at 19 05 20" src="https://user-images.githubusercontent.com/9800740/227792264-d47f4385-20d9-4bee-8586-2cb567de79e7.png">

successor of #2493 
