### PR TITLE
make sure, only one error alert is shown 

### DIFF
--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -74,8 +74,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
                 }
                 progressBar.setVisibility(View.GONE);
                 if (!dcBackupProvider.isOk()) {
-                    activity.setTransferState(BackupTransferActivity.TransferState.TRANSFER_ERROR);
-                    activity.showLastErrorAlert("Cannot create backup provider");
+                    activity.setTransferError("Cannot create backup provider");
                     return;
                 }
                 statusLine.setVisibility(View.GONE);
@@ -144,8 +143,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
 
             Log.i(TAG,"DC_EVENT_IMEX_PROGRESS, " + permille);
             if (permille == 0) {
-                getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_ERROR);
-                getTransferActivity().showLastErrorAlert("Sending Error");
+                getTransferActivity().setTransferError("Sending Error");
                 hideQrCode = true;
             } else if(permille <= 350) {
                 statusLineText = getString(R.string.preparing_account);

--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -40,6 +40,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
     private View             topText;
     private SVGImageView     qrImageView;
     private View             bottomText;
+    private boolean          isFinishing;
 
     @Override
     public void onCreate(Bundle bundle) {
@@ -101,12 +102,13 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
 
     @Override
     public void onDestroyView() {
+        isFinishing = true;
+        DcHelper.getEventCenter(getActivity()).removeObservers(this);
         dcContext.stopOngoingProcess();
         if (dcBackupProvider != null) {
             dcBackupProvider.unref();
         }
         super.onDestroyView();
-        DcHelper.getEventCenter(getActivity()).removeObservers(this);
     }
 
     @Override
@@ -135,6 +137,10 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
     @Override
     public void handleEvent(@NonNull DcEvent event) {
         if (event.getId() == DcContext.DC_EVENT_IMEX_PROGRESS) {
+            if (isFinishing) {
+                return;
+            }
+
             int permille = event.getData1Int();
             int percent = 0;
             int percentMax = 0;

--- a/src/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
@@ -80,8 +80,7 @@ public class BackupReceiverFragment extends Fragment implements DcEventCenter.Dc
 
             Log.i(TAG,"DC_EVENT_IMEX_PROGRESS, " + permille);
             if (permille == 0) {
-                getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_ERROR);
-                getTransferActivity().showLastErrorAlert("Receiving Error");
+                getTransferActivity().setTransferError("Receiving Error");
             } else if (permille <= 100) {
                 statusLineText = getString(R.string.preparing_account);
                 hideSameNetworkHint = true;

--- a/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -15,7 +15,6 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 
-import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.BaseActionBarActivity;
 import org.thoughtcrime.securesms.ConversationListActivity;
@@ -148,6 +147,29 @@ public class BackupTransferActivity extends BaseActionBarActivity {
         this.transferState = transferState;
     }
 
+    public void setTransferError(@NonNull String errorContext) {
+        if (this.transferState != TransferState.TRANSFER_ERROR) {
+            this.transferState = TransferState.TRANSFER_ERROR;
+
+            String lastError = DcHelper.getContext(this).getLastError();
+            if (lastError.isEmpty()) {
+                lastError = "<last error not set>";
+            }
+
+            String error = errorContext;
+            if (!error.isEmpty()) {
+                error += ": ";
+            }
+            error += lastError;
+
+            new AlertDialog.Builder(this)
+                .setMessage(error)
+                .setPositiveButton(android.R.string.ok, null)
+                .setCancelable(false)
+                .show();
+        }
+    }
+
     private void finishOrAskToFinish() {
         switch (transferState) {
           case TRANSFER_ERROR:
@@ -191,25 +213,6 @@ public class BackupTransferActivity extends BaseActionBarActivity {
             overridePendingTransition(0, 0);
         }
         finish();
-    }
-
-    public void showLastErrorAlert(@NonNull String errorContext) {
-        String lastError = DcHelper.getContext(this).getLastError();
-        if (lastError.isEmpty()) {
-          lastError = "<last error not set>";
-        }
-
-        String error = errorContext;
-        if (!error.isEmpty()) {
-            error += ": ";
-        }
-        error += lastError;
-
-        new AlertDialog.Builder(this)
-          .setMessage(error)
-          .setPositiveButton(android.R.string.ok, null)
-          .setCancelable(false)
-          .show();
     }
 
     public static void appendSSID(Activity activity, final TextView textView) {


### PR DESCRIPTION
unref() will soon also emit errors, but also before, this was only correct by coincidence, this is for 1.36.1+ with core 1.112.2+ - but can also be merged sooner