### PR TITLE
contact profiles show chat's green checkmarks

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -130,13 +130,10 @@ public class ConversationTitleView extends RelativeLayout {
     avatar.setAvatar(glideRequests, new Recipient(getContext(), contact), false);
     avatar.setSeenRecently(contact.wasSeenRecently());
 
-    int imgRight = 0;
-    if (contact.isVerified()) {
-      imgRight = R.drawable.ic_verified;
-    }
-
     title.setText(contact.getDisplayName());
-    title.setCompoundDrawablesWithIntrinsicBounds(0, 0, imgRight, 0);
+
+    // the profile titles show if corresponding chats are verified, _not_ that a contact is verified which is shown by verifier id
+    title.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
     subtitle.setText(contact.getAddr());
     subtitle.setVisibility(View.VISIBLE);
   }


### PR DESCRIPTION
the contact profiles mix of contact and chat data for the ease of the user.

the contact profile title,
however, shall show the state of the chat (chat_is_protected()) and not the state of the contact (contact_is_verified()) to make things easier to understand and to be in sync with groups - and also with what we're saying in the faq
at https://github.com/deltachat/deltachat-pages/pull/746 :

> "contact profiles show a green checkmark
> if messaging a contact is guaranteed to be end-to-end encrypted."