### PR TITLE
add strings for improved sendToChat title

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -413,6 +413,9 @@
     <string name="start_app">Start…</string>
     <!-- this is a warning that is shown when one tries to send something to a chat that is not yet accepted. -->
     <string name="accept_request_first">Please accept the chat request first.</string>
+    <!-- placeholder will be replaced by a file name -->
+    <string name="send_file_to">Send \"%1%s\" to…</string>
+    <string name="send_message_to">Send Message to…</string>
 
     <!-- map -->
     <string name="filter_map_on_time">Show locations in time frame</string>


### PR DESCRIPTION
the current dialog that is show on sendToChat() reads `Share with`.

the idea is to add the filename and also adapt verb to "send" instead of "share" (although i am +-0 on that, it seems more fitting)