### PR TITLE
remove "use guaranteed e2ee?" question

### DIFF
--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -203,21 +203,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
         if (groupChatId!=0) {
           updateGroup(groupName);
         } else {
-          if (!broadcast && allMembersVerified()) {
-            new AlertDialog.Builder(this)
-              .setMessage(R.string.create_verified_group_ask)
-              .setNeutralButton(R.string.learn_more, (d, w) -> IntentUtils.showBrowserIntent(this, "https://delta.chat/en/help#verifiedchats"))
-              .setPositiveButton(R.string.yes, (d, w) -> {
-                  verified = true;
-                  createGroup(groupName);
-              })
-              .setNegativeButton(R.string.no, (d, w) -> {
-                  createGroup(groupName);
-              })
-              .setCancelable(true)
-              .show();
-            return true;
-          }
+          verified = !broadcast && allMembersVerified();
           createGroup(groupName);
         }
 


### PR DESCRIPTION
this pr removes the remove "use guaranteed e2ee?" question and instead creates a verified group when all members are verified.

this Yes/No question is a hard one.
this turns out last, not least,
when trying to use self-explaining buttons for iOS without using the term "verified groups".
what would be "No"? "Best-Effort-Encryption"?, "I don't care"? :)

joking aside,
few ppl will really read the question on group creation, let alone understanding it and making and informed decision.

many ppl will just tap the rightmost button,
just to continue.

so better go with defaults here until we get
a real usecase where we would need this question.
and then consider how to solve that usecase
without reintroducing weird questions.

this pr is the outcome of longer discussions with @link2xt and @hpk42 ; in a follow-up, we'll remove the term "verified" anywhere from the ui (it may continue to exist in help)