### PR TITLE
move part of left padding from emoji-button to parent

### DIFF
--- a/res/layout/conversation_input_panel.xml
+++ b/res/layout/conversation_input_panel.xml
@@ -40,6 +40,10 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingLeft="6dp"
+            android:paddingStart="6dp"
+            android:paddingRight="0dp"
+            android:paddingEnd="0dp"
             android:minHeight="40dp"
             android:clipChildren="false"
             android:clipToPadding="false">
@@ -50,10 +54,8 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:minHeight="40dp"
-                android:paddingLeft="12dp"
-                android:paddingStart="12dp"
+                android:paddingLeft="6dp"
                 android:paddingRight="6dp"
-                android:paddingEnd="6dp"
                 android:background="@drawable/touch_highlight_background"
                 android:contentDescription="@string/menu_toggle_keyboard" />
 


### PR DESCRIPTION
 this looks better the emoji button is not needed as using system-emoji are used and is a prerequisite when considering changing the emoji-default to system

before/after:


<img width="335" alt="Screenshot 2023-09-30 at 17 56 29" src="https://github.com/deltachat/deltachat-android/assets/9800740/55e7b680-c2e3-4832-ac00-994e8bdf9022"> <img width="335" alt="Screenshot 2023-09-30 at 17 57 19" src="https://github.com/deltachat/deltachat-android/assets/9800740/92e8a868-790a-4f02-828d-3a478efc4a38">
