### PR TITLE
set a default label for new issues (also to make it more obvious for users that it's only bug reporting)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Report something that isn't working.
 title: ''
 assignees: ''
-
+labels: bug
 ---
 
 <!--


### PR DESCRIPTION
according to https://docs.github.com/en/communities/using-templates-t…o-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository this should work