### PR TITLE
rename blocked-contacts-activity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -277,7 +277,7 @@
               android:theme="@style/TextSecure.LightTheme"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
-    <activity android:name=".BlockedAndShareContactsActivity"
+    <activity android:name=".BlockedContactsActivity"
               android:theme="@style/TextSecure.LightTheme"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 

--- a/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
@@ -26,7 +26,7 @@ import org.thoughtcrime.securesms.contacts.ContactSelectionListItem;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
-public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBarActivity {
+public class BlockedContactsActivity extends PassphraseRequiredActionBarActivity {
 
   @Override
   public void onCreate(Bundle bundle, boolean ready) {
@@ -136,9 +136,7 @@ public class BlockedAndShareContactsActivity extends PassphraseRequiredActionBar
     }
 
     @Override
-    public void onItemLongClick(ContactSelectionListItem view) {
-      // Not needed
-    }
+    public void onItemLongClick(ContactSelectionListItem view) {}
   }
 
 }

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -21,7 +21,7 @@ import androidx.preference.Preference;
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
-import org.thoughtcrime.securesms.BlockedAndShareContactsActivity;
+import org.thoughtcrime.securesms.BlockedContactsActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
@@ -185,7 +185,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   private class BlockedContactsClickListener implements Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      Intent intent = new Intent(getActivity(), BlockedAndShareContactsActivity.class);
+      Intent intent = new Intent(getActivity(), BlockedContactsActivity.class);
       startActivity(intent);
       return true;
     }


### PR DESCRIPTION
`BlockedAndShareContactsActivity` is no longer used for sharing contacts, this was always a misleading name
and is done since #2719 by `AttachContactActivity`.