### PR TITLE
use CONFIG_CONFIGURED_ADDRESS instead of CONFIG_ADDRESS

### DIFF
--- a/src/org/thoughtcrime/securesms/preferences/widgets/ProfilePreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/widgets/ProfilePreference.java
@@ -64,7 +64,7 @@ public class ProfilePreference extends Preference {
   public void refresh() {
     if (profileAddressView == null) return;
 
-    final String address = DcHelper.get(getContext(), DcHelper.CONFIG_ADDRESS);
+    final String address = DcHelper.get(getContext(), DcHelper.CONFIG_CONFIGURED_ADDRESS);
     String profileName  = DcHelper.get(getContext(), DcHelper.CONFIG_DISPLAY_NAME);
 
     if(profileName==null || profileName.isEmpty()) {

--- a/src/org/thoughtcrime/securesms/qr/QrShowActivity.java
+++ b/src/org/thoughtcrime/securesms/qr/QrShowActivity.java
@@ -58,7 +58,7 @@ public class QrShowActivity extends AppCompatActivity {
             // verify-contact
             String selfName = DcHelper.get(this, DcHelper.CONFIG_DISPLAY_NAME); // we cannot use MrContact.getDisplayName() as this would result in "Me" instead of
             if (selfName.isEmpty()) {
-                selfName = DcHelper.get(this, DcHelper.CONFIG_ADDRESS, "unknown");
+                selfName = DcHelper.get(this, DcHelper.CONFIG_CONFIGURED_ADDRESS, "unknown");
             }
             supportActionBar.setTitle(selfName);
             supportActionBar.setSubtitle(R.string.qrshow_join_contact_title);

--- a/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
+++ b/src/org/thoughtcrime/securesms/service/IPCAddAccountsService.java
@@ -24,6 +24,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import java.lang.ref.WeakReference;
 
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ADDRESS;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_CONFIGURED_ADDRESS;
 
 import com.b44t.messenger.DcAccounts;
 import com.b44t.messenger.DcContext;
@@ -58,7 +59,7 @@ public class IPCAddAccountsService extends Service {
         int[] accountIds = accounts.getAll();
         for (int accountId : accountIds) {
           DcContext dcContext = accounts.getAccount(accountId);
-          String accountAddress = dcContext.getConfig(CONFIG_ADDRESS);
+          String accountAddress = dcContext.getConfig(CONFIG_CONFIGURED_ADDRESS);
           if (accountAddress.equals(newAddress)) {
             Log.d(TAG, newAddress + " already exists. Switching account.");
             AccountManager.getInstance().switchAccount(context, accountId);


### PR DESCRIPTION
if you try to change account configuration ex. change address and password and it fails, still the new tried address will be shown in the account overview in settings and some other places 