### PR TITLE
prepare 1.38.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Delta Chat Android Changelog
 
+## v1.38.2
+2023-06
+
+* fix version code issue with google play
+* using core117.0
+
+
 ## v1.38.1
 2023-06
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 657
-        versionName "1.38.1"
+        versionCode 658
+        versionName "1.38.2"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
needed a new version code: after a failing upload of 1.38.1 to google play, further attempts to upload the 1.38.1 file again were rejected 🤣

![Screenshot 2023-06-21 at 22 15 21](https://github.com/deltachat/deltachat-android/assets/9800740/2a4c14d8-0d62-41a8-a1b1-a25eab6de835)

with the version updated to 1.38.2 things are working again (🍋 https://download.delta.chat/android/deltachat-gplay-release-1.38.2.apk) - so 1.38 is finally on the way to gplay ...


