### PR TITLE
set targetSdkVersion to 33

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,7 +14,12 @@
 
     <!-- dangerous permissions - we need to as the user with a PermissionsRequest -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
-
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -16,8 +16,6 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
 
     <uses-permission android:name="android.permission.CAMERA" />

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
 android {
     namespace "org.thoughtcrime.securesms"
     flavorDimensions "none"
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     // Set NDK version to strip native libraries.
     // Even though we compile our libraries outside Gradle with `scripts/ndk-make.sh`,

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ android {
         multiDexEnabled true
 
         minSdkVersion 16
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         vectorDrawables.useSupportLibrary = true
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -919,6 +919,7 @@
     <string name="notify_name_and_message">Name and message</string>
     <string name="notify_name_only">Name only</string>
     <string name="notify_no_name_or_message">No name or message</string>
+    <string name="notifications_disabled">Notifications disabled</string>
 
 
     <!-- permissions -->
@@ -928,6 +929,7 @@
     <string name="perm_explain_access_to_mic_denied">To send audio messages, go to the app settings, select \"Permissions\", and enable \"Microphone\".</string>
     <string name="perm_explain_access_to_storage_denied">To receive or send files, go to the app settings, select \"Permissions\", and enable \"Storage\".</string>
     <string name="perm_explain_access_to_location_denied">To attach a location, go to the app settings, select \"Permissions\", and enable \"Location\".</string>
+    <string name="perm_explain_access_to_notifications_denied">To receive notifications, go to \"System Settings / Apps / Delta Chat\" and enable \"Notifications\".</string>
 
     <!-- ImageEditorHud -->
     <string name="ImageEditorHud_draw_anywhere_to_blur">Draw anywhere to blur</string>

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -17,6 +17,7 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
@@ -247,7 +248,16 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
 
         switch (category) {
         case PREFERENCE_CATEGORY_NOTIFICATIONS:
-          fragment = new NotificationsPreferenceFragment();
+          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || Permissions.hasAll(getActivity(), Manifest.permission.POST_NOTIFICATIONS)) {
+            fragment = new NotificationsPreferenceFragment();
+          } else {
+            new AlertDialog.Builder(getActivity())
+              .setTitle(R.string.notifications_disabled)
+              .setMessage(R.string.perm_explain_access_to_notifications_denied)
+              .setPositiveButton(R.string.perm_continue, (dialog, which) -> getActivity().startActivity(Permissions.getApplicationSettingsIntent(getActivity())))
+              .setNegativeButton(android.R.string.cancel, null)
+              .show();
+          }
           break;
         case PREFERENCE_CATEGORY_CONNECTIVITY:
           startActivity(new Intent(getActivity(), ConnectivityActivity.class));

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -41,6 +41,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.widget.TooltipCompat;
@@ -58,6 +59,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.connect.DirectShareUtil;
 import org.thoughtcrime.securesms.map.MapActivity;
 import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.qr.QrActivity;
 import org.thoughtcrime.securesms.qr.QrCodeHandler;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -442,5 +444,10 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       default:
         break;
     }
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    Permissions.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
   }
 }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -16,6 +16,7 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -60,6 +61,8 @@ import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.connect.DirectShareUtil;
 import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.permissions.Permissions;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.RelayUtil;
 import org.thoughtcrime.securesms.util.SendRelayedMessageUtil;
 import org.thoughtcrime.securesms.util.Util;
@@ -267,7 +270,21 @@ public class ConversationListFragment extends Fragment
 
       @Override
       protected void onPostExecute(Void result) {
-        DozeReminder.maybeAskDirectly(getActivity());
+        Activity activity = ConversationListFragment.this.getActivity();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          if (!Prefs.getBooleanPreference(activity, Prefs.ASKED_FOR_NOTIFICATION_PERMISSION, false)) {
+            Prefs.setBooleanPreference(activity, Prefs.ASKED_FOR_NOTIFICATION_PERMISSION, true);
+            Permissions.with(activity)
+              .request(Manifest.permission.POST_NOTIFICATIONS)
+              .ifNecessary()
+              .onAllGranted(() -> {
+                DozeReminder.maybeAskDirectly(getActivity());
+              })
+              .execute();
+          }
+        } else {
+          DozeReminder.maybeAskDirectly(getActivity());
+        }
       }
     }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, getActivity());
   }

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -280,6 +280,15 @@ public class ConversationListFragment extends Fragment
               .onAllGranted(() -> {
                 DozeReminder.maybeAskDirectly(getActivity());
               })
+              .onAnyDenied(() -> {
+                new AlertDialog.Builder(activity)
+                  .setTitle(R.string.notifications_disabled)
+                  .setMessage(R.string.perm_explain_access_to_notifications_denied)
+                  .setCancelable(false)
+                  .setPositiveButton(R.string.perm_continue, (dialog, which) -> activity.startActivity(Permissions.getApplicationSettingsIntent(activity)))
+                  .setNegativeButton(android.R.string.cancel, null)
+                  .show();
+              })
               .execute();
           }
         } else {

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -51,6 +51,7 @@ import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcChatlist;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
+import com.b44t.messenger.DcMsg;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.thoughtcrime.securesms.ConversationListAdapter.ItemClickListener;
@@ -281,13 +282,11 @@ public class ConversationListFragment extends Fragment
                 DozeReminder.maybeAskDirectly(getActivity());
               })
               .onAnyDenied(() -> {
-                new AlertDialog.Builder(activity)
-                  .setTitle(R.string.notifications_disabled)
-                  .setMessage(R.string.perm_explain_access_to_notifications_denied)
-                  .setCancelable(false)
-                  .setPositiveButton(R.string.perm_continue, (dialog, which) -> activity.startActivity(Permissions.getApplicationSettingsIntent(activity)))
-                  .setNegativeButton(android.R.string.cancel, null)
-                  .show();
+                final DcContext dcContext = DcHelper.getContext(activity);
+                DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+                msg.setText("\uD83D\uDC49 "+activity.getString(R.string.notifications_disabled)+" \uD83D\uDC48\n\n"
+                  +activity.getString(R.string.perm_explain_access_to_notifications_denied));
+                dcContext.addDeviceMsg("android.notifications-disabled", msg);
               })
               .execute();
           }

--- a/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
+++ b/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
@@ -116,7 +116,7 @@ public class AttachmentTypeSelector extends PopupWindow {
   }
 
   public void show(@NonNull Activity activity, final @NonNull View anchor) {
-    if (Permissions.hasAll(activity, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+    if (Permissions.hasAll(activity, Permissions.galleryPermissions())) {
       recentRail.setVisibility(View.VISIBLE);
       loaderManager.restartLoader(1, null, recentRail);
     } else {

--- a/src/org/thoughtcrime/securesms/components/AvatarSelector.java
+++ b/src/org/thoughtcrime/securesms/components/AvatarSelector.java
@@ -80,7 +80,7 @@ public class AvatarSelector extends PopupWindow {
   }
 
   public void show(@NonNull Activity activity, final @NonNull View anchor) {
-    if (Permissions.hasAll(activity, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+    if (Permissions.hasAll(activity, Permissions.galleryPermissions())) {
       recentRail.setVisibility(View.VISIBLE);
       loaderManager.restartLoader(1, null, recentRail);
     } else {

--- a/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
@@ -36,7 +36,7 @@ public class RecentPhotosLoader extends CursorLoader {
 
   @Override
   public Cursor loadInBackground() {
-    if (Permissions.hasAll(context, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+    if (Permissions.hasAll(context, Permissions.galleryPermissions())) {
       return context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                                                 PROJECTION, SELECTION, null,
                                                 MediaStore.Images.ImageColumns.DATE_MODIFIED + " DESC");

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -445,7 +445,7 @@ public class AttachmentManager {
 
   public static void selectGallery(Activity activity, int requestCode) {
     Permissions.with(activity)
-               .request(Manifest.permission.READ_EXTERNAL_STORAGE)
+               .request(Permissions.galleryPermissions())
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
                .onAllGranted(() -> selectMediaType(activity, "image/*", new String[] {"image/*", "video/*"}, requestCode))
@@ -454,7 +454,7 @@ public class AttachmentManager {
 
   public static void selectImage(Activity activity, int requestCode) {
     Permissions.with(activity)
-            .request(Manifest.permission.READ_EXTERNAL_STORAGE)
+            .request(Permissions.galleryPermissions())
             .ifNecessary()
             .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
             .onAllGranted(() -> selectMediaType(activity, "image/*", null, requestCode))

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -463,7 +463,7 @@ public class AttachmentManager {
 
   public static void selectAudio(Activity activity, int requestCode) {
     Permissions.with(activity)
-               .request(Permissions.audioPermissions())
+               .request(Manifest.permission.READ_EXTERNAL_STORAGE)
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
                .onAllGranted(() -> selectMediaType(activity, "audio/*", null, requestCode))

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -463,7 +463,7 @@ public class AttachmentManager {
 
   public static void selectAudio(Activity activity, int requestCode) {
     Permissions.with(activity)
-               .request(Manifest.permission.READ_EXTERNAL_STORAGE)
+               .request(Permissions.audioPermissions())
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
                .onAllGranted(() -> selectMediaType(activity, "audio/*", null, requestCode))

--- a/src/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.permissions;
 
 
+import android.Manifest;
 import android.app.Activity;
 import androidx.appcompat.app.AlertDialog;
 import android.content.Context;
@@ -33,6 +34,14 @@ import java.util.List;
 import java.util.Map;
 
 public class Permissions {
+
+  public static String audioPermissions() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      return Manifest.permission.READ_MEDIA_AUDIO;
+    } else {
+      return Manifest.permission.READ_EXTERNAL_STORAGE;
+    }
+  }
 
   private static final Map<Integer, PermissionsRequest> OUTSTANDING = new LRUCache<>(2);
 

--- a/src/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -36,6 +36,10 @@ import java.util.Map;
 public class Permissions {
 
   public static String[] galleryPermissions() {
+    // on modern androids, the gallery picker works without permissions,
+    // however, the "camera roll" still requires permissions.
+    // to get that dialog at a UX-wise good moment, we still always ask for permission when opening gallery.
+    // just-always-asking this also avoids the mess with handling various paths for various apis.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       return new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO};
     } else {

--- a/src/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -43,14 +43,6 @@ public class Permissions {
     }
   }
 
-  public static String audioPermissions() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      return Manifest.permission.READ_MEDIA_AUDIO;
-    } else {
-      return Manifest.permission.READ_EXTERNAL_STORAGE;
-    }
-  }
-
   private static final Map<Integer, PermissionsRequest> OUTSTANDING = new LRUCache<>(2);
 
   public static PermissionsBuilder with(@NonNull Activity activity) {
@@ -151,6 +143,18 @@ public class Permissions {
     }
 
     public void execute() {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        // READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE does not exist on modern androids
+        // as file access is done by pickers
+        String[] r = requestedPermissions;
+        Arrays.sort(r);
+        if ( (r.length == 1 && (r[0].equals(Manifest.permission.READ_EXTERNAL_STORAGE) || r[0].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)))
+          || (r.length == 2 &&  r[0].equals(Manifest.permission.READ_EXTERNAL_STORAGE) && r[1].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) ) {
+          allGrantedListener.run();
+          return;
+        }
+      }
+
       PermissionsRequest request = new PermissionsRequest(allGrantedListener, anyDeniedListener, anyPermanentlyDeniedListener, anyResultListener,
                                                           someGrantedListener, someDeniedListener, somePermanentlyDeniedListener);
 

--- a/src/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -35,6 +35,14 @@ import java.util.Map;
 
 public class Permissions {
 
+  public static String[] galleryPermissions() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      return new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO};
+    } else {
+      return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE};
+    }
+  }
+
   public static String audioPermissions() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       return Manifest.permission.READ_MEDIA_AUDIO;

--- a/src/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -272,7 +272,7 @@ public class Permissions {
     resultListener.onResult(permissions, grantResults, shouldShowRationaleDialog);
   }
 
-  private static Intent getApplicationSettingsIntent(@NonNull Context context) {
+  public static Intent getApplicationSettingsIntent(@NonNull Context context) {
     Intent intent = new Intent();
     intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
     Uri uri = Uri.fromParts("package", context.getPackageName(), null);

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -21,6 +21,7 @@ import android.text.TextUtils;
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.KeepAliveService;
+import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.Prefs;
 
 import static android.app.Activity.RESULT_OK;
@@ -198,8 +199,10 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
   }
 
   public static CharSequence getSummary(Context context) {
-    boolean notificationsEnabled = Prefs.isNotificationsEnabled(context);
-    String ret = context.getString(notificationsEnabled ? R.string.on : R.string.off);
-    return ret;
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || Permissions.hasAll(context, Manifest.permission.POST_NOTIFICATIONS)) {
+      return context.getString(Prefs.isNotificationsEnabled(context) ? R.string.on : R.string.off);
+    } else {
+      return context.getString(R.string.disabled_in_system_settings);
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -206,7 +206,7 @@ public class BackupTransferActivity extends BaseActionBarActivity {
             new Thread(() -> {
                 try {
                     // depending on the android version, getting the SSID requires none, all or one of
-                    // ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE, ACCESS_NETWORK_STATE and maybe even more.
+                    // ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION, NEARBY_WIFI_DEVICES, ACCESS_WIFI_STATE, ACCESS_NETWORK_STATE and maybe even more.
                     final WifiManager wifiManager = (WifiManager)activity.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                     if (wifiManager.isWifiEnabled()) {
                         final WifiInfo info = wifiManager.getConnectionInfo();

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -49,6 +49,7 @@ public class Prefs {
   private static final String ENTER_SENDS_PREF                 = "pref_enter_sends";
   private static final String PROMPTED_DOZE_MSG_ID_PREF        = "pref_prompted_doze_msg_id";
   public  static final String DOZE_ASKED_DIRECTLY              = "pref_doze_asked_directly";
+  public  static final String ASKED_FOR_NOTIFICATION_PERMISSION= "pref_asked_for_notification_permission";
   private static final String IN_THREAD_NOTIFICATION_PREF      = "pref_key_inthread_notifications";
   public  static final String MESSAGE_BODY_TEXT_SIZE_PREF      = "pref_message_body_text_size";
 


### PR DESCRIPTION
this PR updates targetSdkVersion to 33, compiling and building works, however, this kind if updates usually also comes with behaviour changes (see  https://developer.android.com/about/versions/13/behavior-changes-all ) that need to be checked carefully:

concrete things that do not work at a first glance:




- [x] attach audio or gallery (instead of permission request, the fallback "Permission required" info is shown)

- [x] the "quick image attach bar" is ~~not shown~~ empty as the permissions are granted, but reading photos fails

- [x] check remaining occurrences of READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE: EDIT: done, we keep the permissions in the code, however bypass the check on api33 

- [x] check if writing files (backups, keys, export images, ...) work EDIT: log: OK , key: OK , backup: OK , export attachment (imasge): OK

- [x] ["Privacy": "Runtime permission for notifications"](https://developer.android.com/about/versions/13/behavior-changes-all#notification-permission): "Android 13 (API level 33) introduces a runtime [notification permission](https://developer.android.com/guide/topics/ui/notifiers/notification-permission): [POST_NOTIFICATIONS](https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS). This change helps users focus on the notifications that are most important to them."  
also see [below](https://github.com/deltachat/deltachat-android/pull/2649#issuecomment-1733929228)

- [x] add a device message if the user taps "deny notifications" 

- [x] handle "denied notifications" in the system settings

general aspects (unticked items need to be checked, please add a summary-IMPACT next to the items then):

- [x] ["Performance and battery": "Task Manager"](https://developer.android.com/about/versions/13/behavior-changes-all#fgs-manager): Apps must be able to [handle this user-initiated stopping](https://developer.android.com/guide/components/foreground-services#handle-user-initiated-stop)." - IMPACT: things seem to work as expected, when delta is restarted, the permanent notification reappears (users can disable it in the settings). system looks like the following: <br><img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/f0046a7f-a2c3-43e2-9ffc-41571a3d5ce1> <img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/c44079bf-a0da-406e-ab72-d52fdfb2e2be>

- [x] ["Performance and battery": "Improve prefetch job handling using JobScheduler"](https://developer.android.com/about/versions/13/behavior-changes-all): IMPACT: JobScheduler seems to be unused by us

- [x] ["Performance and battery": "High Priority Firebase Cloud Message (FCM) Quotas"](https://developer.android.com/about/versions/13/behavior-changes-all#fcm-quotas): IMPACT we do not use FCM 

- [x] ["Performance and battery": "Battery Resource Utilization"](https://developer.android.com/about/versions/13/behavior-changes-all#battery-resource-utilization): there is a new battery mode "restricted" where "foreground services" cannot be launched (so, our permantent notification) - we should make sure, that we do not crash in this case - IMPACT: looks good at a first glance, a beta test with different, real devices  will tell more

- [x] ["Privacy": "Hide sensitive content from clipboard"](https://developer.android.com/about/versions/13/behavior-changes-all#copy-sensitive-content) - IMPACT: should not affect us

- [x] ["Security": "Intent filters block non-matching intents"](https://developer.android.com/about/versions/13/behavior-changes-all#intents) - IMPACT: i cannot really make sense of the link, however, in practise, things work on first tries :)

- [x] ["Security": "Migrate away from shared user ID"](https://developer.android.com/about/versions/13/behavior-changes-all): IMPACT: we're not using android:sharedUserId

- [x] ["User experience": "Dismissible foreground service notifications"](https://developer.android.com/about/versions/13/behavior-changes-all#dismissible-fgs-notifs) - not sure if this is the same as _"Performance and battery": "Task Manager"_ above - IMACT: assuming, the foreground service is still active if the notification is dismissed, this is a nice feature. iirc, hiding/dismissing foreground notifications was also possible before. however, if it turns out, the dismissed notification affects the service, we should call [setOngoing()](https://developer.android.com/reference/android/app/Notification.Builder#setOngoing(boolean)) 

- [x] ["Core functionality": "Legacy copy of speech service implementation removed"](https://developer.android.com/about/versions/13/behavior-changes-all#speech-service) - IMPACT: we're not using RecognitionService or SpeechService

closes https://github.com/deltachat/deltachat-android/issues/2599

