### PR TITLE
check shutdown

### DIFF
--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -102,10 +102,6 @@ public class DcContext {
     @Override
     protected void finalize() throws Throwable {
         super.finalize();
-        unref();
-    }
-
-    public void unref() {
         if (contextCPtr != 0) {
             unrefContextCPtr();
             contextCPtr = 0;


### PR DESCRIPTION
this PR aims to implement the "Thread Safety" tips from https://c.delta.chat 

to sum up things

- it is recommended, to check an [`AtomicBool`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicBoolean.html) before calling [`DcEvent event = emitter.getNextEvent()`](https://github.com/deltachat/deltachat-android/blob/main/src/org/thoughtcrime/securesms/ApplicationContext.java#L119)
- [before destroying `DcAccounts`](https://github.com/deltachat/deltachat-android/blob/main/src/com/b44t/messenger/DcContext.java#L103), we would change the `AtomicBool`

while we could implement that easily ([code](https://gist.github.com/r10s/51373a0697091c6e1c74bdc7e215ef86)),  currently, the DcAccounts object is just never deleted as both, main thread as well as the event loop hold a reference - so, in practise DcAccounts.finalize() is never called

idea of the approach is to let the system terminate us if really needed - we want to run as long as possible

regarding that no real-life shutdown issues are known currently, and the described "misuse" does not take effect on android, i would not change potentially sensible shutdown code until there are real issues. then, of course, we shall have this in mind (but i am sure we will, it is really visible in the docs meanwhile :)

also note, that the event look is on DcAccounts - DcContext objects are of course finalized as needed

closes https://github.com/deltachat/deltachat-android/issues/2515