### PR TITLE
Revert "contact profiles show chat's green checkmarks"

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -130,10 +130,13 @@ public class ConversationTitleView extends RelativeLayout {
     avatar.setAvatar(glideRequests, new Recipient(getContext(), contact), false);
     avatar.setSeenRecently(contact.wasSeenRecently());
 
-    title.setText(contact.getDisplayName());
+    int imgRight = 0;
+    if (contact.isVerified()) {
+      imgRight = R.drawable.ic_verified;
+    }
 
-    // the profile titles show if corresponding chats are verified, _not_ that a contact is verified which is shown by verifier id
-    title.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
+    title.setText(contact.getDisplayName());
+    title.setCompoundDrawablesWithIntrinsicBounds(0, 0, imgRight, 0);
     subtitle.setText(contact.getAddr());
     subtitle.setVisibility(View.VISIBLE);
   }


### PR DESCRIPTION
This reverts commit f6c4e189e3b35989acc30396a495d310868022ef.

after lots of discussion (#2836, https://github.com/deltachat/deltachat-core-rust/pull/4966), contact-profiles-without-chat, should show is_verified() for the green checkmarks as in the past.

it still makes sense to streamline the android code, but that is another issue.