### PR TITLE
reword to "Unlock to continue"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -832,8 +832,8 @@
     <string name="devicemsg_bad_time">⚠️ Date or time on your device seems to be inaccurate (%1$s).\n\nAdjust your clock ⏰🔧 to ensure your messages are received correctly.</string>
     <string name="devicemsg_update_reminder">⚠️ Your Delta Chat version might be outdated.\n\nThis may cause problems because your chat partners use newer versions - and you are missing the latest features 😳\nPlease check https://get.delta.chat or your app store for updates.</string>
 
-    <!-- Some options as "Manage keys" or "Backup" may require the system PIN/Fingerprint/Gesture/Etc. to be entered in a system dialog. This hint is added to the system dialog, below a title as "Manage keys" or "Backup". -->
-    <string name="enter_system_secret_to_continue">Please enter your system defined secret to continue.</string>
+    <!-- Some options as "Add Second Device" or "Backup" may require the system PIN/Fingerprint/Gesture/Etc. to be entered in a system dialog. This hint is added to the system dialog, below a title as "Add Second Device" or "Backup". -->
+    <string name="enter_system_secret_to_continue">Unlock to continue</string>
 
     <!-- qr code stuff -->
     <string name="qr_code">QR Code</string>


### PR DESCRIPTION
'Unlock to continue' is shorter and sufficient - the context is shown above - and the way to unlock (password, swipe...) is shown below