### PR TITLE
move reaction pills together with swiped message bubble

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -97,10 +97,10 @@ public class ConversationItem extends BaseConversationItem
   private GlideRequests glideRequests;
 
   protected ViewGroup              bodyBubble;
+  protected ReactionsConversationView reactionsView;
   protected View                   replyView;
   @Nullable private QuoteView      quoteView;
   private   ConversationItemFooter footer;
-  private ReactionsConversationView reactionsView;
   private   TextView               groupSender;
   private   View                   groupSenderHolder;
   private   AvatarImageView        contactPhoto;

--- a/src/org/thoughtcrime/securesms/ConversationSwipeAnimationHelper.java
+++ b/src/org/thoughtcrime/securesms/ConversationSwipeAnimationHelper.java
@@ -33,6 +33,7 @@ final class ConversationSwipeAnimationHelper {
     float progress = dx / TRIGGER_DX;
 
     updateBodyBubbleTransition(conversationItem.bodyBubble, dx, sign);
+    updateReactionsTransition(conversationItem.reactionsView, dx, sign);
     updateReplyIconTransition(conversationItem.replyView, dx, progress, sign);
     updateContactPhotoHolderTransition(conversationItem.contactPhotoHolder, progress, sign);
   }


### PR DESCRIPTION
fix bug and recycle unused code! :recycle:

when you swipe a message to reply it, the message bubble moves, but if the message has reactions, the reaction pills remain in the same static position and the user avatar touches the reaction pills in groups,

this pull request fixes that issue

![image](https://github.com/deltachat/deltachat-android/assets/24558636/2d173861-f95d-47be-a96f-6e10689b2171)
