### PR TITLE
Don't recreate WebxdcActivity when going to dark mode

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -318,7 +318,7 @@
     <activity android:name=".WebxdcActivity"
               android:label=""
               android:theme="@style/TextSecure.LightTheme"
-              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize|uiMode"
               android:exported="true">
     </activity>
 


### PR DESCRIPTION
@adbenitez this fixes the problem you reported that if the user sets the device to dark mode while a webxdc is open, it re-loads veeeeery slowly.

Slight downside: The title bar isn't correctly updated when going into dark mode, i.e. it doesn't become black.
- When going to dark mode, onConfigurationChanged() is called which we can override, but I didn't find a way to update the title bar except for https://stackoverflow.com/a/49209143/8037600, which I didn't want to copy-paste and seems way too complex just to change the color of the title bar a bit.