### PR TITLE
Update ndk-make.sh initial comment to suggest an app for determining CPU architecture

### DIFF
--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -15,6 +15,8 @@
 #
 #     adb shell uname -m
 #
+# Use an app like: https://f-droid.org/packages/com.kgurgul.cpuinfo/
+#
 # Or you just guess your phone's architecture to be arm64-v8a and if you
 # guessed wrongly, a warning message will pop up inside the app, telling
 # you what the correct one is.


### PR DESCRIPTION
Providing an alternative that does not require ADB / connecting a device to laptop. When searching online for "android determine CPU architecture" many non-OSS apps where suggested. I found this app in f-droid to be useful. Maybe somebody else is helped by this.