### PR TITLE
streamline map wording

### DIFF
--- a/res/menu/conversation.xml
+++ b/res/menu/conversation.xml
@@ -35,7 +35,7 @@
         android:title="@string/videochat" />
 
     <item android:id="@+id/menu_show_map"
-        android:title="@string/menu_show_map"
+        android:title="@string/tab_map"
         android:icon="@drawable/ic_map_white_24dp"
         app:showAsAction="ifRoom" />
 

--- a/res/menu/text_secure_normal.xml
+++ b/res/menu/text_secure_normal.xml
@@ -10,13 +10,13 @@
     <item android:title="@string/menu_new_chat"
           android:id="@+id/menu_new_chat" />
 
+    <item android:title="@string/menu_all_media"
+        android:id="@+id/menu_all_media" />
+
     <item android:title="@string/menu_show_global_map"
         android:id="@+id/menu_global_map"
         android:visible="false"
         />
-
-    <item android:title="@string/menu_all_media"
-        android:id="@+id/menu_all_media" />
 
     <item android:title="@string/menu_settings"
           android:id="@+id/menu_settings" />

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -157,6 +157,7 @@
     <string name="switch_camera">Switch Camera</string>
     <string name="toggle_fullscreen">Toggle Full Screen Mode</string>
     <string name="location">Location</string>
+    <string name="locations">Locations</string>
     <string name="gallery">Gallery</string>
     <string name="images_and_videos">Images and Videos</string>
     <string name="file">File</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -203,8 +203,7 @@
     <string name="menu_toggle_keyboard">Toggle Emoji Keyboard</string>
     <string name="menu_edit_group">Edit Group</string>
     <string name="menu_group_name_and_image">Group Name and Image</string>
-    <string name="menu_show_map">Show Map</string>
-    <string name="menu_show_global_map">Show all Locations</string>
+    <string name="menu_show_global_map">All Locations</string>
     <string name="menu_archive_chat">Archive Chat</string>
     <string name="menu_unarchive_chat">Unarchive Chat</string>
     <string name="menu_add_attachment">Add Attachment</string>


### PR DESCRIPTION
this pr syncs the wording of "All Location" to what is used elsewhere in the app and common in apps in general (omitting the verb "show" before objects).

see commit messages for more details.

before / after:

<img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/c70e2982-876b-41dd-b7a0-4aa1e774effe> &nbsp; &nbsp; <img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/9f686b9e-2cb4-4ce3-8c36-224c205ec020>
