### PR TITLE
add `sendMessage()` api for exporting data to saved-messages

### DIFF
--- a/res/raw/webxdc.js
+++ b/res/raw/webxdc.js
@@ -39,5 +39,10 @@ window.webxdc = (() => {
     sendUpdate: (payload, descr) => {
       InternalJSApi.sendStatusUpdate(JSON.stringify(payload), descr);
     },
+
+    sendMessage: (payload) => {
+      payload.__blobBase64 = btoa(payload.blob) // JSON.stringify() does not handle Blob objects
+      InternalJSApi.sendMessage(JSON.stringify(payload));
+    },
   };
 })();

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -1,5 +1,7 @@
 package org.thoughtcrime.securesms;
 
+import static com.b44t.messenger.DcContext.DC_GCL_FOR_FORWARDING;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -344,13 +346,14 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         byte[] data = Base64.decode(jsonObject.getString("__blobBase64"), Base64.NO_WRAP | Base64.NO_PADDING);
         String[] fileName = jsonObject.getString("fileName").split("\\.");
 
+        // consider sending the special webxdc-function with a core function
         File file = File.createTempFile(fileName[0], "."+fileName[1], getCacheDir());
         StreamUtil.copy(new ByteArrayInputStream(data), new FileOutputStream(file));
 
         DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_FILE);
         msg.setText(jsonObject.getString("text"));
         msg.setFile(file.getAbsolutePath(), null);
-        dcContext.sendMsg(dcAppMsg.getChatId(), msg); // TODO: use saved-messages chat instead, probably do a core function
+        dcContext.sendMsg(dcContext.getChatlist(DC_GCL_FOR_FORWARDING, null, 0).getChatId(0), msg); // TODO: use saved-messages chat instead, probably do a core function
       } catch (Exception e) {
         e.printStackTrace();
       }

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -30,6 +30,7 @@ import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
 
 import com.b44t.messenger.DcChat;
+import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
 import com.b44t.messenger.DcMsg;
@@ -353,7 +354,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_FILE);
         msg.setText(jsonObject.getString("text"));
         msg.setFile(file.getAbsolutePath(), null);
-        dcContext.sendMsg(dcContext.getChatlist(DC_GCL_FOR_FORWARDING, null, 0).getChatId(0), msg); // TODO: use saved-messages chat instead, probably do a core function
+        dcContext.sendMsg(dcContext.createChatByContactId(DcContact.DC_CONTACT_ID_SELF), msg);
       } catch (Exception e) {
         e.printStackTrace();
       }

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Base64;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -330,6 +331,23 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         return false;
       }
       return true;
+    }
+
+    @JavascriptInterface
+    public boolean sendMessage(String payload) {
+      Log.i(TAG, "sendMessage");
+      try {
+        JSONObject jsonObject = new JSONObject(payload);
+        byte[] data = Base64.decode(jsonObject.getString("__blobBase64"), Base64.NO_WRAP | Base64.NO_PADDING);
+        //String filename = jsonObject.getString("fileName");
+
+        DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+        msg.setText(jsonObject.getString("text"));
+        dcContext.sendMsg(dcAppMsg.getChatId(), msg); // TODO: use saved-messages chat instead, probably do a core function
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      return false;
     }
 
     @JavascriptInterface

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -38,9 +38,12 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.JsonUtils;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.Prefs;
+import org.thoughtcrime.securesms.util.StreamUtil;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -339,10 +342,14 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       try {
         JSONObject jsonObject = new JSONObject(payload);
         byte[] data = Base64.decode(jsonObject.getString("__blobBase64"), Base64.NO_WRAP | Base64.NO_PADDING);
-        //String filename = jsonObject.getString("fileName");
+        String[] fileName = jsonObject.getString("fileName").split("\\.");
 
-        DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+        File file = File.createTempFile(fileName[0], "."+fileName[1], getCacheDir());
+        StreamUtil.copy(new ByteArrayInputStream(data), new FileOutputStream(file));
+
+        DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_FILE);
         msg.setText(jsonObject.getString("text"));
+        msg.setFile(file.getAbsolutePath(), null);
         dcContext.sendMsg(dcAppMsg.getChatId(), msg); // TODO: use saved-messages chat instead, probably do a core function
       } catch (Exception e) {
         e.printStackTrace();

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -283,7 +283,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         try (InputStream inputStream = getContentResolver().openInputStream(uri)) {
             File file = File.createTempFile(TMP_BACKUP_FILE, ".tmp", getCacheDir());
             try (OutputStream outputStream = new FileOutputStream(file)) {
-                StreamUtil.copy(inputStream, outputStream);
+                StreamUtil.copy(inputStream, new FileOutputStream(file));
             }
             return file;
         }


### PR DESCRIPTION
`sendMessage` takes an object with `blob`, `fileName`, `text` as parameters, currently, the message is always sent to the saved-messages chat, for the future, we consider to allow sending to the webxdc's source chat as well, therefore the broader name

TODO:
- [ ] settle api, maybe return a promise so we can let the user confirm when it comes to sending to another chat


at https://github.com/webxdc/webxdc-test/pull/9 there is a test for the `sendMessage` api

targets https://github.com/deltachat/deltachat-core-rust/issues/4350
