### PR TITLE
resume settings activity on language changes

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -122,7 +122,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
       DynamicTheme.setDefaultDayNightMode(this);
       recreate();
     } else if (key.equals(Prefs.LANGUAGE_PREF)) {
-      recreate();
+      dynamicLanguage.onResume(this);
     }
   }
 


### PR DESCRIPTION
this applies changed immediately,
so esp. right-to-left-changes are correct -
but also weird issues wrt wrong language in the title bar on some api should be fixed.

little downside is that after changing the language, you're back to the "main settings page"
and do not stay in the "appearance page";
but you can regard this also as a feature, one tap less.

(only devs want to stay in the language-selection after language-selection - most users will go on with other things
also - other apps reset much more on language changes)

(reason is that the activity is resumed on language changes and the underlying intent does not track fragments currently)

closes #2698 