### PR TITLE
use 'Group Name' as placeholder for group name

### DIFF
--- a/res/layout/group_create_activity.xml
+++ b/res/layout/group_create_activity.xml
@@ -32,7 +32,7 @@
             android:lines="1"
             android:maxLength="255"
             android:inputType="textAutoCorrect"
-            android:hint="@string/name_desktop" />
+            android:hint="@string/group_name" />
     </LinearLayout>
 
     <TextView

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -216,6 +216,8 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     if (!broadcast) {
       DcContact self = dcContext.getContact(DC_CONTACT_ID_SELF);
       initList.add(new Recipient(this, self));
+    } else {
+      groupName.setHint(R.string.broadcast_list_name);
     }
     ArrayList<Integer> suggestedContactIds = getIntent().getIntegerArrayListExtra(SUGGESTED_CONTACT_IDS);
     if (suggestedContactIds != null && !suggestedContactIds.isEmpty()) {


### PR DESCRIPTION
before if was just 'Name',
which can lead to confusion
when heading instructions as "create a group with that person": one may create a group and enter the email address to "Name" ...

same with 'Broadcast List Name'

cc @hpk42 @link2xt @kermoshina 


<img width="317" alt="Screenshot 2023-11-01 at 18 49 20" src="https://github.com/deltachat/deltachat-android/assets/9800740/29a2ef0a-0f06-44d2-bdf0-296a95d78372"> <img width="317" alt="Screenshot 2023-11-01 at 18 49 27" src="https://github.com/deltachat/deltachat-android/assets/9800740/aed9081c-7d97-430f-8407-b1eb4d2fa001">

this pr will probably mitigate confusion, we can think over additional changes when this problems happens more often
