### PR TITLE
use `dc_contact_profile_is_verified()` api

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1913,6 +1913,12 @@ JNIEXPORT jboolean Java_com_b44t_messenger_DcContact_isVerified(JNIEnv *env, job
 }
 
 
+JNIEXPORT jboolean Java_com_b44t_messenger_DcContact_profileIsVerified(JNIEnv *env, jobject obj)
+{
+    return dc_contact_profile_is_verified(get_dc_contact(env, obj))==2;
+}
+
+
 JNIEXPORT jint Java_com_b44t_messenger_DcContact_getVerifierId(JNIEnv *env, jobject obj)
 {
     return dc_contact_get_verifier_id(get_dc_contact(env, obj));

--- a/src/com/b44t/messenger/DcContact.java
+++ b/src/com/b44t/messenger/DcContact.java
@@ -57,6 +57,7 @@ public class DcContact {
     public native boolean wasSeenRecently();
     public native boolean isBlocked      ();
     public native boolean isVerified     ();
+    public native boolean profileIsVerified();
     public native int     getVerifierId  ();
 
     // working with raw c-data

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -130,10 +130,10 @@ public class ConversationTitleView extends RelativeLayout {
     avatar.setAvatar(glideRequests, new Recipient(getContext(), contact), false);
     avatar.setSeenRecently(contact.wasSeenRecently());
 
-    title.setText(contact.getDisplayName());
+    int imgRight = contact.profileIsVerified() ? R.drawable.ic_verified : 0;
 
-    // the profile titles show if corresponding chats are verified, _not_ that a contact is verified which is shown by verifier id
-    title.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
+    title.setText(contact.getDisplayName());
+    title.setCompoundDrawablesWithIntrinsicBounds(0, 0, imgRight, 0);
     subtitle.setText(contact.getAddr());
     subtitle.setVisibility(View.VISIBLE);
   }


### PR DESCRIPTION
this pr makes use of the [new `dc_contact_profile_is_verified()` api](https://github.com/deltachat/deltachat-core-rust/pull/4951)

the api is of limited use as group-chats, one-to-one-chats and contacts-without-chats share same profile code - and for chats, is_protected() is checked already. iOS does the same, probably desktop. so, for the very most profiles, `chat_is_protected()` is called (which is also called by `dc_contact_profile_is_verified()` in case there is a chat - but we cannot always call `dc_contact_profile_is_verified()` it does not work unconditionally for chats)

in practise, we could probably also revert the `dc_contact_profile_is_verified()` api and just use `dc_contact_is_verified()` for contacts-without-chats [as it was always in the past](https://github.com/deltachat/deltachat-android/pull/2821/files).

note that, for whatever reason, `dc_contact_profile_is_verified()` returns false if a verified-one-to-one-chat was deleted before - while `dc_contact_is_verified()` returns true - i think the latter is correct.

if we want to stay with `dc_contact_profile_is_verified()`, this pr needs a new core before merging