### PR TITLE
fix bug in group creation activity

### DIFF
--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -299,7 +299,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
         if (groupChatId!=0) {
           updateGroup(groupName);
         } else {
-          if (allMembersVerified()) {
+          if (!broadcast && allMembersVerified()) {
             new AlertDialog.Builder(this)
               .setMessage(R.string.create_verified_group_ask)
               .setNeutralButton(R.string.learn_more, (d, w) -> IntentUtils.showBrowserIntent(this, "https://delta.chat/en/help#verifiedchats"))


### PR DESCRIPTION
don't ask to create verified group if the user is creating a broadcast list