### PR TITLE
fix permissions for ~ android 11

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/src/org/thoughtcrime/securesms/LogViewActivity.java
+++ b/src/org/thoughtcrime/securesms/LogViewActivity.java
@@ -56,6 +56,7 @@ public class LogViewActivity extends BaseActionBarActivity {
       case R.id.save_log:
         Permissions.with(this)
             .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            .alwaysGrantOnSdk33()
             .ifNecessary()
             .onAllGranted(() -> {
               boolean success = logViewFragment.saveLogFile();

--- a/src/org/thoughtcrime/securesms/LogViewActivity.java
+++ b/src/org/thoughtcrime/securesms/LogViewActivity.java
@@ -56,7 +56,7 @@ public class LogViewActivity extends BaseActionBarActivity {
       case R.id.save_log:
         Permissions.with(this)
             .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-            .alwaysGrantOnSdk33()
+            .alwaysGrantOnSdk30()
             .ifNecessary()
             .onAllGranted(() -> {
               boolean success = logViewFragment.saveLogFile();

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -305,6 +305,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
         Permissions.with(this)
                    .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                   .alwaysGrantOnSdk33()
                    .ifNecessary()
                    .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
                    .onAllGranted(() -> {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -305,7 +305,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
         Permissions.with(this)
                    .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                   .alwaysGrantOnSdk33()
+                   .alwaysGrantOnSdk30()
                    .ifNecessary()
                    .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
                    .onAllGranted(() -> {

--- a/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -86,7 +86,7 @@ public abstract class MessageSelectorFragment
 
       Permissions.with(getActivity())
               .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-              .alwaysGrantOnSdk33()
+              .alwaysGrantOnSdk30()
               .ifNecessary()
               .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
               .onAllGranted(() -> performSave(messageRecords))

--- a/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -86,6 +86,7 @@ public abstract class MessageSelectorFragment
 
       Permissions.with(getActivity())
               .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+              .alwaysGrantOnSdk33()
               .ifNecessary()
               .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
               .onAllGranted(() -> performSave(messageRecords))

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -138,6 +138,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
   private void requestPermissionForFiles(List<Uri> streamExtras) {
     Permissions.with(this)
             .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+            .alwaysGrantOnSdk33()
             .ifNecessary()
             .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
             .onAllGranted(() -> resolveUris(streamExtras))

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -170,6 +170,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     private void startImportBackup() {
         Permissions.with(this)
                 .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+                .alwaysGrantOnSdk33()
                 .ifNecessary()
                 .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
                 .onAllGranted(() -> {

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -169,7 +169,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     @SuppressLint("InlinedApi")
     private void startImportBackup() {
         Permissions.with(this)
-                .request(Manifest.permission.READ_EXTERNAL_STORAGE)
+                .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
                 .alwaysGrantOnSdk30()
                 .ifNecessary()
                 .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -170,7 +170,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     private void startImportBackup() {
         Permissions.with(this)
                 .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
-                .alwaysGrantOnSdk33()
+                .alwaysGrantOnSdk30()
                 .ifNecessary()
                 .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
                 .onAllGranted(() -> {

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -169,7 +169,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     @SuppressLint("InlinedApi")
     private void startImportBackup() {
         Permissions.with(this)
-                .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+                .request(Manifest.permission.READ_EXTERNAL_STORAGE)
                 .alwaysGrantOnSdk30()
                 .ifNecessary()
                 .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -468,7 +468,7 @@ public class AttachmentManager {
   public static void selectAudio(Activity activity, int requestCode) {
     Permissions.with(activity)
                .request(Manifest.permission.READ_EXTERNAL_STORAGE)
-               .alwaysGrantOnSdk33()
+               .alwaysGrantOnSdk30()
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
                .onAllGranted(() -> selectMediaType(activity, "audio/*", null, requestCode))

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -464,6 +464,7 @@ public class AttachmentManager {
   public static void selectAudio(Activity activity, int requestCode) {
     Permissions.with(activity)
                .request(Manifest.permission.READ_EXTERNAL_STORAGE)
+               .alwaysGrantOnSdk33()
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
                .onAllGranted(() -> selectMediaType(activity, "audio/*", null, requestCode))

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -444,6 +444,10 @@ public class AttachmentManager {
   }
 
   public static void selectGallery(Activity activity, int requestCode) {
+    // to enable camera roll,
+    // we're asking for "gallery permissions" also on newer systems that do not strictly require that.
+    // (asking directly after tapping "attachment" would be not-so-good as the user may want to attach sth. else
+    // and asking for permissions is better done on-point)
     Permissions.with(activity)
                .request(Permissions.galleryPermissions())
                .ifNecessary()

--- a/src/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -80,6 +80,8 @@ public class Permissions {
 
     private boolean condition = true;
 
+    private boolean alwaysGranted = false;
+
     PermissionsBuilder(PermissionObject permissionObject) {
       this.permissionObject = permissionObject;
     }
@@ -97,6 +99,13 @@ public class Permissions {
     public PermissionsBuilder ifNecessary(boolean condition) {
       this.ifNecesary = true;
       this.condition  = condition;
+      return this;
+    }
+
+    public PermissionsBuilder alwaysGrantOnSdk33() {
+      if (Build.VERSION.SDK_INT >= 33) {
+        alwaysGranted = true;
+      }
       return this;
     }
 
@@ -147,16 +156,9 @@ public class Permissions {
     }
 
     public void execute() {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        // READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE does not exist on modern androids
-        // as file access is done by pickers
-        String[] r = requestedPermissions;
-        Arrays.sort(r);
-        if ( (r.length == 1 && (r[0].equals(Manifest.permission.READ_EXTERNAL_STORAGE) || r[0].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)))
-          || (r.length == 2 &&  r[0].equals(Manifest.permission.READ_EXTERNAL_STORAGE) && r[1].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) ) {
-          allGrantedListener.run();
-          return;
-        }
+      if (alwaysGranted) {
+        allGrantedListener.run();
+        return;
       }
 
       PermissionsRequest request = new PermissionsRequest(allGrantedListener, anyDeniedListener, anyPermanentlyDeniedListener, anyResultListener,

--- a/src/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -102,6 +102,13 @@ public class Permissions {
       return this;
     }
 
+    public PermissionsBuilder alwaysGrantOnSdk30() {
+      if (Build.VERSION.SDK_INT >= 30) {
+        alwaysGranted = true;
+      }
+      return this;
+    }
+
     public PermissionsBuilder alwaysGrantOnSdk33() {
       if (Build.VERSION.SDK_INT >= 33) {
         alwaysGranted = true;

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -353,7 +353,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   private void manageKeys() {
     Permissions.with(getActivity())
         .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
-        .alwaysGrantOnSdk33()
+        .alwaysGrantOnSdk30()
         .ifNecessary()
         .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
         .onAllGranted(() -> {

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -353,6 +353,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   private void exportKeys() {
     Permissions.with(getActivity())
         .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+        .alwaysGrantOnSdk33()
         .ifNecessary()
         .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
         .onAllGranted(() -> {

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -191,7 +191,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     super.onActivityResult(requestCode, resultCode, data);
     if (resultCode != RESULT_OK) return;
     if (requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS) {
-        exportKeys();
+        manageKeys();
     } else if (requestCode == PICK_SELF_KEYS) {
         Uri uri = (data != null ? data.getData() : null);
         if (uri == null) {
@@ -344,13 +344,13 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     public boolean onPreferenceClick(Preference preference) {
       boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_manage_keys), getString(R.string.enter_system_secret_to_continue), REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS);
       if (!result) {
-        exportKeys();
+        manageKeys();
       }
       return true;
     }
   }
 
-  private void exportKeys() {
+  private void manageKeys() {
     Permissions.with(getActivity())
         .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
         .alwaysGrantOnSdk33()

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -266,8 +266,8 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
 
   private void performBackup() {
     Permissions.with(getActivity())
-            .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
-            .alwaysGrantOnSdk33()
+            .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            .alwaysGrantOnSdk30()
             .ifNecessary()
             .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
             .onAllGranted(() -> {

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -266,7 +266,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
 
   private void performBackup() {
     Permissions.with(getActivity())
-            .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE) // READ_EXTERNAL_STORAGE required to read folder contents and to generate backup names
             .alwaysGrantOnSdk30()
             .ifNecessary()
             .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -267,6 +267,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   private void performBackup() {
     Permissions.with(getActivity())
             .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+            .alwaysGrantOnSdk33()
             .ifNecessary()
             .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
             .onAllGranted(() -> {


### PR DESCRIPTION
fixes #2726 

- [x] fix import backup from welcome activity on android 11
- [x] check _other file access_ points on android 11
- [x] check other androids (i assume, android10 is same as android11, so the change should be at sdk29 already, but that needs to be double checked and tested)  
    - EDIT: tried at least import-after-fresh-install, export-image, camera-roll on:
        - android5 (sdk21): ok
        - android9 (sdk28): ok
        - android10 (sdk29): ok
        - android11 (sdk30): ok
        - _android12 (sdk31): cannot test, emulator issues_
        - android12 (sdk32): ok
        - android13 (sdk33): ok
    - EDIT: tried backup-after-fresh-install-without-any-rights-granted:
        - android5 (sdk21): ok
        - android9 (sdk28): ok
        - android10 (sdk29): ok
        - android11 (sdk30): ok
        - android12 (sdk32): ok
        - android13 (sdk33): ok

_other file access points_ are:
- export media from chat
- export media from gallery
- export keys
- export log
- export backup
- import key
- import backup on welcome screen