### PR TITLE
improve screen reader support in conversations

### DIFF
--- a/res/layout/conversation_item_footer.xml
+++ b/res/layout/conversation_item_footer.xml
@@ -15,7 +15,7 @@
         android:src="@drawable/msg_encr_out"
         android:visibility="gone"
         android:layout_gravity="center_vertical|end"
-        android:contentDescription="@string/chat_input_placeholder"
+        android:importantForAccessibility="no"
         tools:visibility="visible"/>
 
     <TextView

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -164,6 +164,7 @@
                 android:paddingTop="@dimen/message_bubble_top_padding"
                 android:textColor="?conversation_item_incoming_text_primary_color"
                 android:textColorLink="?conversation_item_incoming_text_primary_color"
+                android:importantForAccessibility="no"
                 app:scaleEmojis="true"
                 tools:text="Mango pickle lorem ipsum"/>
 

--- a/res/layout/conversation_item_received_sticker.xml
+++ b/res/layout/conversation_item_received_sticker.xml
@@ -3,5 +3,4 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/image_view"
     android:layout_width="@dimen/media_bubble_sticker_dimens"
-    android:layout_height="@dimen/media_bubble_sticker_dimens"
-    android:contentDescription="@string/image" />
+    android:layout_height="@dimen/media_bubble_sticker_dimens"/>

--- a/res/layout/conversation_item_received_sticker.xml
+++ b/res/layout/conversation_item_received_sticker.xml
@@ -3,4 +3,5 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/image_view"
     android:layout_width="@dimen/media_bubble_sticker_dimens"
-    android:layout_height="@dimen/media_bubble_sticker_dimens"/>
+    android:layout_height="@dimen/media_bubble_sticker_dimens"
+    android:contentDescription="@string/sticker" />

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -142,6 +142,7 @@
                 android:paddingTop="@dimen/message_bubble_top_padding"
                 android:textColor="?conversation_item_outgoing_text_primary_color"
                 android:textColorLink="?conversation_item_outgoing_text_primary_color"
+                android:importantForAccessibility="no"
                 app:scaleEmojis="true"
                 tools:text="Mango pickle lorem ipsum"/>
 

--- a/res/layout/conversation_item_sent_sticker.xml
+++ b/res/layout/conversation_item_sent_sticker.xml
@@ -3,5 +3,4 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/image_view"
     android:layout_width="@dimen/media_bubble_sticker_dimens"
-    android:layout_height="@dimen/media_bubble_sticker_dimens"
-    android:contentDescription="@string/image" />
+    android:layout_height="@dimen/media_bubble_sticker_dimens"/>

--- a/res/layout/conversation_item_sent_sticker.xml
+++ b/res/layout/conversation_item_sent_sticker.xml
@@ -3,4 +3,5 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/image_view"
     android:layout_width="@dimen/media_bubble_sticker_dimens"
-    android:layout_height="@dimen/media_bubble_sticker_dimens"/>
+    android:layout_height="@dimen/media_bubble_sticker_dimens"
+    android:contentDescription="@string/sticker" />

--- a/res/layout/recent_photo_view_item.xml
+++ b/res/layout/recent_photo_view_item.xml
@@ -11,7 +11,8 @@
     <ImageView android:id="@+id/thumbnail"
                android:layout_width="match_parent"
                android:layout_height="match_parent"
-               android:scaleType="centerCrop"/>
+               android:scaleType="centerCrop"
+               android:contentDescription="@string/image"/>
 
 </org.thoughtcrime.securesms.components.SquareFrameLayout>
 

--- a/src/org/thoughtcrime/securesms/BaseConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BaseConversationItem.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.accessibility.AccessibilityManager;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -77,6 +78,8 @@ public abstract class BaseConversationItem extends LinearLayout
     return batchSelected.isEmpty() && (messageRecord.isFailed());
   }
 
+  protected void onAccessibilityClick() {}
+
   protected class PassthroughClickListener implements View.OnLongClickListener, View.OnClickListener {
 
     @Override
@@ -103,6 +106,9 @@ public abstract class BaseConversationItem extends LinearLayout
 
     public void onClick(View v) {
       if (!shouldInterceptClicks(messageRecord) && parent != null) {
+        if (batchSelected.isEmpty() && ((AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE)).isTouchExplorationEnabled()) {
+          BaseConversationItem.this.onAccessibilityClick();
+        }
         parent.onClick(v);
       } else if (messageRecord.isFailed()) {
         View view = View.inflate(context, R.layout.message_details_view, null);

--- a/src/org/thoughtcrime/securesms/BaseConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BaseConversationItem.java
@@ -3,7 +3,6 @@ package org.thoughtcrime.securesms;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.accessibility.AccessibilityManager;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -17,6 +16,7 @@ import com.b44t.messenger.DcMsg;
 import com.b44t.messenger.rpc.Rpc;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.util.Util;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -106,7 +106,7 @@ public abstract class BaseConversationItem extends LinearLayout
 
     public void onClick(View v) {
       if (!shouldInterceptClicks(messageRecord) && parent != null) {
-        if (batchSelected.isEmpty() && ((AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE)).isTouchExplorationEnabled()) {
+        if (batchSelected.isEmpty() && Util.isTouchExplorationEnabled(context)) {
           BaseConversationItem.this.onAccessibilityClick();
         }
         parent.onClick(v);

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -22,6 +22,7 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
+import android.os.Build;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -193,6 +194,7 @@ public class ConversationItem extends BaseConversationItem
     setReactions(messageRecord);
     setFooter(messageRecord, locale);
     setQuote(messageRecord);
+    setContentDescription(messageRecord);
   }
 
 
@@ -303,6 +305,36 @@ public class ConversationItem extends BaseConversationItem
       webxdcViewStub.get().setFocusable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
       webxdcViewStub.get().setClickable(batchSelected.isEmpty());
     }
+  }
+
+  private void setContentDescription(DcMsg messageRecord) {
+    String desc = "";
+    if (groupSenderHolder.getVisibility() == View.VISIBLE) {
+      desc = groupSender.getText() + "\n";
+    }
+    if (audioViewStub.resolved() && audioViewStub.get().getVisibility() == View.VISIBLE) {
+      desc += audioViewStub.get().getDescription() + "\n";
+    } else if (documentViewStub.resolved() && documentViewStub.get().getVisibility() == View.VISIBLE) {
+      desc += documentViewStub.get().getDescription() + "\n";
+    } else if (webxdcViewStub.resolved() && webxdcViewStub.get().getVisibility() == View.VISIBLE) {
+      desc += webxdcViewStub.get().getDescription() + "\n";
+    } else if (mediaThumbnailStub.resolved() && mediaThumbnailStub.get().getVisibility() == View.VISIBLE) {
+      desc += mediaThumbnailStub.get().getDescription() + "\n";
+    } else if (stickerStub.resolved() && stickerStub.get().getVisibility() == View.VISIBLE) {
+      desc += context.getString(R.string.sticker) + "\n";
+    }
+
+    if (bodyText.getVisibility() == View.VISIBLE) {
+      desc += bodyText.getText() + "\n";
+    }
+
+    if (footer.getVisibility() == View.VISIBLE) {
+      desc += footer.getDescription() + "\n";
+    } else if (stickerFooter.getVisibility() == View.VISIBLE) {
+      desc += stickerFooter.getDescription() + "\n";
+    }
+
+    this.setContentDescription(desc);
   }
 
   private boolean hasAudio(DcMsg messageRecord) {
@@ -447,6 +479,9 @@ public class ConversationItem extends BaseConversationItem
 
       audioViewStub.get().setAudio(new AudioSlide(context, messageRecord), duration);
       audioViewStub.get().setOnLongClickListener(passthroughClickListener);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        audioViewStub.get().setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      }
 
       ViewUtil.updateLayoutParams(bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
       ViewUtil.updateLayoutParams(groupSenderHolder, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -463,6 +498,9 @@ public class ConversationItem extends BaseConversationItem
       documentViewStub.get().setDocument(new DocumentSlide(context, messageRecord));
       documentViewStub.get().setDocumentClickListener(new ThumbnailClickListener());
       documentViewStub.get().setOnLongClickListener(passthroughClickListener);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        documentViewStub.get().setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      }
 
       ViewUtil.updateLayoutParams(bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
       ViewUtil.updateLayoutParams(groupSenderHolder, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -478,6 +516,9 @@ public class ConversationItem extends BaseConversationItem
       webxdcViewStub.get().setWebxdc(messageRecord, context.getString(R.string.webxdc_app));
       webxdcViewStub.get().setWebxdcClickListener(new ThumbnailClickListener());
       webxdcViewStub.get().setOnLongClickListener(passthroughClickListener);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        webxdcViewStub.get().setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      }
 
       ViewUtil.updateLayoutParams(bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
       ViewUtil.updateLayoutParams(groupSenderHolder, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -512,6 +553,9 @@ public class ConversationItem extends BaseConversationItem
       mediaThumbnailStub.get().setOnLongClickListener(passthroughClickListener);
       mediaThumbnailStub.get().setOnClickListener(passthroughClickListener);
       mediaThumbnailStub.get().showShade(TextUtils.isEmpty(messageRecord.getText()));
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        mediaThumbnailStub.get().setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      }
 
       setThumbnailOutlineCorners(messageRecord, showSender);
 
@@ -531,9 +575,11 @@ public class ConversationItem extends BaseConversationItem
 
       stickerStub.get().setSlide(glideRequests, new StickerSlide(context, messageRecord));
       stickerStub.get().setThumbnailClickListener(new StickerClickListener());
-
       stickerStub.get().setOnLongClickListener(passthroughClickListener);
       stickerStub.get().setOnClickListener(passthroughClickListener);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        stickerStub.get().setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      }
 
       ViewUtil.updateLayoutParams(bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
       ViewUtil.updateLayoutParams(groupSenderHolder, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -790,6 +836,14 @@ public class ConversationItem extends BaseConversationItem
     availableWidth -= ViewUtil.getLeftMargin(forView) + ViewUtil.getRightMargin(forView);
 
     return availableWidth;
+  }
+
+  @Override
+  public void onAccessibilityClick() {
+    if (mediaThumbnailStub.resolved())    mediaThumbnailStub.get().performClick();
+    else if (audioViewStub.resolved())    audioViewStub.get().performClick();
+    else if (documentViewStub.resolved()) documentViewStub.get().performClick();
+    else if (webxdcViewStub.resolved())   webxdcViewStub.get().performClick();
   }
 
   /// Event handlers

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -194,7 +194,7 @@ public class ConversationItem extends BaseConversationItem
     setReactions(messageRecord);
     setFooter(messageRecord, locale);
     setQuote(messageRecord);
-    setContentDescription(messageRecord);
+    if (Util.isTouchExplorationEnabled(context)) setContentDescription();
   }
 
 
@@ -307,7 +307,7 @@ public class ConversationItem extends BaseConversationItem
     }
   }
 
-  private void setContentDescription(DcMsg messageRecord) {
+  private void setContentDescription() {
     String desc = "";
     if (groupSenderHolder.getVisibility() == View.VISIBLE) {
       desc = groupSender.getText() + "\n";

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -194,7 +194,9 @@ public class ConversationItem extends BaseConversationItem
     setReactions(messageRecord);
     setFooter(messageRecord, locale);
     setQuote(messageRecord);
-    if (Util.isTouchExplorationEnabled(context)) setContentDescription();
+    if (Util.isTouchExplorationEnabled(context)) {
+      setContentDescription();
+    }
   }
 
 

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -312,6 +312,7 @@ public class ConversationItem extends BaseConversationItem
     if (groupSenderHolder.getVisibility() == View.VISIBLE) {
       desc = groupSender.getText() + "\n";
     }
+
     if (audioViewStub.resolved() && audioViewStub.get().getVisibility() == View.VISIBLE) {
       desc += audioViewStub.get().getDescription() + "\n";
     } else if (documentViewStub.resolved() && documentViewStub.get().getVisibility() == View.VISIBLE) {

--- a/src/org/thoughtcrime/securesms/components/AudioView.java
+++ b/src/org/thoughtcrime/securesms/components/AudioView.java
@@ -93,6 +93,30 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
     }
   }
 
+  @Override
+  public boolean performClick() {
+    if (this.playButton.getVisibility() == View.VISIBLE) {
+        playButton.performClick();
+    } else {
+        pauseButton.performClick();
+    }
+    return super.performClick();
+  }
+
+  public String getDescription() {
+    String desc;
+    if (this.title.getVisibility() == View.VISIBLE) {
+      desc = getContext().getString(R.string.audio);
+    } else {
+      desc = getContext().getString(R.string.voice_message);
+    }
+    desc += "\n" + this.timestamp.getText();
+    if (title.getVisibility() == View.VISIBLE) {
+        desc += "\n" + this.title.getText();
+    }
+    return desc;
+  }
+
   public void setDuration(int duration) {
     if (getProgress()==0)
       this.timestamp.setText(DateUtils.getFormatedDuration(duration));

--- a/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -100,4 +100,13 @@ public class ConversationItemFooter extends LinearLayout {
       deliveryStatusView.setTint(textColor); // Reset the color to the standard color (because the footer is re-used in a RecyclerView)
     }
   }
+
+  public String getDescription() {
+      String desc = dateView.getText().toString();
+      String deliveryDesc = deliveryStatusView.getDescription();
+      if (!"".equals(deliveryDesc)) {
+          desc += "\n" + deliveryDesc;
+      }
+      return desc;
+  }
 }

--- a/src/org/thoughtcrime/securesms/components/ConversationItemThumbnail.java
+++ b/src/org/thoughtcrime/securesms/components/ConversationItemThumbnail.java
@@ -86,6 +86,10 @@ public class ConversationItemThumbnail extends FrameLayout {
     setTouchDelegate(thumbnail.getTouchDelegate());
   }
 
+  public String getDescription() {
+    return thumbnail.getDescription() + "\n" + footer.getDescription();
+  }
+
   @Override
   protected void onMeasure(int originalWidthMeasureSpec, int originalHeightMeasureSpec) {
     int width = MeasureSpec.getSize(originalWidthMeasureSpec);
@@ -183,6 +187,11 @@ public class ConversationItemThumbnail extends FrameLayout {
 
   public void setThumbnailClickListener(SlideClickListener listener) {
     thumbnail.setThumbnailClickListener(listener);
+  }
+
+  @Override
+  public boolean performClick() {
+    return thumbnail.performClick();
   }
 
   @UiThread

--- a/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
+++ b/src/org/thoughtcrime/securesms/components/DeliveryStatusView.java
@@ -123,4 +123,11 @@ public class DeliveryStatusView {
   public void resetTint() {
     deliveryIndicator.setColorFilter(null);
   }
+
+  public String getDescription() {
+    if (deliveryIndicator.getVisibility() == View.VISIBLE) {
+      return deliveryIndicator.getContentDescription().toString();
+    }
+    return "";
+  }
 }

--- a/src/org/thoughtcrime/securesms/components/DocumentView.java
+++ b/src/org/thoughtcrime/securesms/components/DocumentView.java
@@ -59,6 +59,13 @@ public class DocumentView extends FrameLayout {
     this.setOnClickListener(new OpenClickedListener(documentSlide));
   }
 
+  public String getDescription() {
+    String desc = getContext().getString(R.string.file);
+    desc += "\n" + fileName.getText();
+    desc += "\n" + fileSize.getText();
+    return desc;
+  }
+
   @Override
   public void setFocusable(boolean focusable) {
     super.setFocusable(focusable);

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -82,6 +82,14 @@ public class ThumbnailView extends FrameLayout {
 
   }
 
+  public String getDescription() {
+    if (slide != null && slide.hasPlayOverlay()) {
+      return getContext().getString(R.string.video);
+    } else {
+      return getContext().getString(R.string.image);
+    }
+  }
+
   @Override
   protected void onMeasure(int originalWidthMeasureSpec, int originalHeightMeasureSpec) {
     fillTargetDimensions(measureDimens, dimens, bounds);

--- a/src/org/thoughtcrime/securesms/components/WebxdcView.java
+++ b/src/org/thoughtcrime/securesms/components/WebxdcView.java
@@ -89,6 +89,15 @@ public class WebxdcView extends FrameLayout {
     appSubtitle.setText(summary);
   }
 
+  public String getDescription() {
+    String desc = getContext().getString(R.string.webxdc_app);
+    desc += "\n" + appName.getText();
+    if (appSubtitle.getText() != null && !appSubtitle.getText().toString().equals("") && !appSubtitle.getText().toString().equals(getContext().getString(R.string.webxdc_app))) {
+      desc += "\n" + appSubtitle.getText();
+    }
+    return desc;
+  }
+
   private class OpenClickedListener implements View.OnClickListener {
     private final @NonNull DocumentSlide slide;
 

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -33,6 +33,7 @@ import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.Log;
+import android.view.accessibility.AccessibilityManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -343,5 +344,13 @@ public class Util {
     }
     lastClickTime = now;
     return false;
+  }
+
+  public static boolean isTouchExplorationEnabled(Context context) {
+    try {
+      return ((AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE)).isTouchExplorationEnabled();
+    } catch (Exception e) {
+      return false;
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -38,6 +38,7 @@ import android.view.accessibility.AccessibilityManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.ComposeText;
 
@@ -346,9 +347,14 @@ public class Util {
     return false;
   }
 
+  private static AccessibilityManager accessibilityManager;
   public static boolean isTouchExplorationEnabled(Context context) {
     try {
-      return ((AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE)).isTouchExplorationEnabled();
+      if (accessibilityManager == null) {
+        Context applicationContext = context.getApplicationContext();
+        accessibilityManager = ((AccessibilityManager) applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE));
+      }
+      return accessibilityManager.isTouchExplorationEnabled();
     } catch (Exception e) {
       return false;
     }


### PR DESCRIPTION
close #2470 

treat voice messages, audios, videos, documents, webxdc apps, images and stickers as a single unit for screen readers, being able to "activate"/open each of that attachments from the action double-tapping the message without carefully having to select small play buttons etc.

also now the message body is read when a text message is selected instead of just saying "message" and user having to find the text with their finger to read it.

videos are now announced as videos instead of "image"
