### PR TITLE
fix: add missing `bqi` entry to language_values array

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -70,6 +70,7 @@
       <item>hr</item>
       <item>it</item>
       <item>lt</item>
+      <item>bqi</item>
       <item>hu</item>
       <item>nl</item>
       <item>nb</item>


### PR DESCRIPTION
Fixes #2645

This was missing in #2628 