### PR TITLE
Reduce native library size

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -20,10 +20,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE     := native-utils
 
 LOCAL_C_INCLUDES := $(JNI_DIR)/utils/
-LOCAL_LDLIBS 	:= -ljnigraphics -llog -lz
+LOCAL_LDLIBS := -llog
 LOCAL_STATIC_LIBRARIES :=  deltachat-core
 
-LOCAL_CFLAGS 	:= -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Os -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
+LOCAL_CFLAGS 	:= -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
 LOCAL_CFLAGS 	+= -Drestrict='' -D__EMX__ -DFIXED_POINT -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -fno-math-errno
 LOCAL_CFLAGS 	+= -DANDROID_NDK -DDISABLE_IMPORTGL -fno-strict-aliasing -DAVOID_TABLES -DANDROID_TILE_BASED_DECODE -DANDROID_ARMV6_IDCT -ffast-math -D__STDC_CONSTANT_MACROS
 

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,3 +1,8 @@
 APP_PLATFORM := android-16
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
-APP_STL := c++_static
+APP_STL := none
+
+ifneq ($(NDK_DEBUG),1)
+APP_CFLAGS  += -Oz -flto=full -fno-unwind-tables -fno-exceptions -fno-asynchronous-unwind-tables -fomit-frame-pointer
+APP_LDFLAGS += -flto=full
+endif

--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -39,6 +39,8 @@
 set -e
 echo "starting time: `date`"
 
+export CFLAGS="-fno-unwind-tables -fno-exceptions -fno-asynchronous-unwind-tables -fomit-frame-pointer"
+
 : "${ANDROID_NDK_ROOT:=$ANDROID_NDK_HOME}"
 : "${ANDROID_NDK_ROOT:=$ANDROID_NDK}"
 if test -z "$ANDROID_NDK_ROOT"; then


### PR DESCRIPTION
This PR reduces the size of the native library and cleans up the makefiles used by `ndk-build`.

CFLAGS set in `Application.mk` or `Android.mk` are also not passed to the C compiler building vendored OpenSSL, because by the time `scripts/ndk-make.sh` executes [`ndk-build`](https://developer.android.com/ndk/guides/ndk-build), `cargo` has already finished. If we want to build OpenSSL with additional flags like `-fno-unwind-tables`, we need to set these flags via CFLAGS in ndk-make.sh.

Closes #2597 