### PR TITLE
set correct mime type for .wasm files

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -238,6 +238,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         if (mimeType == null) {
           switch (ext) {
             case "js": mimeType = "text/javascript"; break;
+            case "wasm": mimeType = "application/wasm"; break;
             default:   mimeType = "application/octet-stream"; Log.i(TAG, "unknown mime type for " + rawUrl); break;
           }
         }


### PR DESCRIPTION
in case, getMimeTypeFromExtension()
fails to figure out the mime type for .wasm files, we set application/wasm manually afterwards

closes #2635 

