### PR TITLE
if known, show ssid in the AlertDialog directly after scanning

### DIFF
--- a/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -213,7 +213,7 @@ public class BackupTransferActivity extends BaseActionBarActivity {
     }
 
     public static void appendSSID(Activity activity, final TextView textView) {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+        if (textView != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             new Thread(() -> {
                 try {
                     // depending on the android version, getting the SSID requires none, all or one of

--- a/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -84,7 +84,11 @@ public class QrCodeHandler {
                 });
                 builder.setNegativeButton(R.string.cancel, null);
                 builder.setCancelable(false);
-                break;
+
+                AlertDialog alertDialog = builder.create();
+                alertDialog.show();
+                BackupTransferActivity.appendSSID(activity, alertDialog.findViewById(android.R.id.message));
+                return;
 
             case DcContext.DC_QR_LOGIN:
                 String email = qrParsed.getText1();


### PR DESCRIPTION
this was requested several times during testing - also, later on, switching the network may require recreating qr and/or rescan

<img width="300" alt="Screenshot 2023-03-31 at 19 33 12" src="https://user-images.githubusercontent.com/9800740/229194233-0540d073-afb0-4d76-b708-19618a590018.png">
