### PR TITLE
Adapt Padlock and Location indicator to screen size

### DIFF
--- a/res/layout/conversation_item_footer.xml
+++ b/res/layout/conversation_item_footer.xml
@@ -10,8 +10,8 @@
 
     <ImageView
         android:id="@+id/footer_secure_indicator"
-        android:layout_width="12dp"
-        android:layout_height="11dp"
+        android:layout_width="12sp"
+        android:layout_height="11sp"
         android:src="@drawable/msg_encr_out"
         android:visibility="gone"
         android:layout_gravity="center_vertical|end"
@@ -30,8 +30,8 @@
 
     <ImageView
         android:id="@+id/footer_location_indicator"
-        android:layout_width="12dp"
-        android:layout_height="11dp"
+        android:layout_width="12sp"
+        android:layout_height="11sp"
         android:src="@drawable/ic_location_msg"
         android:visibility="gone"
         android:layout_gravity="center_vertical|end"


### PR DESCRIPTION
Fix #2566 - well, mostly: This enlarges the padlock (and the location indicator if it's present), but not the checkmark(s), because I didn't manage to also enlarge the checkmark(s) within a bit more than half an hour of work (and I still don't have an idea how it might work, though surely possible).

When using the app like this, this feels good as-is.

This PR with "Largest" resp. "Normal" text size:

![Screenshot_20230522-235058](https://github.com/deltachat/deltachat-android/assets/18012815/ad3acbaf-a990-482d-84ad-6019880be918)

![Screenshot_20230522-235028](https://github.com/deltachat/deltachat-android/assets/18012815/8dd1c4eb-bcb8-4185-b68a-6b64def904e4)
