### PR TITLE
Tweak chatlist colors: Make titles more visible in dark mode

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -215,10 +215,10 @@
         <item name="conversation_list_item_background">@drawable/conversation_list_item_background_dark</item>
         <item name="pinned_list_item_background">@drawable/pinned_list_item_background_dark</item>
         <item name="conversation_list_deaddrop_bg_color">@color/pinned_bg_dark</item>
-        <item name="conversation_list_item_contact_color">@color/gray10</item>
-        <item name="conversation_list_item_subject_color">@color/gray10</item>
+        <item name="conversation_list_item_contact_color">@color/white</item>
+        <item name="conversation_list_item_subject_color">@color/core_dark_30</item>
         <item name="conversation_list_item_delivery_icon_color">@color/core_dark_55</item>
-        <item name="conversation_list_item_date_color">@color/gray10</item>
+        <item name="conversation_list_item_date_color">@color/core_dark_30</item>
         <item name="conversation_list_item_unread_color">@color/core_white</item>
         <item name="conversation_list_item_divider">@drawable/conversation_list_divider_shape_dark</item>
 


### PR DESCRIPTION
Before, the chat names were as bright as the subtitles, which made them hard to distinguish.