### PR TITLE
join prepare/wait threads before calling unref

### DIFF
--- a/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -109,11 +109,15 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
         isFinishing = true;
         DcHelper.getEventCenter(getActivity()).removeObservers(this);
         dcContext.stopOngoingProcess();
+
         try {
             prepareThread.join();
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        // prepareThread has failed to create waitThread, as we already did wait for prepareThread right above.
+        // Order of waiting is important here.
         if (waitThread!=null) {
             try {
                 waitThread.join();
@@ -121,6 +125,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
                 e.printStackTrace();
             }
         }
+
         if (dcBackupProvider != null) {
             dcBackupProvider.unref();
         }


### PR DESCRIPTION
in theory, this should be more proper, if `stopOngoingProcess()` does not block and returns immediately - otherwise, we get ANR. did not test much yet, however

closes #2531 