### PR TITLE
disable web API for fullscreen

### DIFF
--- a/res/raw/webxdc.js
+++ b/res/raw/webxdc.js
@@ -1,3 +1,8 @@
+// fullscreen mode is not supported so we disable the API
+document.fullscreenEnabled = false;
+document.exitFullscreen = undefined;
+document.requestFullscreen = undefined;
+
 window.webxdc = (() => {
   let setUpdateListenerPromise = null
   var update_listener = () => {};


### PR DESCRIPTION
disable web API for fullscreen mode since it is not supported by the webview