### PR TITLE
adapt videochat instance example

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -311,7 +311,7 @@
     <string name="videochat_tap_to_open">Tap to Open</string>
     <string name="videochat_instance">Video Chat Instance</string>
     <string name="videochat_instance_placeholder">Your Video Chat Instance</string>
-    <string name="videochat_instance_example">Examples: https://meet.jit.si/$ROOM or basicwebrtc:https://your-server</string>
+    <string name="videochat_instance_example">Example: https://your-server.org/$ROOM</string>
     <string name="videochat_instance_explain_2">If enabled, you can start a video chat from each chat. Requires a compatible app or a browser on both ends.</string>
     <string name="videochat_instance_from_qr">Use \"%1$s\" to invite others to video chats?\n\nOnce set, you can start a video chat from each chat. This replaces any previous setting for video chats.</string>
     <string name="videochat_invitation">Video chat invitation</string>


### PR DESCRIPTION
- meet.jit.si is no longer usable without registration, so does not work smoothly for ad-hoc calls

- basicwebrtc: protocol is no longer build-in in any app, so that example does not make sense as well

this is an intermediate step,
we want to get rid of the example string completely and instead show the URLs of the predefined settings.

closes https://github.com/deltachat/deltachat-android/issues/2642

once merged, this requires `./scripts/tx-update-changed-sources.sh` to be run (**from master, not stable!**, so before, we need to merge stable to master /me still not convinced that this stable/master makes sense ... there are so many additional things that can be done wrong, once verified-one-to-ones are stable, we should reconsider this)