### PR TITLE
reword 'Copy to Clipboard' to 'Copy Text'

### DIFF
--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -25,7 +25,7 @@
         android:visible="false"
         app:showAsAction="never" />
 
-    <item android:title="@string/menu_copy_to_clipboard"
+    <item android:title="@string/menu_copy_text_to_clipboard"
         android:id="@+id/menu_context_copy"
         android:icon="?menu_copy_icon"
         app:showAsAction="always" />


### PR DESCRIPTION
message list allows multiple messages
being copied to clipboard at the same time;
if these messages as not just text, a summary is added, sth. as "Voice Messages" or "Forwarded: Image - this is my family" etc.

this is on purpose and the gist of the action,
renaming the action to 'Copy Text' makes that more clear.

targets #2569 