### PR TITLE
fix: Make replying privately work again

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -469,8 +469,8 @@ public class ConversationFragment extends MessageSelectorFragment
 
             Intent intent = new Intent(getActivity(), ConversationActivity.class);
             intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, privateChatId);
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             getActivity().startActivity(intent);
-            getActivity().finish();
         } else {
             Log.e(TAG, "Activity was null");
         }
@@ -841,10 +841,10 @@ public class ConversationFragment extends MessageSelectorFragment
                 intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, foreignChatId);
                 int start = DcMsg.getMessagePosition(quoted, dcContext);
                 intent.putExtra(ConversationActivity.STARTING_POSITION_EXTRA, start);
+                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 ((ConversationActivity) getActivity()).hideSoftKeyboard();
                 if (getActivity() != null) {
                     getActivity().startActivity(intent);
-                    getActivity().finish();
                 } else {
                     Log.e(TAG, "Activity was null");
                 }


### PR DESCRIPTION
Follow-up for #2549

The bug was: Replying privately gets you to the chatlist instead of the chat, and quotes to messages replied privately don't jump to the chat but to the chatlist.

The bugfix is removing the `finish()`. Adding `FLAG_ACTIVITY_CLEAR_TOP` is just to make sure that we will never have two ConversationActivities at once here, also in future Android versions that might change the behavior.