### PR TITLE
make back button work in webxdc

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -387,6 +387,15 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     super.onActivityResult(reqCode, resultCode, data);
   }
 
+  @Override
+  public void onBackPressed() {
+    if (webView.canGoBack()) {
+      webView.goBack();
+    } else {
+      super.onBackPressed();
+    }
+  }
+
   class InternalJSApi {
     @JavascriptInterface
     public String selfAddr() {


### PR DESCRIPTION
this pr switches the "hardware" back button
from always terminating the app
to going back in history first,
only if the history is empty, the app is terminated.

this enables a webxdc to use document.history as additional navigation as usual.

the "back" upper left of the screen still always exits the app.