### PR TITLE
remove unnecessary attribute isLandscape

### DIFF
--- a/res/values-land/attrs.xml
+++ b/res/values-land/attrs.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <bool name="isLandscape">true</bool>
-</resources>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -265,7 +265,6 @@
         <attr name="compact" format="boolean" />
     </declare-styleable>
 
-    <bool name="isLandscape">false</bool>
     <!-- if the device is big enough (ex. a tablet) -->
     <bool name="isBigScreen">false</bool>
 </resources>

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -106,7 +106,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
 
     // enter fullscreen mode if necessary,
     // this is needed here because if the app is opened while already in landscape mode, onConfigurationChanged() is not triggered
-    setScreenMode();
+    setScreenMode(getResources().getConfiguration());
 
     webView.setWebChromeClient(new WebChromeClient() {
       @Override
@@ -212,13 +212,13 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     Log.i(TAG, "onConfigurationChanged(" + newConfig.orientation + ")");
     super.onConfigurationChanged(newConfig);
     // orientation might have changed, enter/exit fullscreen mode if needed
-    setScreenMode();
+    setScreenMode(newConfig);
   }
 
-  private void setScreenMode() {
+  private void setScreenMode(Configuration config) {
     // enter/exit fullscreen mode depending on orientation (landscape/portrait),
     // on tablets there is enough height so fullscreen mode is never enabled there
-    boolean enable = getResources().getBoolean(R.bool.isLandscape) && !getResources().getBoolean(R.bool.isBigScreen);
+    boolean enable = config.orientation == Configuration.ORIENTATION_LANDSCAPE && !getResources().getBoolean(R.bool.isBigScreen);
     getWindow().getDecorView().setSystemUiVisibility(enable? View.SYSTEM_UI_FLAG_FULLSCREEN : 0);
     ActionBar actionBar = getSupportActionBar();
     if (actionBar != null) {


### PR DESCRIPTION
isLandscape attribute was introduced initially as part of a complex logic that would set it to true only if in landscape mode AND device screen size was not big (ex. tablets) but later it was decoupled and a dedicated "isBigScreen" was introduced, then isLandscape was just telling if the device is in landscape mode, for that there is no need for this trick using an attribute, screen orientation can be checked directly and is already available in the onConfigurationChanged() event that calls setScreenMode() so there is no need to check an extra attribute