### PR TITLE
check areNotificationsEnabled() before adding notification

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -31,6 +31,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.fragment.app.Fragment;
@@ -248,7 +249,8 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
 
         switch (category) {
         case PREFERENCE_CATEGORY_NOTIFICATIONS:
-          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || Permissions.hasAll(getActivity(), Manifest.permission.POST_NOTIFICATIONS)) {
+          NotificationManagerCompat notificationManager = NotificationManagerCompat.from(getActivity());
+          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || notificationManager.areNotificationsEnabled()) {
             fragment = new NotificationsPreferenceFragment();
           } else {
             new AlertDialog.Builder(getActivity())

--- a/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -337,14 +337,17 @@ public class NotificationCenter {
                 return;
             }
 
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !notificationManager.areNotificationsEnabled()) {
+                return;
+            }
+
             if (Util.equals(visibleChat, chatData)) {
                 if (Prefs.isInChatNotifications(context)) {
                     InChatSounds.getInstance(context).playIncomingSound();
                 }
                 return;
             }
-
-            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
 
             // get notification text as a single line
             NotificationPrivacyPreference privacy = Prefs.getNotificationPrivacy(context);

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Settings;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
@@ -199,7 +200,8 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
   }
 
   public static CharSequence getSummary(Context context) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || Permissions.hasAll(context, Manifest.permission.POST_NOTIFICATIONS)) {
+    NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || notificationManager.areNotificationsEnabled()) {
       return context.getString(Prefs.isNotificationsEnabled(context) ? R.string.on : R.string.off);
     } else {
       return context.getString(R.string.disabled_in_system_settings);


### PR DESCRIPTION
this is best-practise according to
https://developer.android.com/develop/ui/views/notifications/notification-permission

moreover, use the same check for displaying the settings.

successor of https://github.com/deltachat/deltachat-android/pull/2695