### PR TITLE
api33: update webview darkmode, enable webxdc darkmode for older androids

### DIFF
--- a/assets/help/help.css
+++ b/assets/help/help.css
@@ -1,3 +1,7 @@
+html {
+  color-scheme: dark light;
+}
+
 a {
   text-decoration: none;
 }

--- a/src/org/thoughtcrime/securesms/ConnectivityActivity.java
+++ b/src/org/thoughtcrime/securesms/ConnectivityActivity.java
@@ -35,7 +35,8 @@ public class ConnectivityActivity extends WebViewActivity implements DcEventCent
   }
 
   private void refresh() {
-    String connectivityHtml = DcHelper.getContext(this).getConnectivityHtml();
+    final String connectivityHtml = DcHelper.getContext(this).getConnectivityHtml()
+                                      .replace("</style>", " html { color-scheme: dark light; }</style>");
     webView.loadDataWithBaseURL(null, connectivityHtml, "text/html", "utf-8", null);
   }
 

--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -133,9 +133,10 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
   }
 
   protected void setForceDark() {
-    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+    if (Build.VERSION.SDK_INT <= 32 && WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+      // needed for older API (tested on android7) that do not set `color-scheme` without the following hint
       WebSettingsCompat.setForceDark(webView.getSettings(),
-                                     DynamicTheme.isDarkTheme(this) ? WebSettingsCompat.FORCE_DARK_ON : WebSettingsCompat.FORCE_DARK_OFF);
+        DynamicTheme.isDarkTheme(this) ? WebSettingsCompat.FORCE_DARK_ON : WebSettingsCompat.FORCE_DARK_OFF);
     }
   }
 


### PR DESCRIPTION
`setForceDark()` will be a no-op function in api33, use css-attributes instead

~~moreover, this pr enables webxdc darkmode for older androids - for whatever reason, `setForceDark()` was not called in `WebxdcActivity`~~ EDIT: it was not called for reasons as it not sets dark/light and let the css decide what to do but really changes colors, which usually does not work out, see 2048 app as an example

targets #2599