### PR TITLE
./update-core.sh accepts tags as well as branches

### DIFF
--- a/scripts/update-core.sh
+++ b/scripts/update-core.sh
@@ -1,3 +1,5 @@
+set -e # stop on all errors
+
 git submodule update --init --recursive
 cd jni/deltachat-core-rust
 OLD=`git branch --show-current`
@@ -10,7 +12,7 @@ fi
 NEW=$1
 
 git fetch
-git checkout $NEW || exit 1
+git checkout $NEW
 TEST=`git branch --show-current`
 if [ "$TEST" == "$NEW" ]; then
     git pull

--- a/scripts/update-core.sh
+++ b/scripts/update-core.sh
@@ -2,28 +2,26 @@ git submodule update --init --recursive
 cd jni/deltachat-core-rust
 OLD=`git branch --show-current`
 if [ $# -eq 0 ]; then
-    echo "updates deltachat-core-rust submodule to last commit of a branch."
-    echo "usage: ./scripts/update-core.sh BRANCH_NAME"
+    echo "updates deltachat-core-rust submodule to a tag or to last commit of a branch."
+    echo "usage: ./scripts/update-core.sh BRANCH_OR_TAG"
     echo "current branch: $OLD"
     exit
 fi
-BRANCH=$1
-
+NEW=$1
 
 git fetch
-git checkout $BRANCH
+git checkout $NEW || exit 1
 TEST=`git branch --show-current`
-if [ "$TEST" != "$BRANCH" ]; then
-    echo "cannot select branch: $BRANCH"
-    exit
+if [ "$TEST" == "$NEW" ]; then
+    git pull
 fi
-git pull
+
 commitmsg=`git log -1 --pretty=%s`
 cd ../..
 
 
 git add jni/deltachat-core-rust
-git commit -m "update deltachat-core-rust to '$commitmsg' of branch '$BRANCH'"
-echo "old branch: $OLD, new branch: $BRANCH"
+git commit -m "update deltachat-core-rust to '$commitmsg' of '$NEW'"
+echo "old: $OLD, new: $NEW"
 echo "changes are committed to local repo."
 echo "use 'git push' to use them or 'git reset HEAD~1; git submodule update --recursive' to abort."


### PR DESCRIPTION
core always has a new tag for releases, but only randomly a branch.

this pr changes the update script so that both are accepted and branches can be created as needed.