### PR TITLE
revert 'introduced by' to 'verified by'

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="emoji">Emoji</string>
     <string name="attachment">Attachment</string>
     <string name="back">Back</string>
-    <!-- this string is deprecated; the new wording is "introduced by ..." -->
+    <!-- deprecated, use verified_by/verified_by_you -->
     <string name="verified">Verified</string>
     <string name="close">Close</string>
     <string name="close_window">Close Window</string>
@@ -892,7 +892,7 @@
     <string name="revive_qr_code">Activate QR Code</string>
     <string name="qrshow_title">QR Invite Code</string>
     <string name="qrshow_x_joining">%1$s joins.</string>
-    <string name="qrshow_x_verified">%1$s introduced.</string>
+    <string name="qrshow_x_verified">%1$s verified.</string>
     <string name="qrshow_x_has_joined_group">%1$s joined the group.</string>
     <string name="qrshow_join_group_title">QR Invite Code</string>
     <!-- This text is shown inside the "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by the group name, eg. "Scan to join group \"Testing group\"" -->
@@ -914,14 +914,14 @@
     <string name="secure_join_started">%1$s invited you to join this group.\n\nWaiting for the device of %2$s to reply…</string>
     <!-- placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_replies">%1$s replied, waiting for being added to the group…</string>
-    <string name="contact_verified">%1$s introduced.</string>
+    <string name="contact_verified">%1$s verified.</string>
     <string name="contact_not_verified">Cannot establish guaranteed end-to-end encryption with %1$s.</string>
-    <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
-    <string name="verified_by">Introduced by %1$s</string>
-    <string name="verified_by_you">Introduced by me</string>
+    <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that verified the contact. -->
+    <string name="verified_by">Verified by %1$s</string>
+    <string name="verified_by_you">Verified by me</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Changed setup for %1$s.</string>
-    <string name="verified_contact_required_explain">To guarantee end-to-end-encryption, you can only add contacts with a green checkmark to this group.\n\nYou may meet contacts in person and scan their QR Code to introduce them.</string>
+    <string name="verified_contact_required_explain">To guarantee end-to-end-encryption, you can only add contacts with a green checkmark to this group.\n\nYou may meet contacts in person and scan their QR Code to verify them.</string>
     <string name="copy_qr_data_success">Copied QR url to clipboard</string>
     <string name="mailto_dialog_header_select_chat">Select chat to send the message to</string>
     <!-- first placeholder is the name of the chat -->


### PR DESCRIPTION
while it is still true that we need
to avoid the term 'verified' in the context of groups, removing 'verified' completely at #2804 was maybe a bit over the top.

for contacts, 'verified by may still be better than 'introduced' which opens the questions if not all contacts are somehow introduced.

so, to sum up, we stroke 'verified group' and 'verified checkmarks' in favor to guaranteed 'end-to-end encryption' -
but we leave 'verified contact' as is.