### PR TITLE
Fix crash in the "Full Msg" view by downgrading Gson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.journeyapps:zxing-android-embedded:3.4.0' // QR Code scanner
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1' // used as JSON library
-    implementation 'com.google.code.gson:gson:2.10.1' // used as JSON library
+    implementation 'com.google.code.gson:gson:2.9.1' // used as JSON library
     implementation "me.leolin:ShortcutBadger:1.1.16" // display messagecount on the home screen icon.
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9' // used in the emoji selector for the tab selection.
     implementation 'com.github.chrisbanes:PhotoView:2.1.3' // does the zooming on photos / media

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.journeyapps:zxing-android-embedded:3.4.0' // QR Code scanner
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1' // used as JSON library
-    implementation 'com.google.code.gson:gson:2.9.1' // used as JSON library
+    implementation 'com.google.code.gson:gson:2.9.1' // used as JSON library. Don't upgrade to 2.10.1: https://github.com/deltachat/deltachat-android/pull/2610
     implementation "me.leolin:ShortcutBadger:1.1.16" // display messagecount on the home screen icon.
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9' // used in the emoji selector for the tab selection.
     implementation 'com.github.chrisbanes:PhotoView:2.1.3' // does the zooming on photos / media

--- a/src/com/b44t/messenger/rpc/Rpc.java
+++ b/src/com/b44t/messenger/rpc/Rpc.java
@@ -93,7 +93,7 @@ public class Rpc {
 
     public Map<String, String> getSystemInfo() throws RpcException {
         TypeToken<Map<String, String>> mapType = new TypeToken<Map<String, String>>(){};
-        return gson.fromJson(getResult("get_system_info"), mapType);
+        return gson.fromJson(getResult("get_system_info"), mapType.getType());
     }
 
     public HttpResponse getHttpResponse(int accountId, String url) throws RpcException {


### PR DESCRIPTION
@adbenitez figured this out, I'm just creating the PR because we tested it on my laptop.

Thanks :tada:!

The issue was:
- On Android 4.2 or older:
- Open an HTML message in Full Msg View
- Enable loading remote images

-> The app crashes.

We only had an Android 4.1 Emulator to test it, but assume that it's the same issue.

It's a known issue in gson 2.10.1: https://github.com/google/gson/issues/2310