### PR TITLE
ignore title click when relaying content

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -308,7 +308,11 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   }
 
   private void initializeTitleListener() {
-    title.setOnClickListener(v -> startActivity(new Intent(this, ConnectivityActivity.class)));
+    title.setOnClickListener(v -> {
+      if (!isRelayingMessageContent(this)) {
+        startActivity(new Intent(this, ConnectivityActivity.class));
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
don't open connectivity activity when title is clicked if the program is relaying content (forwarding, sharing, etc)