### PR TITLE
use system camera as default

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -644,6 +644,8 @@
     <string name="pref_manage_keys">Manage Keys</string>
     <string name="pref_use_system_emoji">Use System Emoji</string>
     <string name="pref_use_system_emoji_explain">Turn off Delta Chat\'s built-in emoji support</string>
+    <string name="pref_use_builtin_camera">Use Built-In Camera</string>
+    <string name="pref_use_builtin_camera_explain">Built-in camera usually has less features</string>
     <string name="pref_app_access">App Access</string>
     <string name="pref_chats">Chats</string>
     <string name="pref_in_chat_sounds">In-Chat Sounds</string>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -57,6 +57,12 @@
             android:key="pref_incognito_keyboard"
             android:summary="@string/pref_incognito_keyboard_explain"
             android:title="@string/pref_incognito_keyboard" />
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_builtin_camera"
+            android:title="@string/pref_use_builtin_camera"
+            android:summary="@string/pref_use_builtin_camera_explain"/>
     </PreferenceCategory>
 
 

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -874,13 +874,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     composeText.setOnClickListener(composeKeyPressedListener);
     composeText.setOnFocusChangeListener(composeKeyPressedListener);
 
-    if (QuickAttachmentDrawer.isDeviceSupported(this)) {
-      quickAttachmentDrawer.setListener(this);
-      quickCameraToggle.setOnClickListener(new QuickCameraToggleListener());
-    } else {
-      quickCameraToggle.setVisibility(View.GONE);
-      quickCameraToggle.setEnabled(false);
-    }
+    quickAttachmentDrawer.setListener(this);
+    quickCameraToggle.setOnClickListener(new QuickCameraToggleListener());
 
     initializeBackground();
   }
@@ -1390,18 +1385,23 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private class QuickCameraToggleListener implements OnClickListener {
     @Override
     public void onClick(View v) {
-      if (!quickAttachmentDrawer.isShowing()) {
-        Permissions.with(ConversationActivity.this)
-                   .request(Manifest.permission.CAMERA)
-                   .ifNecessary()
-                   .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_camera_denied))
-                   .onAllGranted(() -> {
-                     composeText.clearFocus();
-                     container.show(composeText, quickAttachmentDrawer);
-                   })
-                   .execute();
+      if (Prefs.isBuiltInCameraPreferred(ConversationActivity.this)
+       && QuickAttachmentDrawer.isDeviceSupported(ConversationActivity.this)) {
+        if (!quickAttachmentDrawer.isShowing()) {
+          Permissions.with(ConversationActivity.this)
+            .request(Manifest.permission.CAMERA)
+            .ifNecessary()
+            .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_camera_denied))
+            .onAllGranted(() -> {
+              composeText.clearFocus();
+              container.show(composeText, quickAttachmentDrawer);
+            })
+            .execute();
+        } else {
+          container.hideAttachedInput(false);
+        }
       } else {
-        container.hideAttachedInput(false);
+        attachmentManager.capturePhoto(ConversationActivity.this, TAKE_PHOTO);
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -56,6 +56,7 @@ public class Prefs {
   public  static final String NOTIFICATION_PRIORITY_PREF       = "pref_notification_priority";
 
   public  static final String SYSTEM_EMOJI_PREF                = "pref_system_emoji";
+  public  static final String BUILTIN_CAMERA_PREF              = "pref_builtin_camera";
   public  static final String DIRECT_CAPTURE_CAMERA_ID         = "pref_direct_capture_camera_id";
   private static final String PROFILE_AVATAR_ID_PREF           = "pref_profile_avatar_id";
   public  static final String INCOGNITO_KEYBORAD_PREF          = "pref_incognito_keyboard";
@@ -314,6 +315,10 @@ public class Prefs {
 
   public static boolean isSystemEmojiPreferred(Context context) {
     return getBooleanPreference(context, SYSTEM_EMOJI_PREF, false);
+  }
+
+  public static boolean isBuiltInCameraPreferred(Context context) {
+    return getBooleanPreference(context, BUILTIN_CAMERA_PREF, false);
   }
 
   public static boolean getAlwaysLoadRemoteContent(Context context) {


### PR DESCRIPTION
the system camera has usually more features (flash, physical zoom, filter) and is less buggy than the mostly unmaintained built-in one. also, the system camera seems to be more supported (isDeviceSupported() is not needed) and does not require to ask for permission

there is still a switch in "advanced settings" to use the old built-in camera, however, at some point we may remove the old code completely

@adbenitez can you please verify that on your device the permission is not needed by disabling it beforehand?