### PR TITLE
[WIP] fix disappearing drafts, part II

### DIFF
--- a/androidTest/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
+++ b/androidTest/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
@@ -10,6 +10,7 @@ import androidx.test.filters.LargeTest;
 import com.b44t.messenger.TestUtils;
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,7 +26,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-
+@Ignore("This is not a test, but a benchmark. Remove the @Ignore to run it.")
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class EnterChatsBenchmark {


### PR DESCRIPTION
Fix #2509 

---

**Pecularities I didn't fix because they doesn't cause a bug, and I don't want to introduce one by changing a running system:**

---

`isSharing()` returns `false` if there is a `TEXT_EXTRA`, but no `IS_SHARING` set. So, it's possible that `getSharedText()` returns a non-null result, but `isSharing()` returns `false`. This diff would fix it:

```diff
--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@@ -31,7 -31,7 +31,8 @@@ public class RelayUtil 
  
      public static boolean isSharing(Activity activity) {
          try {
--            return activity.getIntent().getBooleanExtra(IS_SHARING, false);
++            Intent intent = activity.getIntent();
++            return intent.getBooleanExtra(IS_SHARING, false) || intent.hasExtra(TEXT_EXTRA);
```

---

When sharing text, `initializeDraft()` is actually called twice while the activity starts: Once directly from `onCreate()` an once from `handleSharing()`. Right now,
- When sharing a text, the first `initializeDraft()` sets it as a draft in the compose field.
- When sharing an image, `handleSharing()` sets it as a draft in the core, and the second `initializeDraft()` loads this into the compose field.

---

I have no idea what `isShareDraftInitialized` is good for. It's somehow used for setting `setResult(RESULT_OK);` if we shared, but 1. I'm not convinced `isShareDraftInitialized` is set to `true` everytime something is shared and 2. why do we need to call `setResult(RESULT_OK);` at all.

---

It's weird that there can be multiple running ConversationActivity's at all, and we wouldn't have to do all this `doReinitializeDraft` if there were not. In WA and TG, there is just one chat activity active at a time, and when you press back, you _alway_ get to the chat list.

It is currently the cause for at least three bugs:

1. - Share to the same chat from within DC
   - Go back
   - The shared text is gone
   
2. - Share to another chat from within DC
   - Open the image
   - Click Back
   - The image is gone

3. #2509