### PR TITLE
fix: load updated display name when chat protection breaks

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1649,9 +1649,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (dcChat.isProtectionBroken()) {
       messageRequestBottomView.setBlockText(R.string.more_info_desktop);
-      messageRequestBottomView.setBlockOnClickListener(v -> DcHelper.showVerificationBrokenDialog(this, recipient.getName()));
+      String name = dcContext.getContact(recipient.getDcContact().getId()).getDisplayName();
+      messageRequestBottomView.setBlockOnClickListener(v -> DcHelper.showVerificationBrokenDialog(this, name));
 
-      messageRequestBottomView.setQuestion(getString(R.string.chat_protection_broken, recipient.getName()));
+      messageRequestBottomView.setQuestion(getString(R.string.chat_protection_broken, name));
       messageRequestBottomView.setAcceptText(R.string.ok);
 
     } else if (dcChat.getType() == DcChat.DC_CHAT_TYPE_GROUP) {


### PR DESCRIPTION
`recipient.getDcContact()` has an old snapshot of the contact that might have changed display name specially by the time we receive a message from a new device and encryption breaks