### PR TITLE
use display name for verified-by row

### DIFF
--- a/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
+++ b/src/org/thoughtcrime/securesms/ProfileSettingsAdapter.java
@@ -318,7 +318,7 @@ public class ProfileSettingsAdapter extends RecyclerView.Adapter
           if (verifierId == DcContact.DC_CONTACT_ID_SELF) {
             verifiedInfo = context.getString(R.string.verified_by_you);
           } else {
-            verifiedInfo = context.getString(R.string.verified_by, dcContext.getContact(verifierId).getNameNAddr());
+            verifiedInfo = context.getString(R.string.verified_by, dcContext.getContact(verifierId).getDisplayName());
           }
           itemData.add(new ItemData(ItemData.CATEGORY_INFO, INFO_VERIFIED, verifiedInfo, 0, R.drawable.ic_verified));
         }


### PR DESCRIPTION
using display name and email address adds quite some noise, esp. if the email addresses are long and non-telling, this does not really add sth. to "security".

depending one the language, this issue may be even worse.

the verified-by address is shown bigger that the address of the contact itself.

it just looks bad.

the idea of showing the address was only to "protect" against ppl that set their name to "You" or "Me" - however, this trick is maybe a joke but no security issue, it was not really thought to the end:

- the verifier is always a directly verified, known contact
- we do not regard verified contacts as enemies
- the "Me" or "You" is visible and annoying at quite more visible placed
- you can always tap the row and will see that this is just a contact with a weird name (iOS, eg. shows a > to clarify that the cell is tappable, we could do sth. like that one android, other colors or whatever, however, i would not do that beforehand without more reasonings and usecases)

all in all, showing a long, non-telling row here,
seems over the top and not regarding the whole story.

<img width="314" alt="Screenshot 2023-11-07 at 15 38 33" src="https://github.com/deltachat/deltachat-android/assets/9800740/252dadf1-f2ef-47a3-bfc9-d08aa97ebc8b">

_example of cluttered ui - and this name / email address is not even long - by linebreaks, also all other things shift down, the verified-by takes quite some room and does not look good overall_
