### PR TITLE
finish settings on language changes

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -122,7 +122,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
       DynamicTheme.setDefaultDayNightMode(this);
       recreate();
     } else if (key.equals(Prefs.LANGUAGE_PREF)) {
-      dynamicLanguage.onResume(this);
+      finish();
     }
   }
 


### PR DESCRIPTION
if we do not stay in the appearance page (see https://github.com/deltachat/deltachat-android/pull/2699),
it makes more sense to quit the settings completely.

also, this removes potential other issues with the language change as there is really only the chatlist that needs an update