### PR TITLE
allow to clone groups and broadcasts

### DIFF
--- a/res/menu/profile_common.xml
+++ b/res/menu/profile_common.xml
@@ -30,4 +30,8 @@
         android:id="@+id/block_contact"
         app:showAsAction="never"/>
 
+    <item android:title="@string/menu_clone"
+        android:id="@+id/menu_clone"
+        app:showAsAction="never"/>
+
 </menu>

--- a/res/menu/profile_common.xml
+++ b/res/menu/profile_common.xml
@@ -30,7 +30,7 @@
         android:id="@+id/block_contact"
         app:showAsAction="never"/>
 
-    <item android:title="@string/menu_clone"
+    <item android:title="@string/clone_chat"
         android:id="@+id/menu_clone"
         app:showAsAction="never"/>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -201,7 +201,7 @@
     <string name="menu_new_contact">New Contact</string>
     <string name="menu_new_chat">New Chat</string>
     <string name="menu_new_group">New Group</string>
-    <string name="menu_clone">Clone</string>
+    <string name="menu_clone">Clone Chat</string>
     <!-- Use the same wording as "Subject" to help people coming from the e-mail context; eg. "Betreff" in German -->
     <string name="new_group_or_subject">New Group or Subject</string>
     <string name="menu_new_verified_group">New Verified Group</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="menu_new_contact">New Contact</string>
     <string name="menu_new_chat">New Chat</string>
     <string name="menu_new_group">New Group</string>
+    <string name="menu_clone">Clone</string>
     <!-- Use the same wording as "Subject" to help people coming from the e-mail context; eg. "Betreff" in German -->
     <string name="new_group_or_subject">New Group or Subject</string>
     <string name="menu_new_verified_group">New Verified Group</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -201,7 +201,7 @@
     <string name="menu_new_contact">New Contact</string>
     <string name="menu_new_chat">New Chat</string>
     <string name="menu_new_group">New Group</string>
-    <string name="menu_clone">Clone Chat</string>
+    <string name="clone_chat">Clone Chat</string>
     <!-- Use the same wording as "Subject" to help people coming from the e-mail context; eg. "Betreff" in German -->
     <string name="new_group_or_subject">New Group or Subject</string>
     <string name="menu_new_verified_group">New Verified Group</string>

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -52,7 +52,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   public static final String EDIT_GROUP_CHAT_ID = "edit_group_chat_id";
   public static final String GROUP_CREATE_VERIFIED_EXTRA  = "group_create_verified";
   public static final String CREATE_BROADCAST  = "group_create_broadcast";
-  public static final String SUGGESTED_CONTACT_IDS = "suggested_contact_ids";
+  public static final String CLONE_CHAT_EXTRA = "clone_chat";
 
   private static final int PICK_CONTACT = 1;
   public static final  int AVATAR_SIZE  = 210;
@@ -95,6 +95,11 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
       broadcast = dcChat.isBroadcast();
     }
 
+    int chatId = getIntent().getIntExtra(CLONE_CHAT_EXTRA, 0);
+    if (chatId != 0) {
+      broadcast = dcContext.getChat(chatId).isBroadcast();
+    }
+
     initializeResources();
   }
 
@@ -135,13 +140,28 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     groupName           = ViewUtil.findById(this, R.id.group_name);
     TextView groupHints = ViewUtil.findById(this, R.id.group_hints);
 
+    initializeAvatarView();
+
     SelectedContactsAdapter adapter = new SelectedContactsAdapter(this, GlideApp.with(this), broadcast);
     adapter.setItemClickListener(this);
     lv.setAdapter(adapter);
 
-    ArrayList<Integer> suggestedContactIds = getIntent().getIntegerArrayListExtra(SUGGESTED_CONTACT_IDS);
-    adapter.changeData(suggestedContactIds);
-    initializeAvatarView();
+    int chatId = getIntent().getIntExtra(CLONE_CHAT_EXTRA, 0);
+    if (chatId != 0) {
+      DcChat dcChat = dcContext.getChat(chatId);
+      groupName.setText(dcChat.getName());
+      File file = new File(dcChat.getProfileImage());
+      if (file.exists()) {
+        setAvatarView(Uri.fromFile(file));
+      }
+
+      int[] contactIds = dcContext.getChatContacts(chatId);
+      ArrayList<Integer> preselectedContactIds = new ArrayList<>(contactIds.length);
+      for (int id : contactIds) {
+        preselectedContactIds.add(id);
+      }
+      adapter.changeData(preselectedContactIds);
+    }
 
     if (broadcast) {
       avatar.setVisibility(View.GONE);

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -573,14 +573,8 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void onClone() {
-    int[] contactIds = dcContext.getChatContacts(chatId);
-    ArrayList<Integer> preselectedContactIds = new ArrayList<>(contactIds.length);
-    for (int id : contactIds) {
-      preselectedContactIds.add(id);
-    }
-
     Intent intent = new Intent(this, GroupCreateActivity.class);
-    intent.putExtra(GroupCreateActivity.SUGGESTED_CONTACT_IDS, preselectedContactIds);
+    intent.putExtra(GroupCreateActivity.CLONE_CHAT_EXTRA, chatId);
     startActivity(intent);
   }
 

--- a/src/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/ProfileActivity.java
@@ -130,6 +130,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       boolean canReceive = true;
 
       if (chatId != 0) {
+        menu.findItem(R.id.menu_clone).setVisible(chatIsMultiUser && !chatIsMailingList);
         if (chatIsDeviceTalk) {
           menu.findItem(R.id.edit_name).setVisible(false);
           menu.findItem(R.id.show_encr_info).setVisible(false);
@@ -424,6 +425,9 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       case R.id.block_contact:
         onBlockContact();
         break;
+      case R.id.menu_clone:
+        onClone();
+        break;
     }
 
     return false;
@@ -566,6 +570,18 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
             dcContext.blockContact(contactId, 1);
           }).show();
     }
+  }
+
+  private void onClone() {
+    int[] contactIds = dcContext.getChatContacts(chatId);
+    ArrayList<Integer> preselectedContactIds = new ArrayList<>(contactIds.length);
+    for (int id : contactIds) {
+      preselectedContactIds.add(id);
+    }
+
+    Intent intent = new Intent(this, GroupCreateActivity.class);
+    intent.putExtra(GroupCreateActivity.SUGGESTED_CONTACT_IDS, preselectedContactIds);
+    startActivity(intent);
   }
 
   @Override


### PR DESCRIPTION
close #2786 

this allows to upgrade existing non-verified groups to verified  by drafting a new group and then getting the chance to make it verified if all contacts are verified, thanks to recent changes in the group creation workflow