### PR TITLE
no more than one webxdc start within 500ms

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -63,13 +63,15 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   private boolean internetAccess = false;
 
   public static void openWebxdcActivity(Context context, DcMsg instance) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      if (Prefs.isDeveloperModeEnabled(context)) {
-        WebView.setWebContentsDebuggingEnabled(true);
+    if (!Util.isClickedRecently()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Prefs.isDeveloperModeEnabled(context)) {
+          WebView.setWebContentsDebuggingEnabled(true);
+        }
+        context.startActivity(getWebxdcIntent(context, instance.getId()));
+      } else {
+        Toast.makeText(context, "At least Android 5.0 (Lollipop) required for Webxdc.", Toast.LENGTH_LONG).show();
       }
-      context.startActivity(getWebxdcIntent(context, instance.getId()));
-    } else {
-      Toast.makeText(context, "At least Android 5.0 (Lollipop) required for Webxdc.", Toast.LENGTH_LONG).show();
     }
   }
 

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -345,4 +345,15 @@ public class Util {
   public static int rgbToArgbColor(int rgb) {
     return Color.argb(0xFF, Color.red(rgb), Color.green(rgb), Color.blue(rgb));
   }
+
+  private static long lastClickTime = 0;
+  public static boolean isClickedRecently() {
+    long now = System.currentTimeMillis();
+    if (now - lastClickTime < 500) {
+      Log.i(TAG, "tap discarded");
+      return true;
+    }
+    lastClickTime = now;
+    return false;
+  }
 }


### PR DESCRIPTION
it seems, fast tapping may result in starting a webxdc twice on some systems, https://github.com/deltachat/deltachat-android/issues/2546, i cannot reproduce this, but the timing-check introduced by this PR may help

@WofWca there will be an `.apk` created by CI soonish - can you please check if that fixes your issue and answer in this PR then?