### PR TITLE
properly display webxdc's loading screen in dark mode

### DIFF
--- a/res/raw/webxdc_wrapper.html
+++ b/res/raw/webxdc_wrapper.html
@@ -15,6 +15,7 @@
         position: relative;
       }
       .iframe-container iframe {
+        display: none;
         border: 0;
         height: 100%;
         left: 0;
@@ -129,6 +130,7 @@
               "Error: was not able to block webrtc ERROR_C";
           } else {
             loadingDiv.innerHTML = "";
+            iframe.style.display = 'block';
             iframe.src = "index.html";
           }
         }


### PR DESCRIPTION
without this, only the progress bar has dark background but the rest of the screen is still white