### PR TITLE
don't display "new contact" in verified group contact selection

### DIFF
--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -280,7 +280,7 @@ public class ContactSelectionListFragment extends    Fragment
   @Override
   public Loader<DcContactsLoader.Ret> onCreateLoader(int id, Bundle args) {
     boolean allowCreation = getActivity().getIntent().getBooleanExtra(ALLOW_CREATION, true);
-    boolean addCreateContactLink = allowCreation;
+    boolean addCreateContactLink = allowCreation && !isSelectVerfied();
     boolean addCreateGroupLinks = allowCreation && !isRelayingMessageContent(getActivity()) && !isMulti();
 
     int listflags = DcContext.DC_GCL_ADD_SELF;


### PR DESCRIPTION
the created new contact via the "new contact" button can't be added to the verified group anyways

this also fixes existing crash on master if you try to press the "new contact" button in a verified group because it was assumed all items where contacts and then it is tried to check isVerified() in a null pointer reference since the "new contact" item doesn't holds any real DcContact