### PR TITLE
style: add dark theme for webxdc wrapper

### DIFF
--- a/res/raw/webxdc_wrapper.html
+++ b/res/raw/webxdc_wrapper.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="color-scheme" content="dark light">
     <style>
       html,
       body {


### PR DESCRIPTION
~~With webxdc~~ it affects the "loading" stage

Related: https://github.com/deltachat/deltachat-desktop/pull/3411

I have not tested it live. ~~I only checked the color on the help page with dev tools on Desktop. The contrast is better than it is in light mode.~~