### PR TITLE
Ask for the name when creating a broadcast list

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -376,7 +376,7 @@
     </plurals>
     <!-- The placeholder will be replaced by the name of the recipient in a one-to-one chat. -->
     <string name="chat_new_one_to_one_hint">Send a message to %1$s; they can even receive it without Delta Chat.</string>
-    <string name="chat_new_broadcast_hint">In a broadcast list, the recipients will receive messages in a read-only chat.\n\nThey will not be see the other recipients.</string>
+    <string name="chat_new_broadcast_hint">In a broadcast list, recipients will receive messages in a read-only chat with you.</string>
     <string name="chat_new_group_hint">Others will only see this group after you sent a first message.</string>
     <string name="chat_record_slide_to_cancel">Slide to cancel</string>
     <string name="chat_record_explain">Tap and hold to record a voice message, release to send</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -376,7 +376,7 @@
     </plurals>
     <!-- The placeholder will be replaced by the name of the recipient in a one-to-one chat. -->
     <string name="chat_new_one_to_one_hint">Send a message to %1$s; they can even receive it without Delta Chat.</string>
-    <string name="chat_new_broadcast_hint">In a broadcast list, others will receive messages in their private chats with you.\n\nThe recipients will not be aware of each other.</string>
+    <string name="chat_new_broadcast_hint">In a broadcast list, the recipients will receive messages in a read-only chat.\n\nThey will not be see the other recipients.</string>
     <string name="chat_new_group_hint">Others will only see this group after you sent a first message.</string>
     <string name="chat_record_slide_to_cancel">Slide to cancel</string>
     <string name="chat_record_explain">Tap and hold to record a voice message, release to send</string>

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -232,6 +232,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     initializeAvatarView();
 
     if (broadcast) {
+      avatar.setVisibility(View.GONE);
       groupHints.setText(R.string.chat_new_broadcast_hint);
       groupHints.setVisibility(isEdit()? View.GONE : View.VISIBLE);
       ViewUtil.findById(this, R.id.verify_button).setVisibility(View.INVISIBLE);

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -232,10 +232,6 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     initializeAvatarView();
 
     if (broadcast) {
-      ViewUtil.findById(this, R.id.group_image_holder).setVisibility(isEdit()? View.VISIBLE : View.GONE);
-      avatar.setVisibility(View.GONE);
-      groupName.setVisibility(isEdit()? View.VISIBLE : View.GONE);
-      groupName.setHint(R.string.name_desktop);
       groupHints.setText(R.string.chat_new_broadcast_hint);
       groupHints.setVisibility(isEdit()? View.GONE : View.VISIBLE);
       ViewUtil.findById(this, R.id.verify_button).setVisibility(View.INVISIBLE);
@@ -329,11 +325,12 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void groupCreateInDb() {
+    String groupName = getGroupName();
+    if (showGroupNameEmptyToast(groupName)) return;
     if (broadcast) {
       groupChatId = dcContext.createBroadcastList();
+      dcContext.setChatName(groupChatId, groupName);
     } else {
-      String groupName = getGroupName();
-      if (showGroupNameEmptyToast(groupName)) return;
       groupChatId = dcContext.createGroupChat(verified, groupName);
     }
 


### PR DESCRIPTION
Before https://github.com/deltachat/deltachat-core-rust/pull/4644, when creating a broadcast list, the UIs didn't ask for a name since the name wasn't shown to the recipients and therefore not that important.

As of https://github.com/deltachat/deltachat-core-rust/pull/4644, broadcast lists will create their own chat for the recipients, showing the broadcast lists's name, so we should ask the user for a name when creating a broadcast list.