### PR TITLE
cleanup chore: target duplicate autocrypt strings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -773,7 +773,7 @@
     <string name="autocrypt_send_asm_title">Send Autocrypt Setup Message</string>
     <string name="autocrypt_send_asm_explain_before">An Autocrypt Setup Message securely shares your end-to-end setup with other Autocrypt-compliant apps.\n\nThe setup will be encrypted by a setup code displayed here and must be typed on the other device.</string>
     <string name="autocrypt_send_asm_button">Send Autocrypt Setup Message</string>
-    <string name="autocrypt_send_asm_explain_after">Your setup has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:\n\n%1$s</string>
+    <string name="autocrypt_send_asm_explain_after">Your setup has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:</string>
     <string name="autocrypt_prefer_e2ee">Prefer End-To-End Encryption</string>
     <string name="autocrypt_asm_subject">Autocrypt Setup Message</string>
     <string name="autocrypt_asm_general_body">This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\nTo decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1000,13 +1000,17 @@
     <string name="remove_desktop">Remove</string>
     <string name="save_desktop">Save</string>
     <string name="name_desktop">Name</string>
+    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
     <string name="autocrypt_key_transfer_desktop">Autocrypt key transfer</string>
+    <!-- deprecated, use autocrypt_send_asm_explain_before -->
     <string name="initiate_key_transfer_desktop">An Autocrypt Setup Message securely shares your end-to-end setup with other Autocrypt-compliant apps. The setup will be encrypted by a setup code displayed here and must be typed on the other device.</string>
     <string name="select_group_image_desktop">Select Group Image</string>
     <string name="imex_progress_title_desktop">Backup Progress</string>
     <string name="export_backup_desktop">Export Backup</string>
+    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
     <string name="show_key_transfer_message_desktop">Your key has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:</string>
     <string name="autocrypt_correct_desktop">Autocrypt setup transferred.</string>
+    <!-- deprecated, use autocrypt_bad_setup_code instead -->
     <string name="autocrypt_incorrect_desktop">Incorrect setup code. Please try again.</string>
     <string name="create_chat_error_desktop">Could not create chat.</string>
     <string name="forget_login_confirmation_desktop">Delete this login? Everything will be deleted, including your end-to-end setup, contacts, chats, messages and media. This action cannot be undone.</string>

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -323,7 +323,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
                 }
                 new AlertDialog.Builder(getActivity())
                   .setTitle(getActivity().getString(R.string.autocrypt_send_asm_title))
-                  .setMessage(getActivity().getString(R.string.autocrypt_send_asm_explain_after, scFormatted))
+                  .setMessage(getActivity().getString(R.string.autocrypt_send_asm_explain_after) + "\n\n" + scFormatted)
                   .setPositiveButton(android.R.string.ok, null)
                   .setCancelable(false) // prevent the dialog from being dismissed accidentally (when the dialog is closed, the setup code is gone forever and the user has to create a new setup message)
                   .show();


### PR DESCRIPTION
these comparable complicated strings are duplicated and also partly wrong (eg. autocrypt does not talk about "keys")

once this is merged, ios should adapt to now missing %1$1 in autocrypt_send_asm_explain_after and we can file a pr for desktop using the new strings. once next android-string-cleanup, the duplicate strings can be deleted