### PR TITLE
always open account switcher from main title bar

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -116,12 +116,16 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     conversationListFragment = initFragment(R.id.fragment_container, new ConversationListFragment(), dynamicLanguage.getCurrentLocale(), bundle);
 
     initializeSearchListener();
-    initializeTitleListener();
 
     TooltipCompat.setTooltipText(searchAction, getText(R.string.search_explain));
 
     TooltipCompat.setTooltipText(selfAvatar, getText(R.string.switch_account));
     selfAvatar.setOnClickListener(v -> AccountManager.getInstance().showSwitchAccountMenu(this));
+    title.setOnClickListener(v -> {
+      if (!isRelayingMessageContent(this)) {
+        AccountManager.getInstance().showSwitchAccountMenu(this);
+      }
+    });
 
     refresh();
 
@@ -306,14 +310,6 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
                                      .commit();
           searchFragment = null;
         }
-      }
-    });
-  }
-
-  private void initializeTitleListener() {
-    title.setOnClickListener(v -> {
-      if (!isRelayingMessageContent(this)) {
-        startActivity(new Intent(this, ConnectivityActivity.class));
       }
     });
   }

--- a/src/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.accounts;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.b44t.messenger.DcAccounts;
 
+import org.thoughtcrime.securesms.ConnectivityActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.DcHelper;
@@ -51,6 +53,9 @@ public class AccountSelectionListFragment extends DialogFragment
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
             .setTitle(R.string.switch_account)
+            .setNeutralButton(R.string.connectivity, ((dialog, which) -> {
+              startActivity(new Intent(getActivity(), ConnectivityActivity.class));
+            }))
             .setNegativeButton(R.string.cancel, null);
 
     LayoutInflater inflater = getActivity().getLayoutInflater();


### PR DESCRIPTION
avatar and title appears as one unit to the user;
doing different things on taps in the avatar (open account switcher) and the title (open connectivity)
is confusing - and also easily done wrong.

this pr always opens the account switcher;
to get to the connetivity view,
there is a static button inside the account switchter.