### PR TITLE
start all backups

### DIFF
--- a/src/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -147,6 +147,10 @@ public class DcEventCenter {
       case DcContext.DC_EVENT_MSGS_NOTICED:
         DcHelper.getNotificationCenter(context).removeNotifications(accountId, event.getData1Int());
         break;
+
+      case DcContext.DC_EVENT_IMEX_PROGRESS:
+        sendToObservers(event);
+        return 0;
     }
 
     if (accountId != context.dcContext.getAccountId()) {

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -351,7 +351,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       .setTitle(R.string.pref_managekeys_import_secret_keys)
       .setMessage(getActivity().getString(R.string.pref_managekeys_import_explain, pathAsDisplayedToUser))
       .setNegativeButton(android.R.string.cancel, null)
-      .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImex(DcContext.DC_IMEX_IMPORT_SELF_KEYS, imexPath, pathAsDisplayedToUser))
+      .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImexOne(DcContext.DC_IMEX_IMPORT_SELF_KEYS, imexPath, pathAsDisplayedToUser))
       .show();
   }
 
@@ -385,7 +385,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
                           .setTitle(R.string.pref_managekeys_export_secret_keys)
                           .setMessage(getActivity().getString(R.string.pref_managekeys_export_explain, DcHelper.getImexDir().getAbsolutePath()))
                           .setNegativeButton(android.R.string.cancel, null)
-                          .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImex(DcContext.DC_IMEX_EXPORT_SELF_KEYS))
+                          .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImexOne(DcContext.DC_IMEX_EXPORT_SELF_KEYS))
                           .show();
                     }
                     else {

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -273,13 +273,11 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
                       .setTitle(R.string.pref_backup)
                       .setMessage(R.string.pref_backup_export_explain)
                       .setNeutralButton(android.R.string.cancel, null)
-                      .setPositiveButton(getActivity().getString(R.string.pref_backup_export_x, addr), (dialogInterface, i) -> startImex(DcContext.DC_IMEX_EXPORT_BACKUP));
+                      .setPositiveButton(getActivity().getString(R.string.pref_backup_export_x, addr), (dialogInterface, i) -> startImexOne(DcContext.DC_IMEX_EXPORT_BACKUP));
               int[] allAccounts = DcHelper.getAccounts(getActivity()).getAll();
               if (allAccounts.length > 1) {
                 String exportAllString = getActivity().getString(R.string.pref_backup_export_all, allAccounts.length);
-                builder.setNegativeButton(exportAllString, (dialogInterface, i) -> {
-                    // TODO: backup all accounts
-                });
+                builder.setNegativeButton(exportAllString, (dialogInterface, i) -> startImexAll(DcContext.DC_IMEX_EXPORT_BACKUP));
               }
               builder.show();
             })


### PR DESCRIPTION
this starts all backups at the same time,
overwriting different progress-dialogs as needed.
when the last "done" arrives, the progress dialog is closed. the progress itself, is taken from the first account (this could be improved, but maybe it is just good enough)

best review without whitespace as indentation has changes.

needs lots of testing.