### PR TITLE
Rework how activities interact when forwarding/sharing

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -162,6 +162,7 @@
 
     <activity android:name=".ConversationActivity"
               android:windowSoftInputMode="stateUnchanged"
+              android:launchMode="singleTask"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
               android:parentActivityName=".ConversationListActivity">
         <meta-data

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -163,8 +163,16 @@
     <activity android:name=".ConversationActivity"
               android:windowSoftInputMode="stateUnchanged"
               android:launchMode="singleTask"
+              android:relinquishTaskIdentity="true"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
               android:parentActivityName=".ConversationListActivity">
+        <!--
+        Without relinquishTaskIdentity="true", we would have the following bug:
+        - Directly open a chat via shortcut (by long-pressing on the DeltaChat icon in the launcher)
+        - Press back twice
+        - Reopen DeltaChat from recent apps
+        - Expected: ConversationList shown. Actual: The chat from the beginning is shown again.
+        -->
         <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.thoughtcrime.securesms.ConversationListActivity" />

--- a/androidTest/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
+++ b/androidTest/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
@@ -10,6 +10,7 @@ import androidx.test.filters.LargeTest;
 import com.b44t.messenger.TestUtils;
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,7 +26,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-
+@Ignore("This is not a test, but a benchmark. Remove the @Ignore to run it.")
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class EnterChatsBenchmark {

--- a/androidTest/com/b44t/messenger/uitests/offline/ForwardingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/offline/ForwardingTest.java
@@ -89,9 +89,6 @@ public class ForwardingTest {
     onView(withId(R.id.title)).check(matches(withText("group")));
 
     pressBack();
-    onView(withId(R.id.title)).check(matches(withText(R.string.saved_messages)));
-
-    pressBack();
     onView(withId(R.id.toolbar_title)).check(matches(withText(R.string.connectivity_not_connected)));
   }
 }

--- a/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
@@ -197,11 +197,15 @@ public class SharingTest {
     // In DC, select the same chat you opened before
     onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItem(hasDescendant(withText("abc@example.org")), click()));
 
-    // Leave DC and go back to the previous activity (that is still open in the background)
+    // Leave DC and go back to the previous activity
     pressBack();
 
+    // Here, we can't exactly replicate the "steps to reproduce". Previously, the other activity
+    // stayed open in the background, but since it doesn't anymore, we need to open it again:
+    onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItem(hasDescendant(withText("abc@example.org")), click()));
+
     // Check that the draft is still there
-    Util.sleep(2000);
+    // Util.sleep(2000);  // Uncomment for debugging
     onView(withHint(R.string.chat_input_placeholder)).check(matches(withText("Veeery important draft")));
   }
 

--- a/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
@@ -9,9 +9,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
-import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
-import com.b44t.messenger.DcMsg;
 import com.b44t.messenger.TestUtils;
 
 import org.junit.After;
@@ -31,10 +29,10 @@ import java.io.File;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
+import static androidx.test.espresso.matcher.ViewMatchers.withChild;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -90,7 +88,14 @@ public class SharingTest {
   @Test
   public void testShareFromScreenshot() {
     DcContext dcContext = DcHelper.getContext(getInstrumentation().getTargetContext());
-    String pngImage = getPngImage();
+    String[] files = new File(dcContext.getBlobdir()).list();
+    String pngImage = null;
+    assert files != null;
+    for (String file : files) {
+      if (file.endsWith(".png")) {
+        pngImage = file;
+      }
+    }
     Uri uri = Uri.parse("content://" + BuildConfig.APPLICATION_ID + ".attachments/" + Uri.encode(pngImage));
     DcHelper.sharedFiles.put("/" + pngImage, 1);
 
@@ -117,23 +122,6 @@ public class SharingTest {
     pressBack();
 
     onView(withId(R.id.fab)).check(matches(isClickable()));
-  }
-
-  /**
-   * Get the URI of a PNG image we find in the blobdir.
-   * It doesn't matter which one, this is just meant so that we can test sending an image.
-   */
-  private String getPngImage() {
-    DcContext dcContext = DcHelper.getContext(getInstrumentation().getTargetContext());
-    String[] files = new File(dcContext.getBlobdir()).list();
-    assert files != null;
-    for (String file : files) {
-      if (file.endsWith(".png")) {
-        return file;
-      }
-    }
-
-    throw new RuntimeException("No image files found");
   }
 
   /**
@@ -215,41 +203,6 @@ public class SharingTest {
     // Check that the draft is still there
     Util.sleep(2000);
     onView(withHint(R.string.chat_input_placeholder)).check(matches(withText("Veeery important draft")));
-  }
-
-  // - Share an image to another chat from within DC
-  // - Open the image
-  // - Click back
-  // - Check that the image is still there
-  @Test
-  public void testShareToOtherChat() {
-    DcContext dcContext = DcHelper.getContext(getInstrumentation().getTargetContext());
-
-    String image = getPngImage();
-
-    DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_IMAGE);
-    msg.setFile(dcContext.getBlobdir() + "/" + image, "image/png");
-    int chatId = dcContext.createChatByContactId(DcContact.DC_CONTACT_ID_SELF);
-    dcContext.sendMsg(chatId, msg);
-
-    onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItem(hasDescendant(withText("Saved Messages")), click()));
-    onView(withId(android.R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(0, longClick()));
-
-    DcHelper.INSTRUMENTATION_TESTING = true;
-    onView(withId(R.id.menu_context_share)).perform(click());
-
-    onView(withId(R.id.list)).perform(RecyclerViewActions.actionOnItem(hasDescendant(withText("abc@example.org")), click()));
-    onView(withId(R.id.removable_media_view)).perform(click());
-    pressBack();
-
-    onView(withId(R.id.removable_media_view)).perform(click());
-    pressBack();
-
-    TestUtils.pressSend();
-
-    onView(withId(android.R.id.list)).perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-    pressBack();
-    pressBack();
   }
 
   @After

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -263,11 +263,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       eventCenter.addObserver(DcContext.DC_EVENT_MSG_DELIVERED, this);
     }
 
-    if (isForwarding(this)) {
-      handleForwarding();
-    } else if (isSharing(this)) {
-      handleSharing();
-    }
+    handleRelaying();
   }
 
   @Override
@@ -293,15 +289,21 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       }
     });
 
+    handleRelaying();
+
+    if (fragment != null) {
+      fragment.onNewIntent();
+    }
+  }
+
+  private void handleRelaying() {
     if (isForwarding(this)) {
       handleForwarding();
     } else if (isSharing(this)) {
       handleSharing();
     }
 
-    if (fragment != null) {
-      fragment.onNewIntent();
-    }
+    ConversationListRelayingActivity.finishActivity();
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -281,6 +281,9 @@ public class ConversationFragment extends MessageSelectorFragment
             ConversationAdapter adapter = new ConversationAdapter(getActivity(), this.recipient.getChat(), GlideApp.with(this), locale, selectionClickListener, this.recipient);
             list.setAdapter(adapter);
 
+            if (dateDecoration != null) {
+                list.removeItemDecoration(dateDecoration);
+            }
             dateDecoration = new StickyHeaderDecoration(adapter, false, false);
             list.addItemDecoration(dateDecoration);
 
@@ -295,11 +298,11 @@ public class ConversationFragment extends MessageSelectorFragment
             reloadList();
             updateLocationButton();
 
+            if (lastSeenDecoration != null) {
+                list.removeItemDecoration(lastSeenDecoration);
+            }
             if (freshMsgs > 0) {
                 getListAdapter().setLastSeenPosition(freshMsgs - 1);
-                if (lastSeenDecoration != null) {
-                    list.removeItemDecoration(lastSeenDecoration);
-                }
                 lastSeenDecoration = new ConversationAdapter.LastSeenHeader(getListAdapter());
                 list.addItemDecoration(lastSeenDecoration);
             }

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -19,7 +19,6 @@ package org.thoughtcrime.securesms;
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
 import static org.thoughtcrime.securesms.ConversationActivity.STARTING_POSITION_EXTRA;
 import static org.thoughtcrime.securesms.map.MapDataManager.ALL_CHATS_GLOBAL_MAP;
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.getDirectSharingChatId;
 import static org.thoughtcrime.securesms.util.RelayUtil.isDirectSharing;
@@ -66,6 +65,7 @@ import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.Prefs;
+import org.thoughtcrime.securesms.util.RelayUtil;
 import org.thoughtcrime.securesms.util.SendRelayedMessageUtil;
 
 public class ConversationListActivity extends PassphraseRequiredActionBarActivity
@@ -209,10 +209,6 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     refreshAvatar();
     refreshTitle();
     handleOpenpgp4fpr();
-    if (isDirectSharing(this)) {
-      openConversation(getDirectSharingChatId(this), -1);
-    }
-
     if (isDirectSharing(this)) {
       openConversation(getDirectSharingChatId(this), -1);
     }
@@ -437,13 +433,6 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
         IntentResult scanResult = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
         QrCodeHandler qrCodeHandler = new QrCodeHandler(this);
         qrCodeHandler.onScanPerformed(scanResult);
-        break;
-      case REQUEST_RELAY:
-        if (resultCode == RESULT_OK) {
-          handleResetRelaying();
-          setResult(RESULT_OK);
-          finish();
-        }
         break;
       default:
         break;

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -395,10 +395,8 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       intent.putExtra(STARTING_POSITION_EXTRA, startingPosition);
       if (isRelayingMessageContent(this)) {
         acquireRelayMessageContent(this, intent);
-        startActivityForResult(intent, REQUEST_RELAY);
-      } else {
-        startActivity(intent);
       }
+      startActivity(intent);
 
       overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
     }
@@ -409,10 +407,8 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     Intent intent = new Intent(this, ConversationListArchiveActivity.class);
     if (isRelayingMessageContent(this)) {
       acquireRelayMessageContent(this, intent);
-      startActivityForResult(intent, REQUEST_RELAY);
-    } else {
-      startActivity(intent);
     }
+    startActivity(intent);
     overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
   }
 
@@ -429,10 +425,8 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     Intent intent = new Intent(this, NewConversationActivity.class);
     if (isRelayingMessageContent(this)) {
       acquireRelayMessageContent(this, intent);
-      startActivityForResult(intent, REQUEST_RELAY);
-    } else {
-      startActivity(intent);
     }
+    startActivity(intent);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
@@ -102,10 +102,8 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
     intent.putExtra(FROM_ARCHIVED_CHATS_EXTRA, true);
     if (isRelayingMessageContent(this)) {
       acquireRelayMessageContent(this, intent);
-      startActivityForResult(intent, REQUEST_RELAY);
-    } else {
-      startActivity(intent);
     }
+    startActivity(intent);
 
     overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
   }

--- a/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
@@ -14,7 +14,6 @@ import org.thoughtcrime.securesms.util.DynamicTheme;
 
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
 import static org.thoughtcrime.securesms.ConversationActivity.FROM_ARCHIVED_CHATS_EXTRA;
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.isSharing;
@@ -84,7 +83,7 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
 
     switch (item.getItemId()) {
       case android.R.id.home:
-        super.onBackPressed();
+        onBackPressed();
         return true;
 
       case R.id.mark_as_read:
@@ -96,12 +95,31 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
   }
 
   @Override
+  public void onBackPressed() {
+    if (isRelayingMessageContent(this)) {
+      // Go back to the ConversationListRelayingActivity
+      super.onBackPressed();
+    } else {
+      // Load the ConversationListActivity in case it's not existent for some reason
+      Intent intent = new Intent(this, ConversationListActivity.class);
+      intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+      startActivity(intent);
+      finish();
+    }
+  }
+
+  @Override
   public void onCreateConversation(int chatId) {
     Intent intent = new Intent(this, ConversationActivity.class);
     intent.putExtra(CHAT_ID_EXTRA, chatId);
     intent.putExtra(FROM_ARCHIVED_CHATS_EXTRA, true);
     if (isRelayingMessageContent(this)) {
       acquireRelayMessageContent(this, intent);
+
+      // Just finish instead of updating the title and so on. This is not user-visible
+      // because the ConversationActivity will restart the ConversationListArchiveActivity
+      // after the user left.
+      finish();
     }
     startActivity(intent);
 
@@ -111,14 +129,5 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
   @Override
   public void onSwitchToArchive() {
     throw new AssertionError();
-  }
-
-  @Override
-  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-    super.onActivityResult(requestCode, resultCode, data);
-    if (requestCode == REQUEST_RELAY && resultCode == RESULT_OK) {
-      setResult(RESULT_OK);
-      finish();
-    }
   }
 }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -232,7 +232,7 @@ public class ConversationListFragment extends Fragment
         });
       } else {
         acquireRelayMessageContent(getActivity(), intent);
-        fab.setOnClickListener(v -> getActivity().startActivityForResult(intent, REQUEST_RELAY));
+        fab.setOnClickListener(v -> getActivity().startActivity(intent));
       }
     } else {
       fab.setOnClickListener(v -> startActivity(intent));

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -74,7 +74,6 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedText;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedUris;
@@ -597,13 +596,13 @@ public class ConversationListFragment extends Fragment
   public void handleEvent(@NonNull DcEvent event) {
     if (event.getId() == DcContext.DC_EVENT_CONNECTIVITY_CHANGED) {
       Activity activity = getActivity();
-      if (activity != null) {
+      if (activity instanceof ConversationListActivity) {
         ((ConversationListActivity) activity).refreshTitle();
       }
 
     } else if (event.getId() == DcContext.DC_EVENT_SELFAVATAR_CHANGED) {
       Activity activity = getActivity();
-      if (activity != null) {
+      if (activity instanceof ConversationListActivity) {
         ((ConversationListActivity) activity).refreshAvatar();
       }
 

--- a/src/org/thoughtcrime/securesms/ConversationListRelayingActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListRelayingActivity.java
@@ -27,11 +27,11 @@ import androidx.fragment.app.Fragment;
 public class ConversationListRelayingActivity extends ConversationListActivity {
   public static void start(Fragment fragment, Intent intent) {
     intent.setComponent(new ComponentName(fragment.getContext(), ConversationListRelayingActivity.class));
-    fragment.startActivityForResult(intent, REQUEST_RELAY);
+    fragment.startActivity(intent);
   }
 
   public static void start(Activity activity, Intent intent) {
     intent.setComponent(new ComponentName(activity, ConversationListRelayingActivity.class));
-    activity.startActivityForResult(intent, REQUEST_RELAY);
+    activity.startActivity(intent);
   }
 }

--- a/src/org/thoughtcrime/securesms/ConversationListRelayingActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListRelayingActivity.java
@@ -1,12 +1,13 @@
 package org.thoughtcrime.securesms;
 
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
-
 import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Intent;
+import android.os.Bundle;
 
 import androidx.fragment.app.Fragment;
+
+import java.lang.ref.WeakReference;
 
 /**
  * "Relaying" means "Forwarding or Sharing".
@@ -25,6 +26,21 @@ import androidx.fragment.app.Fragment;
  */
 
 public class ConversationListRelayingActivity extends ConversationListActivity {
+  static WeakReference<ConversationListRelayingActivity> INSTANCE = null;
+
+  @Override
+  protected void onCreate(Bundle icicle, boolean ready) {
+    super.onCreate(icicle, ready);
+    INSTANCE = new WeakReference<>(this);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    INSTANCE = null;
+  }
+
+  // =================== Static Methods ===================
   public static void start(Fragment fragment, Intent intent) {
     intent.setComponent(new ComponentName(fragment.getContext(), ConversationListRelayingActivity.class));
     fragment.startActivity(intent);
@@ -33,5 +49,11 @@ public class ConversationListRelayingActivity extends ConversationListActivity {
   public static void start(Activity activity, Intent intent) {
     intent.setComponent(new ComponentName(activity, ConversationListRelayingActivity.class));
     activity.startActivity(intent);
+  }
+
+  public static void finishActivity() {
+    if (INSTANCE != null && INSTANCE.get() != null) {
+      INSTANCE.get().finish();
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -182,11 +182,9 @@ public class NewConversationActivity extends ContactSelectionActivity {
     intent.putExtra(CHAT_ID_EXTRA, chatId);
     if (isRelayingMessageContent(this)) {
       acquireRelayMessageContent(this, intent);
-      startActivityForResult(intent, REQUEST_RELAY);
-    } else {
-      startActivity(intent);
-      finish();
     }
+    startActivity(intent);
+    finish();
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -40,7 +40,6 @@ import java.util.Map;
 
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
 import static org.thoughtcrime.securesms.ConversationActivity.TEXT_EXTRA;
-import static org.thoughtcrime.securesms.util.RelayUtil.REQUEST_RELAY;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 
@@ -207,15 +206,6 @@ public class NewConversationActivity extends ContactSelectionActivity {
     */
     super.onPrepareOptionsMenu(menu);
     return true;
-  }
-
-  @Override
-  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-    super.onActivityResult(requestCode, resultCode, data);
-    if (requestCode == REQUEST_RELAY && resultCode == RESULT_OK) {
-      setResult(RESULT_OK);
-      finish();
-    }
   }
 
 }

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -269,8 +269,6 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
       RelayUtil.setSharedUris(composeIntent, resolvedExtras);
       ConversationListRelayingActivity.start(this, composeIntent);
     }
-    // We use startActivityForResult() here so that the conversations list is correctly updated. (hide "Device messages", ...)a
-    // With startActivity() the list was not always updated before and after sharing and incorrectly showed or did not show the device talk.
     finish();
   }
 

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 public class DcHelper {
 
   private static final String TAG = DcHelper.class.getSimpleName();
-  public static boolean INSTRUMENTATION_TESTING = false;
 
     public static final String CONFIG_ADDRESS = "addr";
     public static final String CONFIG_CONFIGURED_ADDRESS = "configured_addr";
@@ -299,14 +298,7 @@ public class DcHelper {
         intent.putExtra(Intent.EXTRA_STREAM, uri);
         intent.putExtra(Intent.EXTRA_TEXT, msg.getText());
         intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        if (INSTRUMENTATION_TESTING) {
-          // When we're running an instrumentation test, we can't use an activity chooser.
-          // Instead, just open the share intent with DC itself.
-          intent.setPackage(activity.getPackageName());
-          activity.startActivity(intent);
-        } else {
-          activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.chat_share_with_title)));
-        }
+        activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.chat_share_with_title)));
       }
     } catch (RuntimeException e) {
       Toast.makeText(activity, String.format("%s (%s)", activity.getString(R.string.no_app_to_handle_data), mimeType), Toast.LENGTH_LONG).show();

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 public class DcHelper {
 
   private static final String TAG = DcHelper.class.getSimpleName();
+  public static boolean INSTRUMENTATION_TESTING = false;
 
     public static final String CONFIG_ADDRESS = "addr";
     public static final String CONFIG_CONFIGURED_ADDRESS = "configured_addr";
@@ -298,7 +299,14 @@ public class DcHelper {
         intent.putExtra(Intent.EXTRA_STREAM, uri);
         intent.putExtra(Intent.EXTRA_TEXT, msg.getText());
         intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.chat_share_with_title)));
+        if (INSTRUMENTATION_TESTING) {
+          // When we're running an instrumentation test, we can't use an activity chooser.
+          // Instead, just open the share intent with DC itself.
+          intent.setPackage(activity.getPackageName());
+          activity.startActivity(intent);
+        } else {
+          activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.chat_share_with_title)));
+        }
       }
     } catch (RuntimeException e) {
       Toast.makeText(activity, String.format("%s (%s)", activity.getString(R.string.no_app_to_handle_data), mimeType), Toast.LENGTH_LONG).show();

--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@ -14,7 +14,6 @@ public class RelayUtil {
     private static final String FORWARDED_MESSAGE_IDS   = "forwarded_message_ids";
     private static final String SHARED_URIS             = "shared_uris";
     private static final String IS_SHARING              = "is_sharing";
-    public static final int REQUEST_RELAY = 100;
     private static final String DIRECT_SHARING_CHAT_ID = "direct_sharing_chat_id";
 
     public static boolean isRelayingMessageContent(Activity activity) {

--- a/src/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcMsg;
 
+import org.thoughtcrime.securesms.ConversationListRelayingActivity;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
@@ -33,7 +34,7 @@ public class SendRelayedMessageUtil {
   }
 
   public static void immediatelyRelay(Activity activity, final Long[] chatIds) {
-    activity.setResult(RESULT_OK);
+    ConversationListRelayingActivity.finishActivity();
     if (isForwarding(activity)) {
       int[] forwardedMessageIDs = getForwardedMessageIDs(activity);
       resetRelayingMessageContent(activity);


### PR DESCRIPTION
It always seemed weird to me that there can be multiple running ConversationActivity's. In WA and TG, there is just one chat activity active at a time, and when you press back, you _alway_ get to the chat list.

Now, I noticed that having multiple ConversationActivity's is the cause for at least three bugs on master:

1. - Share to the same chat from within DC
   - Go back
   - The shared text is gone
   
2. - Share to another chat from within DC
   - Open the image
   - Click Back
   - The image is gone

3. #2509

In the past, it was also the reason for #2032 and made #1770 necessary.

@adbenitez also agreed that WA's and TG's behavior is nicer. Soooo, that's what this PR introduces.

This is a pretty big change, so this PR probably introduces new bugs, but fixing three bugs at once, making the logic a lot easier (`doReinitializeDraft`, I'm looking at you), and introducing the behavior that users know from other messengers seems worth it. Plus, I assume that the future bugs will be easier to fix, because there isn't a whole bunch of complex logic that could break with every change you make.

Fixes #2509.

---

**Pecularities I didn't fix because they doesn't cause a bug, and I didn't want to introduce one by changing a running system: (maybe I'll fix some of them later, I'll see)**

---

`isSharing()` returns `false` if there is a `TEXT_EXTRA`, but no `IS_SHARING` set. So, it's possible that `getSharedText()` returns a non-null result, but `isSharing()` returns `false`. This diff would fix it:

```diff
--- a/src/org/thoughtcrime/securesms/util/RelayUtil.java
+++ b/src/org/thoughtcrime/securesms/util/RelayUtil.java
@@@ -31,7 -31,7 +31,8 @@@ public class RelayUtil 
  
      public static boolean isSharing(Activity activity) {
          try {
--            return activity.getIntent().getBooleanExtra(IS_SHARING, false);
++            Intent intent = activity.getIntent();
++            return intent.getBooleanExtra(IS_SHARING, false) || intent.hasExtra(TEXT_EXTRA);
```

---

When sharing text, `initializeDraft()` is actually called twice while the activity starts: Once directly from `onCreate()` an once from `handleSharing()`. Right now,
- When sharing a text, the first `initializeDraft()` sets it as a draft in the compose field.
- When sharing an image, `handleSharing()` sets it as a draft in the core, and the second `initializeDraft()` loads this into the compose field.

---

`DIRECT_SHARING_CHAT_ID` isn't actually used anymore. It's read, but `setDirectSharing()`, which would write it, is unused as of #1852. Instead, the intent created by getChooserTargets() directly sets `EXTRA_CHAT_ID`. So, `DIRECT_SHARING_CHAT_ID` and related logic could be removed.