### PR TITLE
show 'verified by SELF' as such

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1909,15 +1909,6 @@ JNIEXPORT jboolean Java_com_b44t_messenger_DcContact_isVerified(JNIEnv *env, job
 }
 
 
-JNIEXPORT jstring Java_com_b44t_messenger_DcContact_getVerifierAddr(JNIEnv *env, jobject obj)
-{
-    char* temp = dc_contact_get_verifier_addr(get_dc_contact(env, obj));
-        jstring ret = JSTRING_NEW(temp);
-    dc_str_unref(temp);
-    return ret;
-}
-
-
 JNIEXPORT jint Java_com_b44t_messenger_DcContact_getVerifierId(JNIEnv *env, jobject obj)
 {
     return dc_contact_get_verifier_id(get_dc_contact(env, obj));

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -897,6 +897,7 @@
     <string name="contact_not_verified">Cannot verify %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that verified the contact shown. -->
     <string name="verified_by">Verified by %1$s</string>
+    <string name="verified_by_you">Verified by you</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Changed setup for %1$s.</string>
     <string name="verified_group_explain">Verified groups (experimental) provide safety against active attacks. Members are verified with a second factor by other members and messages are always end-to-end-encrypted.</string>

--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -58,7 +58,6 @@ public class DcContact {
     public native boolean wasSeenRecently();
     public native boolean isBlocked      ();
     public native boolean isVerified     ();
-    public native String  getVerifierAddr();
     public native int     getVerifierId  ();
 
     // working with raw c-data

--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -313,9 +313,15 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
       itemDataContact = dcContact;
       if (!chatIsDeviceTalk) {
         if (dcContact.isVerified()) {
-          String verifiedInfo = context.getString(R.string.verified);
-          if (!dcContact.getVerifierAddr().isEmpty()) {
-            verifiedInfo = context.getString(R.string.verified_by, dcContact.getVerifierAddr());
+          int verifierId = dcContact.getVerifierId();
+
+          String verifiedInfo;
+          if (verifierId == DcContact.DC_CONTACT_ID_SELF) {
+            verifiedInfo = context.getString(R.string.verified_by_you);
+          } else if (verifierId != 0) {
+            verifiedInfo = context.getString(R.string.verified_by, dcContext.getContact(verifierId).getAddr());
+          } else {
+            verifiedInfo = context.getString(R.string.verified);
           }
           itemData.add(new ItemData(ItemData.CATEGORY_INFO, INFO_VERIFIED, verifiedInfo, 0, R.drawable.ic_verified));
         }

--- a/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -240,7 +240,7 @@ public class ProfileSettingsFragment extends Fragment
     DcContact dcContact = dcContext.getContact(contactId);
     if (dcContact.isVerified()) {
       int verifierId = dcContact.getVerifierId();
-      if (verifierId != 0 && verifierId != contactId) {
+      if (verifierId != 0 && verifierId != DcContact.DC_CONTACT_ID_SELF && verifierId != contactId) {
         Intent intent = new Intent(getContext(), ProfileActivity.class);
         intent.putExtra(ProfileActivity.CONTACT_ID_EXTRA, verifierId);
         startActivity(intent);


### PR DESCRIPTION
core was changed to return SELF from `get_verifier_id()` at https://github.com/deltachat/deltachat-core-rust/pull/4754 - until then, core will return always a contact-id,
which is equal to the current state