### PR TITLE
Compile native library with -fvisibility=hidden

### DIFF
--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -39,7 +39,7 @@
 set -e
 echo "starting time: `date`"
 
-export CFLAGS="-fno-unwind-tables -fno-exceptions -fno-asynchronous-unwind-tables -fomit-frame-pointer"
+export CFLAGS="-fno-unwind-tables -fno-exceptions -fno-asynchronous-unwind-tables -fomit-frame-pointer -fvisibility=hidden"
 
 : "${ANDROID_NDK_ROOT:=$ANDROID_NDK_HOME}"
 : "${ANDROID_NDK_ROOT:=$ANDROID_NDK}"


### PR DESCRIPTION
This avoids exposing the symbols of the used libraries like SQLite3 and reduces the library size.

Fixes #2606 