### PR TITLE
do not intercept requests when loading remote content is disabled

### DIFF
--- a/src/org/thoughtcrime/securesms/FullMsgActivity.java
+++ b/src/org/thoughtcrime/securesms/FullMsgActivity.java
@@ -172,6 +172,9 @@ public class FullMsgActivity extends WebViewActivity
   protected WebResourceResponse interceptRequest(String url) {
     WebResourceResponse res = null;
     try {
+      if (!loadRemoteContent) {
+        throw new Exception("loading remote content disabled");
+      }
       if (url == null) {
         throw new Exception("no url specified");
       }


### PR DESCRIPTION
even with setBlockNetworkLoads(true),
shouldInterceptRequest() is called,
not sure if this is a bug or expected behavior,
i did not find documentation for that;
intuitively, i dit not expect sort of a proxy to bypass and explicit block_networks = true,
however, one can probably also argue in the other direction.

leaving setBlockNetworkLoads(true),
in case default behavior changes (or older webviews have different ones), we have a second layer.