### PR TITLE
allow to backup/export all accounts at once

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -658,6 +658,7 @@
     <string name="pref_backup">Backup</string>
     <string name="pref_backup_explain">Back Up Chats to External Storage</string>
     <string name="pref_backup_export_explain">A backup helps you to set up a new installation on this or on another device.\n\nThe backup will contain all messages, contacts and chats and your end-to-end Autocrypt setup. Keep the backup file in a safe place or delete it as soon as possible.</string>
+    <string name="pref_backup_export_all">Backup all accounts</string>
     <string name="pref_backup_export_start_button">Start Backup</string>
     <string name="pref_backup_written_to_x">Backup written successfully to \"%1$s\".</string>
     <string name="pref_managekeys_menu_title">Manage Keys</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -658,7 +658,8 @@
     <string name="pref_backup">Backup</string>
     <string name="pref_backup_explain">Back Up Chats to External Storage</string>
     <string name="pref_backup_export_explain">A backup helps you to set up a new installation on this or on another device.\n\nThe backup will contain all messages, contacts and chats and your end-to-end Autocrypt setup. Keep the backup file in a safe place or delete it as soon as possible.</string>
-    <string name="pref_backup_export_all">Backup all accounts</string>
+    <string name="pref_backup_export_x">Export %1$s</string>
+    <string name="pref_backup_export_all">Export all %1$d accounts</string>
     <string name="pref_backup_export_start_button">Start Backup</string>
     <string name="pref_backup_written_to_x">Backup written successfully to \"%1$s\".</string>
     <string name="pref_managekeys_menu_title">Manage Keys</string>

--- a/src/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -147,6 +147,10 @@ public class DcEventCenter {
       case DcContext.DC_EVENT_MSGS_NOTICED:
         DcHelper.getNotificationCenter(context).removeNotifications(accountId, event.getData1Int());
         break;
+
+      case DcContext.DC_EVENT_IMEX_PROGRESS:
+        sendToObservers(event);
+        return 0;
     }
 
     if (accountId != context.dcContext.getAccountId()) {

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -351,7 +351,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       .setTitle(R.string.pref_managekeys_import_secret_keys)
       .setMessage(getActivity().getString(R.string.pref_managekeys_import_explain, pathAsDisplayedToUser))
       .setNegativeButton(android.R.string.cancel, null)
-      .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImex(DcContext.DC_IMEX_IMPORT_SELF_KEYS, imexPath, pathAsDisplayedToUser))
+      .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImexOne(DcContext.DC_IMEX_IMPORT_SELF_KEYS, imexPath, pathAsDisplayedToUser))
       .show();
   }
 
@@ -385,7 +385,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
                           .setTitle(R.string.pref_managekeys_export_secret_keys)
                           .setMessage(getActivity().getString(R.string.pref_managekeys_export_explain, DcHelper.getImexDir().getAbsolutePath()))
                           .setNegativeButton(android.R.string.cancel, null)
-                          .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImex(DcContext.DC_IMEX_EXPORT_SELF_KEYS))
+                          .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImexOne(DcContext.DC_IMEX_EXPORT_SELF_KEYS))
                           .show();
                     }
                     else {

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -265,6 +265,13 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   }
 
   private void performBackup() {
+    View gl = View.inflate(getActivity(), R.layout.dialog_with_checkbox, null);
+    CheckBox confirmCheckbox = gl.findViewById(R.id.dialog_checkbox);
+    TextView msg = gl.findViewById(R.id.dialog_message);
+
+    msg.setText(getString(R.string.pref_backup_export_explain));
+    confirmCheckbox.setText(R.string.pref_backup_export_all);
+
     Permissions.with(getActivity())
             .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE) // READ_EXTERNAL_STORAGE required to read folder contents and to generate backup names
             .alwaysGrantOnSdk30()
@@ -273,9 +280,15 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
             .onAllGranted(() -> {
               new AlertDialog.Builder(getActivity())
                       .setTitle(R.string.pref_backup)
-                      .setMessage(R.string.pref_backup_export_explain)
+                      .setView(gl)
                       .setNegativeButton(android.R.string.cancel, null)
-                      .setPositiveButton(R.string.pref_backup_export_start_button, (dialogInterface, i) -> startImex(DcContext.DC_IMEX_EXPORT_BACKUP))
+                      .setPositiveButton(R.string.pref_backup_export_start_button, (dialogInterface, i) -> {
+                          if (confirmCheckbox.isChecked()) {
+                            // TODO: backup all accounts
+                          } else {
+                            startImex(DcContext.DC_IMEX_EXPORT_BACKUP);
+                          }
+                      })
                       .show();
             })
             .execute();

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -273,13 +273,11 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
                       .setTitle(R.string.pref_backup)
                       .setMessage(R.string.pref_backup_export_explain)
                       .setNeutralButton(android.R.string.cancel, null)
-                      .setPositiveButton(getActivity().getString(R.string.pref_backup_export_x, addr), (dialogInterface, i) -> startImex(DcContext.DC_IMEX_EXPORT_BACKUP));
+                      .setPositiveButton(getActivity().getString(R.string.pref_backup_export_x, addr), (dialogInterface, i) -> startImexOne(DcContext.DC_IMEX_EXPORT_BACKUP));
               int[] allAccounts = DcHelper.getAccounts(getActivity()).getAll();
               if (allAccounts.length > 1) {
                 String exportAllString = getActivity().getString(R.string.pref_backup_export_all, allAccounts.length);
-                builder.setNegativeButton(exportAllString, (dialogInterface, i) -> {
-                    // TODO: backup all accounts
-                });
+                builder.setNegativeButton(exportAllString, (dialogInterface, i) -> startImexAll(DcContext.DC_IMEX_EXPORT_BACKUP));
               }
               builder.show();
             })

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -29,9 +29,6 @@ import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.Util;
 
 public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
-  private static final String TAG = ChatsPreferenceFragment.class.getSimpleName();
-
-
   private ListPreference showEmails;
   private ListPreference mediaQuality;
   private ListPreference autoDownload;
@@ -265,31 +262,26 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   }
 
   private void performBackup() {
-    View gl = View.inflate(getActivity(), R.layout.dialog_with_checkbox, null);
-    CheckBox confirmCheckbox = gl.findViewById(R.id.dialog_checkbox);
-    TextView msg = gl.findViewById(R.id.dialog_message);
-
-    msg.setText(getString(R.string.pref_backup_export_explain));
-    confirmCheckbox.setText(R.string.pref_backup_export_all);
-
     Permissions.with(getActivity())
             .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE) // READ_EXTERNAL_STORAGE required to read folder contents and to generate backup names
             .alwaysGrantOnSdk30()
             .ifNecessary()
             .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
             .onAllGranted(() -> {
-              new AlertDialog.Builder(getActivity())
+              final String addr = DcHelper.get(getActivity(), DcHelper.CONFIG_CONFIGURED_ADDRESS);
+              AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                       .setTitle(R.string.pref_backup)
-                      .setView(gl)
+                      .setMessage(R.string.pref_backup_export_explain)
                       .setNegativeButton(android.R.string.cancel, null)
-                      .setPositiveButton(R.string.pref_backup_export_start_button, (dialogInterface, i) -> {
-                          if (confirmCheckbox.isChecked()) {
-                            // TODO: backup all accounts
-                          } else {
-                            startImex(DcContext.DC_IMEX_EXPORT_BACKUP);
-                          }
-                      })
-                      .show();
+                      .setPositiveButton(getActivity().getString(R.string.pref_backup_export_x, addr), (dialogInterface, i) -> startImex(DcContext.DC_IMEX_EXPORT_BACKUP));
+              int[] allAccounts = DcHelper.getAccounts(getActivity()).getAll();
+              if (allAccounts.length > 1) {
+                String exportAllString = getActivity().getString(R.string.pref_backup_export_all, allAccounts.length);
+                builder.setNeutralButton(exportAllString, (dialogInterface, i) -> {
+                    // TODO: backup all accounts
+                });
+              }
+              builder.show();
             })
             .execute();
   }

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -272,12 +272,12 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
               AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                       .setTitle(R.string.pref_backup)
                       .setMessage(R.string.pref_backup_export_explain)
-                      .setNegativeButton(android.R.string.cancel, null)
+                      .setNeutralButton(android.R.string.cancel, null)
                       .setPositiveButton(getActivity().getString(R.string.pref_backup_export_x, addr), (dialogInterface, i) -> startImex(DcContext.DC_IMEX_EXPORT_BACKUP));
               int[] allAccounts = DcHelper.getAccounts(getActivity()).getAll();
               if (allAccounts.length > 1) {
                 String exportAllString = getActivity().getString(R.string.pref_backup_export_all, allAccounts.length);
-                builder.setNeutralButton(exportAllString, (dialogInterface, i) -> {
+                builder.setNegativeButton(exportAllString, (dialogInterface, i) -> {
                     // TODO: backup all accounts
                 });
               }


### PR DESCRIPTION
- [x] adapt backup/export dialog
- [x] hide the "backup all" offering if user has only one account
- [x] implement "export all"

~~:warning:  before this gets merged, would be nicer if core sets the account address in the backup filename~~ (DONE: https://github.com/deltachat/deltachat-core-rust/issues/4816)