### PR TITLE
Merge "improve mailto Intent handling in ShareActivity" into main

### DIFF
--- a/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
+++ b/androidTest/com/b44t/messenger/uitests/offline/SharingTest.java
@@ -205,6 +205,25 @@ public class SharingTest {
     onView(withHint(R.string.chat_input_placeholder)).check(matches(withText("Veeery important draft")));
   }
 
+  /**
+   * Regression test:
+   *
+   * If you save your contacts's emails in the contacts app of the phone, there are buttons to call
+   * them and also to write an email to them.
+   *
+   * If you click the email button, Delta Chat opened but instead of opening a chat with that contact,
+   * the chat list was show and "share with" was displayed at the top
+   */
+  @Test
+  public void testOpenChatFromContacts() {
+    Intent i = new Intent(Intent.ACTION_SENDTO);
+    i.setData(Uri.parse("mailto:bob%40example.org"));
+    i.setPackage(getInstrumentation().getTargetContext().getPackageName());
+    activityRule.getScenario().onActivity(a -> a.startActivity(i));
+
+    onView(withId(R.id.subtitle)).check(matches(withText("bob@example.org")));
+  }
+
   @After
   public void cleanup() {
     TestUtils.cleanup();

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -17,7 +17,6 @@
 package org.thoughtcrime.securesms;
 
 import android.content.Intent;
-import android.net.MailTo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -31,11 +30,7 @@ import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.HashMap;
-import java.util.Map;
+import org.thoughtcrime.securesms.util.MailtoUtil;
 
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
 import static org.thoughtcrime.securesms.ConversationActivity.TEXT_EXTRA;
@@ -51,11 +46,6 @@ import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent
 public class NewConversationActivity extends ContactSelectionActivity {
 
   private static final String TAG = NewConversationActivity.class.getSimpleName();
-  public  static final String MAILTO = "mailto";
-  private static final String SUBJECT = "subject";
-  private static final String BODY = "body";
-  private static final String QUERY_SEPARATOR = "&";
-  private static final String KEY_VALUE_SEPARATOR = "=";
 
   @Override
   public void onCreate(Bundle bundle, boolean ready) {
@@ -73,19 +63,14 @@ public class NewConversationActivity extends ContactSelectionActivity {
         Uri uri = intent.getData();
         if(uri != null) {
           String scheme = uri.getScheme();
-          if(scheme != null && scheme.equals(MAILTO) ) {
-            String textToShare = getTextToShare(uri);
-            MailTo mailto = MailTo.parse(uri.toString());
-            String recipientsList = mailto.getTo();
-            if(recipientsList != null && !recipientsList.trim().isEmpty()) {
-              String[] recipientsArray = recipientsList.trim().split(",");
-              if (recipientsArray.length >= 1) {
-                String recipient = recipientsArray[0];
-                if (textToShare != null && !textToShare.isEmpty()) {
-                  getIntent().putExtra(TEXT_EXTRA, textToShare);
-                }
-                onContactSelected(DcContact.DC_CONTACT_ID_NEW_CONTACT, recipient);
+          if(MailtoUtil.isMailto(uri)) {
+            String textToShare = MailtoUtil.getText(uri);
+            String[] recipientsArray = MailtoUtil.getRecipients(uri);
+            if (recipientsArray.length >= 1) {
+              if (!textToShare.isEmpty()) {
+                getIntent().putExtra(TEXT_EXTRA, textToShare);
               }
+              onContactSelected(DcContact.DC_CONTACT_ID_NEW_CONTACT, recipientsArray[0]);
             } else {
               Intent shareIntent = new Intent(this, ShareActivity.class);
               shareIntent.putExtra(Intent.EXTRA_TEXT, textToShare);
@@ -99,37 +84,6 @@ public class NewConversationActivity extends ContactSelectionActivity {
         Log.e(TAG, "start activity from external 'mailto:' link failed", e);
       }
     }
-  }
-
-  private String getTextToShare(Uri uri) {
-    Map<String, String> mailtoQueryMap = getMailtoQueryMap(uri);
-    String textToShare = mailtoQueryMap.get(SUBJECT);
-    String body = mailtoQueryMap.get(BODY);
-    if (body != null && !body.isEmpty()) {
-      if (textToShare != null && !textToShare.isEmpty()) {
-        textToShare += "\n" + body;
-      } else {
-        textToShare = body;
-      }
-    }
-    return textToShare;
-  }
-
-  private Map<String, String> getMailtoQueryMap(Uri uri) {
-    Map<String, String> mailtoQueryMap = new HashMap<>();
-    String query =  uri.getEncodedQuery();
-    if (query != null && !query.isEmpty()) {
-      String[] queryArray = query.split(QUERY_SEPARATOR);
-      for(String queryEntry : queryArray) {
-        String[] queryEntryArray = queryEntry.split(KEY_VALUE_SEPARATOR);
-        try {
-          mailtoQueryMap.put(queryEntryArray[0], URLDecoder.decode(queryEntryArray[1], "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
-        }
-      }
-    }
-    return mailtoQueryMap;
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -40,6 +40,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
+import org.thoughtcrime.securesms.util.MailtoUtil;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.RelayUtil;
 
@@ -112,6 +113,18 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
         streamExtras.add(uri);
     } else if (getIntent().getParcelableArrayListExtra(Intent.EXTRA_STREAM) != null) {
       streamExtras = getIntent().getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+    } else {
+        Uri uri = getIntent().getData();
+        if (MailtoUtil.isMailto(uri)) {
+            String[] extraEmail = getIntent().getStringArrayExtra(Intent.EXTRA_EMAIL);
+            if (extraEmail == null || extraEmail.length == 0) {
+                getIntent().putExtra(Intent.EXTRA_EMAIL, MailtoUtil.getRecipients(uri));
+            }
+            String text = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+            if (text == null || text.isEmpty()) {
+                getIntent().putExtra(Intent.EXTRA_TEXT, MailtoUtil.getText(uri));
+            }
+        }
     }
 
     if (needsFilePermission(streamExtras)) {

--- a/src/org/thoughtcrime/securesms/util/MailtoUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MailtoUtil.java
@@ -1,0 +1,64 @@
+package org.thoughtcrime.securesms.util;
+
+import android.net.MailTo;
+import android.net.Uri;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MailtoUtil {
+    private static final String MAILTO = "mailto";
+    private static final String SUBJECT = "subject";
+    private static final String BODY = "body";
+    private static final String QUERY_SEPARATOR = "&";
+    private static final String KEY_VALUE_SEPARATOR = "=";
+
+    public static boolean isMailto(Uri uri) {
+        return uri != null && MAILTO.equals(uri.getScheme());
+    }
+
+    public static String[] getRecipients(Uri uri) {
+        String[] recipientsArray = new String[0];
+        if (uri != null) {
+            MailTo mailto = MailTo.parse(uri.toString());
+            String recipientsList = mailto.getTo();
+            if(recipientsList != null && !recipientsList.trim().isEmpty()) {
+                recipientsArray = recipientsList.trim().split(",");
+            }
+        }
+        return recipientsArray;
+    }
+
+    public static String getText(Uri uri) {
+        Map<String, String> mailtoQueryMap = getMailtoQueryMap(uri);
+        String textToShare = mailtoQueryMap.get(SUBJECT);
+        String body = mailtoQueryMap.get(BODY);
+        if (body != null && !body.isEmpty()) {
+            if (textToShare != null && !textToShare.isEmpty()) {
+                textToShare += "\n" + body;
+            } else {
+                textToShare = body;
+            }
+        }
+        return textToShare != null? textToShare : "";
+    }
+
+    private static Map<String, String> getMailtoQueryMap(Uri uri) {
+        Map<String, String> mailtoQueryMap = new HashMap<>();
+        String query =  uri.getEncodedQuery();
+        if (query != null && !query.isEmpty()) {
+            String[] queryArray = query.split(QUERY_SEPARATOR);
+            for(String queryEntry : queryArray) {
+                String[] queryEntryArray = queryEntry.split(KEY_VALUE_SEPARATOR);
+                try {
+                    mailtoQueryMap.put(queryEntryArray[0], URLDecoder.decode(queryEntryArray[1], "UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return mailtoQueryMap;
+    }
+}


### PR DESCRIPTION
That's https://github.com/deltachat/deltachat-android/pull/2637 which was (probably accidentally) dropped out when renaming `stable` to `main` and `main` to `feat/verified-1to1`.

@r10s would you like this to go into 1.41? It might be better to wait until 1.42, since sharing is an area with lots of regressions, and 1.42 is not that far out.