### PR TITLE
remove deprecated strings from translations, update translations

### DIFF
--- a/res/drawable/divider_start.xml
+++ b/res/drawable/divider_start.xml
@@ -4,7 +4,7 @@
 <gradient
     android:angle="0"
     android:startColor="@color/transparent"
-    android:endColor="#80B0B0B0"
+    android:endColor="#80B0B0B0g"
     android:type="linear" />
 
 </shape>

--- a/res/drawable/divider_start.xml
+++ b/res/drawable/divider_start.xml
@@ -4,7 +4,7 @@
 <gradient
     android:angle="0"
     android:startColor="@color/transparent"
-    android:endColor="#80B0B0B0g"
+    android:endColor="#80B0B0B0"
     android:type="linear" />
 
 </shape>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">موافق</string>
     <string name="cancel">إلغاء</string>
-    <string name="yes">نعم</string>
+   <string name="yes">نعم</string>
     <string name="no">لا</string>
     <string name="on">يعمل</string>
     <string name="off">معطّل</string>

--- a/res/values-az/strings.xml
+++ b/res/values-az/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Imtina</string>
-    <string name="yes">Bəli</string>
+   <string name="yes">Bəli</string>
     <string name="no">Xeyir</string>
     <string name="on">Açıq</string>
     <string name="off">Bağlı</string>
@@ -390,7 +390,6 @@
 
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Qəbul olunanları oxuyun</string>
-    <string name="systemmsg_cannot_decrypt">Bu mesaj şifresi çözülə bilməz. \n\n • Bu mesaja yalnız cavab vermək və göndərənin mesajı yenidən göndərməsini xahiş edə bilər. \n\n • Bu barədə Delta Chat və ya başqa bir e-poçt proqramını yenidən quraşdırdığınız halda oradan Autocrypt Kurulum Mesajı göndərmək istədiyiniz başqa bir qurğudan istifadə edə bilərsiniz.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Qrupun adı \"%1$s\" - dən \"%2$s\" - yə deyişildi məndən. </string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->

--- a/res/values-az/strings.xml
+++ b/res/values-az/strings.xml
@@ -449,8 +449,6 @@
     <!-- dc_str_* resources -->
     <string name="encrypted_message">Şifrələnmiş mesaj</string>
 
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Bilinən hesablar</string>
     <string name="global_menu_preferences_language_desktop">Dil səç</string>
     <string name="global_menu_file_desktop">Fayl</string>
     <string name="global_menu_file_quit_desktop">Çıxış</string>
@@ -473,24 +471,12 @@
     <string name="delete_message_desktop">Mesajı sil</string>
     <string name="more_info_desktop">Daha çox məlumat</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Şifrələmə məlumatını göstər</string>
     <string name="remove_desktop">Sil</string>
     <string name="save_desktop">Saxla</string>
     <string name="name_desktop">Ad</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Avtoşifrələmə açarın ötürülməsi</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Autocrypt konfiqurasiya mesajı təhlükəsiz olaraq \"sondan sona\" parametrinizi Autocrypt ilə uyğun olan digər tətbiqlərlə bölüşür. Quraşdırma burada göstərilir və başqa bir cihazda yığılmış olmalıdır. Bir quraşdırma kodu ilə şifrələ olunacaq.</string>
     <string name="select_group_image_desktop">Qrup şəklini seç</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Ehtiyat nüsxəsinin yaradılması</string>
     <string name="export_backup_desktop">Ehtiyat nüsxəsinin ixracı</string>
     <string name="autocrypt_correct_desktop">Autocrypt ayarı müvəffəqiyyətlə köçürüldü!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Yanlış kod. Yenidən cəhd edin. </string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Yeni çat yaratmaq alınmadı</string>
     <string name="forget_login_confirmation_desktop">Bu giriş silmək istəyirsiniz? Hər şey, sizin \"sondan sona\" quraşdırma, kontaktlar, söhbətlər, mesajlar və daşıyıcıları daxil olmaqla silinəcəkdir. Bu hərəkət son və ləğv edilə bilməz.</string>
     <string name="message_detail_sent_desktop">Göndər</string>
     <string name="message_detail_received_desktop">qəbul olundu</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Отказ</string>
-    <string name="clear_search">Изчистване на търсенето</string>
+   <string name="clear_search">Изчистване на търсенето</string>
     <string name="yes">Да</string>
     <string name="no">Не</string>
     <string name="select">Избор</string>
@@ -748,7 +748,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Съобщението е отворено</string>
     <string name="systemmsg_read_receipt_body">Съобщението \"%1$s\", което изпратихте, беше показано на екрана на получателя.\n\nТова не е гаранция, че съдържанието му е прочетено.</string>
-    <string name="systemmsg_cannot_decrypt">Това съобщение не може да бъде декриптирано.\n\n• Може би ще помогне просто да отговорите на това съобщение и да поискате от подателя да го изпрати отново.\n\n• В случай, че сте преинсталирали Delta Chat или друга програма за електронна поща на това или друго устройство, бихте могли да изпратите съобщение за настройка на Autocrypt от там.</string>
     <string name="systemmsg_unknown_sender_for_chat">Неизвестен подател за този чат. Вижте \"информация\" за повече подробности.</string>
     <string name="systemmsg_subject_for_new_contact">Съобщение от %1$s</string>
     <string name="systemmsg_failed_sending_to">Неуспешно изпращане на съобщение до %1$s.</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -911,8 +911,6 @@
     <string name="about_offical_app_desktop">Това е официалното настолно приложение Delta Chat.</string>
     <string name="about_licensed_under_desktop">Този софтуер е лицензиран под GNU GPL версия 3. Изходният код е наличен в GitHub.</string>
     <string name="welcome_desktop">Добре дошли в Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Познати акаунти</string>
     <string name="global_menu_preferences_language_desktop">Език</string>
     <string name="global_menu_file_desktop">Файл</string>
     <string name="global_menu_file_quit_desktop">Напускане</string>
@@ -939,26 +937,12 @@
     <string name="delete_message_desktop">Изтриване на съобщение</string>
     <string name="more_info_desktop">Повече информация</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Показване на информация за криптирането</string>
     <string name="remove_desktop">Премахване</string>
     <string name="save_desktop">Запис</string>
     <string name="name_desktop">Име</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Прехвърляне на ключ на Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Съобщението за настройка на Autocrypt споделя по сигурен начин Вашата настройка за криптиране \"от край до край\" с други приложения, съвместими с Autocrypt. Настройката ще бъде криптирана с код, показан тук, който трябва да бъде въведен на другото устройство.</string>
     <string name="select_group_image_desktop">Изберете изображение за групата</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Прогрес в създаването на резервно копие</string>
     <string name="export_backup_desktop">Експорт на резервно копие</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Изпратихте Вашия ключ до себе си. Преминете на другото устройство и отворете съобщението за настройка. Би трябвало да Ви бъде поискан код за настройка. Въведете следните цифри:</string>
     <string name="autocrypt_correct_desktop">Найстроката на Autocrypt е прехвърлена.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Неправилен код за настройка. Моля, опитайте отново.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Неуспешно създаване на чат.</string>
     <string name="forget_login_confirmation_desktop">Да бъде ли изтрита тази регистрация? Всичко ще бъде изтрито, включително Вашата настройка за криптиране \"от край до край\", контакти, чатове, съобщения и медийни файлове. Това действие не може да бъде отменено.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nРазмер: %2$s\n Идентификатор на акаунт: %3$s</string>
     <string name="message_detail_sent_desktop">изпратено</string>

--- a/res/values-bqi/strings.xml
+++ b/res/values-bqi/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Dêltā Čat</string>
     <string name="ok">xā</string>
     <string name="cancel">raď</string>
-    <string name="clear_search">roftênê pitiniďên</string>
+   <string name="clear_search">roftênê pitiniďên</string>
     <string name="yes">harêy</string>
     <string name="no">na</string>
     <string name="select">pêsand</string>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancel·la</string>
-    <string name="clear_search">Neteja la cerca</string>
+   <string name="clear_search">Neteja la cerca</string>
     <string name="yes">Si</string>
     <string name="no">No</string>
     <string name="select">Trieu</string>
@@ -577,7 +577,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Confirmació de lectura</string>
     <string name="systemmsg_read_receipt_body">Confirmació de lectura del missatge \"%1$s\".\n\nVol dir que el missatge s\'ha mostrat al dispositiu del receptor, no necessàriament que s\'hagi llegit.</string>
-    <string name="systemmsg_cannot_decrypt">Aquest missatge no es pot desxifrar.\n\n• Proveu de respondre\'l i demanar-li al remitent que us el torni a enviar.\n\n• Si heu reinstal·lat Delta Chat o un altre gestor de correu en aquest dispositiu o en algun altre, proveu d\'enviar un missatge de configuració Autocrypt des d\'allà.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Nom del grup \"%1$s\" canviat a \"%2$s\" per mi.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -635,8 +635,6 @@
     <!-- dc_str_* resources -->
     <string name="encrypted_message">Missatge encriptat</string>
 
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Comptes coneguts</string>
     <string name="global_menu_preferences_language_desktop">Trieu l\'idioma...</string>
     <string name="global_menu_file_desktop">Arxiva</string>
     <string name="global_menu_file_quit_desktop">Surt</string>
@@ -659,26 +657,12 @@
     <string name="delete_message_desktop">Esborra missatge</string>
     <string name="more_info_desktop">Més informació</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Mostra la informació de xifratge</string>
     <string name="remove_desktop">Elimina</string>
     <string name="save_desktop">Desa</string>
     <string name="name_desktop">Nom</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transfereix la clau d\'Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Un missatge de configuració Autocrypt comparteix de manera segura la vostra configuració d\'extrem a extrem amb altres aplicacions compatibles. La configuració es xifrarà mitjançant un codi de configuració que es mostrarà aquí i que s\'ha d’escriure a l’altre dispositiu.</string>
     <string name="select_group_image_desktop">Tria una imatge de grup</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Progrés de còpia de seguretat</string>
     <string name="export_backup_desktop">Exporta la còpia de seguretat</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">La vostra clau us ha estat enviada. Canvieu a l\'altre dispositiu i obriu-hi el missatge de configuració. Se us demanarà un codi de configuració. Introduïu els següents dígits a l\'indicador. Un cop hagueu acabat, l’altre dispositiu estarà llest per utilitzar Autocrypt.</string>
     <string name="autocrypt_correct_desktop">S\'ha transferit correctament la configuració Autocrypt!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Codi de configuració incorrecte. Siusplau torneu-ho a provar.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">No s\'ha pogut crear el xat.</string>
     <string name="forget_login_confirmation_desktop">Voleu suprimir aquesta sessió? S\'eliminarà tot, incloent-hi la configuració, els contactes, els xats, els missatges i els arxius multimèdia. Aquesta acció és definitiva i no es pot desfer.</string>
     <string name="message_detail_sent_desktop">enviat</string>
     <string name="message_detail_received_desktop">rebut</string>

--- a/res/values-ckb/strings.xml
+++ b/res/values-ckb/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">دێڵتا چات</string>
     <string name="ok">باشە</string>
     <string name="cancel">وازبێنە</string>
-    <string name="yes">بەڵێ</string>
+   <string name="yes">بەڵێ</string>
     <string name="no">نا</string>
     <string name="select">هەڵبژاردن</string>
     <string name="on">چالاک</string>

--- a/res/values-ckb/strings.xml
+++ b/res/values-ckb/strings.xml
@@ -550,8 +550,6 @@
     <!-- strings introduced on desktop. we want to share strings between the os, in general, please do not add generic strings here -->
     <string name="about_offical_app_desktop">ئەمە نەرمامێری فەرمی دێڵتا چاتە بۆ کۆمپووتەری ڕوومێز.</string>
     <string name="welcome_desktop">بەخێر بێن بۆ دێڵتا چات</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">هەژمارە ناسراوەکان</string>
     <string name="global_menu_preferences_language_desktop">زمان</string>
     <string name="global_menu_file_desktop">پەڕگە</string>
     <string name="global_menu_file_quit_desktop">چوونەدەرەوە</string>
@@ -571,19 +569,11 @@
     <string name="encryption_info_title_desktop">زانیاری شفرەکردن</string>
     <string name="delete_message_desktop">سڕینەوەی پەیام</string>
     <string name="more_info_desktop">زانیاری زۆرتر</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">پیشاندانی زانیاری شفرەکردن</string>
     <string name="remove_desktop">سڕینەوە</string>
     <string name="save_desktop">پاشەکەوت کردن</string>
     <string name="name_desktop">ناو</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">گواستنەوەی کلیلی ئۆتۆکریپت</string>
     <string name="select_group_image_desktop">هەڵبژاردنی وێنەی کۆڕ</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">پرۆسەی یەدەک هەڵگرتن</string>
     <string name="export_backup_desktop">هەناردەکردنی یەدەک</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">وتووێژەکە ڕێک نەخرا.</string>
     <string name="message_detail_sent_desktop">هەنێردراو</string>
     <string name="message_detail_received_desktop">وەرگیراو</string>
     <!-- accessibility, the general idea is to use the normal strings for accessibility hints wherever possible -->

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Souhlas</string>
     <string name="cancel">Zrušit</string>
-    <string name="yes">Ano</string>
+   <string name="yes">Ano</string>
     <string name="no">Ne</string>
     <string name="select">Vyber</string>
     <string name="on">Zapnout</string>
@@ -574,7 +574,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Zpráva otevřena</string>
     <string name="systemmsg_read_receipt_body">Odeslaná zpráva \"%1$s\" byla příjemci zobrazena na jeho přístroji.\n\nNicméně přečtení obsahu není zaručeno.</string>
-    <string name="systemmsg_cannot_decrypt">Zprávu nelze dešifrovat.\n\n• Může pomoct jednoduchá odpověď odesílateli s požadavkem o znovuzaslání zprávy.\n\n• Pokud jde o novou instalaci Delta Chatu či jiného e-mailového programu na tomto nebo jiném zařízení, může být nutné poslat si z nich Nastavení Autocryptu.</string>
     <string name="systemmsg_unknown_sender_for_chat">Neznámý odesilatel v tomto hovoru. Více najdeš v Popisu.</string>
     <string name="systemmsg_subject_for_new_contact">Zpráva od %1$s</string>
     <string name="systemmsg_failed_sending_to">Odeslání zprávy pro %1$s selhalo.</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -687,8 +687,6 @@
     <string name="about_offical_app_desktop">Toto je původní aplikace Delta Chat Desktop.</string>
     <string name="about_licensed_under_desktop">Tento software je pod licencí GNU GPL verze 3 a zdrojový kód je k mání na GitHubu.</string>
     <string name="welcome_desktop">Vítej v Delta Chatu</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Známé účty</string>
     <string name="global_menu_preferences_language_desktop">Jazyk</string>
     <string name="global_menu_file_desktop">Soubor</string>
     <string name="global_menu_file_quit_desktop">Ukončit</string>
@@ -713,26 +711,12 @@
     <string name="delete_message_desktop">Vymaž zprávu</string>
     <string name="more_info_desktop">Více podrobností</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Zobraz popis šifrování</string>
     <string name="remove_desktop">Odstranit</string>
     <string name="save_desktop">Uložit</string>
     <string name="name_desktop">Jméno</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Přenos klíče Autocryptu</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Nastavení Autocryptu zabezpečeně sdílí nastavení tvého šifrování s ostatními programy používající Autocrypt. Nastavení bude zašifrováno zobrazeným kódem, který musíš zadat i na tom druhém zařízení.</string>
     <string name="select_group_image_desktop">Vyber obrázek skupiny</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Stav zálohování</string>
     <string name="export_backup_desktop">Ulož zálohu</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Poslal jsi si svůj klíč. Přejdi k druhému zařízení a otevři zprávu s nastavením. Měla by se ti objevit výzva k zadání kódu. Pak opiš následující číslo:</string>
     <string name="autocrypt_correct_desktop">Nastavení Autocryptu přeneseno.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Nesprávný kód. Zkus to znovu, prosím.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Hovor nelze vytvořit.</string>
     <string name="forget_login_confirmation_desktop">Smazat toto přihlášení? Vše bude smazáno, včetně nastavení tvého end-to-end šifrování, kontaktů, hovorů, zpráv a multimedií. Tuto akci nelze vrátit zpět.</string>
     <string name="message_detail_sent_desktop">odesláno</string>
     <string name="message_detail_received_desktop">přijato</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -710,8 +710,6 @@
     <string name="about_offical_app_desktop">Dette er den officielle Delta Chat Desktop app.</string>
     <string name="about_licensed_under_desktop">Denne software er licenseret under GNU GPL version 3 og kildekoden er tilgængelig på GitHub</string>
     <string name="welcome_desktop">Velkommen til Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Kendte konti</string>
     <string name="global_menu_preferences_language_desktop">Vælge sprog...</string>
     <string name="global_menu_file_desktop">Fil</string>
     <string name="global_menu_file_quit_desktop">Afslut</string>
@@ -737,26 +735,12 @@
     <string name="delete_message_desktop">Slet besked</string>
     <string name="more_info_desktop">Mere information</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Vis krypteringsinformation</string>
     <string name="remove_desktop">Fjern</string>
     <string name="save_desktop">Gem</string>
     <string name="name_desktop">Navn</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt nøgleoverførsel</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">En Autocrypt opsætning beskeddeler sikkert ende-til-ende opsætning med andre Autocrypt kompatible programmer. Opsætninger er krypteret med en opsætning kode som er vist her og skal indtastes på de andre enheder.</string>
     <string name="select_group_image_desktop">Vælg gruppebillede</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Sikkerhedskopiering fremgang</string>
     <string name="export_backup_desktop">Eksporter sikkerhedskopi</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Nøgle er sendt til dig selv. Skift til den anden enhed og åben opsætning beskeden. Der bliver promptet for en opsætning kode.. Indtast følgende cifre i prompten. Når det er afsluttet vil den anden enhed være klar til at bruge Autocrypt.</string>
     <string name="autocrypt_correct_desktop">Autocrypt opsætning overført!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Forkert opsætningskode. Prøv igen.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Kunne ikke oprette samtale</string>
     <string name="forget_login_confirmation_desktop">Slet login? Alt vil blive slettet, din end-to-end opsætning, kontakter, samtaler, meddelelser og medier. Denne handling er endelig og kan ikke fortrydes.</string>
     <string name="message_detail_sent_desktop">sendt</string>
     <string name="message_detail_received_desktop">modtaget</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Annuller</string>
-    <string name="clear_search">Ryd søgning</string>
+   <string name="clear_search">Ryd søgning</string>
     <string name="yes">Ja</string>
     <string name="no">Nej</string>
     <string name="select">Vælg</string>
@@ -593,7 +593,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Besked åbnet</string>
     <string name="systemmsg_read_receipt_body">Beskeden \"%1$s\" du har sendt blev vist på modtagerens skærm.\n\nDette er ikke en garanti for at indholdet blev læst.</string>
-    <string name="systemmsg_cannot_decrypt">Denne besked kan ikke dekrypteres.\n\n• Det kan måske hjælpe at svare på beskeden og bede afsender sende beskeden igen.\n\n• I tilfælde at Delta Chat eller andet e-mail program på denne enhed eller en anden er blevet gen-installeret bør der sendes en Autocrypt opsætning besked derfra.</string>
     <string name="systemmsg_unknown_sender_for_chat">Ukent afsender af denne chat. Se \'info\' for flere detaljer.</string>
     <string name="systemmsg_subject_for_new_contact">Besked fra %1$s</string>
     <string name="systemmsg_failed_sending_to">Mislykket forsøg på afsendelse af besked til %1$s.</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -4,6 +4,8 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Abbruch</string>
+   <!-- the word "or" to separate blocks in the user interface that are mutually exclusive -->
+    <string name="or_separator">oder</string>
     <string name="clear_search">Suche löschen</string>
     <string name="yes">Ja</string>
     <string name="no">Nein</string>
@@ -788,7 +790,7 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Empfangsbestätigung</string>
     <string name="systemmsg_read_receipt_body">Ihre Nachricht \"%1$s\" wurde auf dem Empfangsgerät angezeigt.\n\nDas ist keine Garantie dafür, dass sie auch gelesen wurde.</string>
-    <string name="systemmsg_cannot_decrypt">Diese Nachricht kann nicht entschlüsselt werden.\n\n• Es könnte bereits helfen, einfach auf diese Nachricht zu antworten und die/den AbsenderIn zu bitten, die Nachricht erneut zu senden.\n\n• Falls Delta Chat oder ein anderes E-Mail-Programm auf diesem oder einem anderen Gerät neu installiert wurde, kann von dort aus eine Autocrypt Setup-Nachricht gesendet werden.</string>
+    <string name="systemmsg_cannot_decrypt">Diese Nachricht kann nicht entschlüsselt werden.\n\n• Es kann bereits helfen, auf diese Nachricht zu antworten und den Absender zu bitten, die Nachricht noch einmal zu senden.\n\n• Wenn Sie Delta Chat gerade neu installiert haben, ist es am besten, wenn Sie Delta Chat mit \"Als Zweitgerät hinzufügen\" neu einrichten oder ein Backup importieren.</string>
     <string name="systemmsg_unknown_sender_for_chat">Absender ist für diesen Chat unbekannt. Siehe \"Info\" für weitere Details,</string>
     <string name="systemmsg_subject_for_new_contact">Nachricht von %1$s</string>
     <string name="systemmsg_failed_sending_to">Nachricht senden an %1$s fehlgeschlagen.</string>
@@ -800,7 +802,7 @@
     <!-- %1$s will be replaced by name and address of the contact who did the action -->
     <string name="group_image_changed_by_other">Gruppenbild geändert von %1$s.</string>
     <!-- %1$s will be replaced by name and address of the contact added to the group -->
-    <string name="add_member_by_you">Sie haben %1$s hinzugefügt.</string>
+    <string name="add_member_by_you">%1$s hinzugefügt.</string>
     <!-- %1$s will be replaced by name and address of the contact added to the group, %2$s will be replaced by name and address of the contact who did the action -->
     <string name="add_member_by_other">%1$s hinzugefügt von %2$s.</string>
     <!-- %1$s will be replaced by name and address of the contact removed from the group -->

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -971,8 +971,6 @@
     <string name="about_offical_app_desktop">Dies ist die offizielle Delta Chat Desktop App.</string>
     <string name="about_licensed_under_desktop">Dieses Programm ist lizenziert unter der GNU GPL version 3 und der Quellcode ist auf Github verfügbar.</string>
     <string name="welcome_desktop">Willkommen bei Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Bekannte E-Mail-Konten</string>
     <string name="global_menu_preferences_language_desktop">Sprache</string>
     <string name="global_menu_file_desktop">Datei</string>
     <string name="global_menu_file_quit_desktop">Beenden</string>
@@ -999,26 +997,12 @@
     <string name="delete_message_desktop">Nachricht löschen</string>
     <string name="more_info_desktop">Mehr Informationen</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Zeige Verschlüsselungsinfo</string>
     <string name="remove_desktop">Entfernen</string>
     <string name="save_desktop">Speichern</string>
     <string name="name_desktop">Name</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt-Schlüsselübertragung</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Eine \"Autocrypt-Setup-Nachricht\" überträgt das Ende-zu-Ende-Setup sicher auf ein anderes Autocrypt-kompatibles Gerät. Das Setup wird mit einem Setup-Code geschützt; dieser wird hier angezeigt und muss auf dem anderen Gerät eingetippt werden.</string>
     <string name="select_group_image_desktop">Gruppenbild auswählen</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Backup-Prozess</string>
     <string name="export_backup_desktop">Backup exportieren</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Der Schlüssel wurde an Sie versandt. Nun zum anderen Gerät wechseln und die Setup-Nachricht öffnen. Nach Aufforderung, den Setup-Code einzugeben, die folgenden Zahlen eingeben. Danach ist Autocrypt auf dem anderen Gerät eingerichtet.</string>
     <string name="autocrypt_correct_desktop">Erfolgreich übertragenes Autocrypt-Setup!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Falscher Setup-Code. Bitte versuche es erneut.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Konnte Chat nicht erstellen.</string>
     <string name="forget_login_confirmation_desktop">Dieses Login löschen? Alles wird gelöscht, einschließlich des Ende-zu-Ende-Setups, der Kontakte, Chats, Nachrichten und Medien. Diese Aktion ist endgültig und kann nicht rückgängig gemacht werden.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nGröße: %2$s\nAccount-ID: %3$s</string>
     <string name="message_detail_sent_desktop">gesendet</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Εντάξει</string>
     <string name="cancel">Ακύρωση</string>
-    <string name="clear_search">Αναζήτηση</string>
+   <string name="clear_search">Αναζήτηση</string>
     <string name="yes">Ναι</string>
     <string name="no">Όχι</string>
     <string name="select">Επιλογή</string>
@@ -707,7 +707,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Το μήνυμα ανοίχτηκε</string>
     <string name="systemmsg_read_receipt_body">Το μήνυμα \"%1$s\" που στείλατε εμφανίστηκε στην οθόνη του παραλήπτη.\n\nΑυτό δεν αποτελεί εγγύηση για την ανάγνωση του περιεχομένου.</string>
-    <string name="systemmsg_cannot_decrypt">Αυτό το μήνυμα δεν μπορεί να αποκρυπτογραφηθεί.\n\n• Μπορεί ήδη να σας βοηθήσει να απαντήσετε απλώς σε αυτό το μήνυμα και να ζητήσετε από τον αποστολέα να στείλει ξανά το μήνυμα.\n\n• Σε περίπτωση που εγκαταστήσατε ξανά το Delta Chat ή άλλο πρόγραμμα e-mail σε αυτήν ή σε άλλη συσκευή μπορεί να θέλετε να στείλετε ένα μήνυμα ρύθμισης αυτόματης κρυπτογράφησης από εκεί.</string>
     <string name="systemmsg_unknown_sender_for_chat">Άγνωστος αποστολέας για αυτήν τη συνομιλία. Δείτε \"πληροφορίες\" για περισσότερες λεπτομέρειες.</string>
     <string name="systemmsg_subject_for_new_contact">Μήνυμα από τον/την %1$s</string>
     <string name="systemmsg_failed_sending_to">Αποτυχία αποστολής μηνύματος σε %1$s.</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -868,8 +868,6 @@
     <string name="about_offical_app_desktop">Αυτή είναι η επίσημη εφαρμογή Delta Chat Desktop.</string>
     <string name="about_licensed_under_desktop">Αυτό το λογισμικό έχει άδεια χρήσης σύμφωνα με την GNU GPL έκδοση 3 και ο πηγαίος κώδικας είναι διαθέσιμος στο GitHub.</string>
     <string name="welcome_desktop">Καλώς ήρθατε στο Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Γνωστοί Λογαριασμοί</string>
     <string name="global_menu_preferences_language_desktop">Γλώσσα</string>
     <string name="global_menu_file_desktop">Αρχείο</string>
     <string name="global_menu_file_quit_desktop">Κλείσιμο</string>
@@ -896,26 +894,12 @@
     <string name="delete_message_desktop">Διαγραφή μηνύματος</string>
     <string name="more_info_desktop">Περισσότερες πληροφορίες</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Εμφάνιση Πληροφοριών Κρυπτογράφησης</string>
     <string name="remove_desktop">Αφαίρεση</string>
     <string name="save_desktop">Αποθήκευση</string>
     <string name="name_desktop">Όνομα</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Αυτόματη κρυπτογράφηση μεταφοράς κλειδιού</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Ένα μήνυμα ρύθμισης αυτόματης κρυπτογράφησης μοιράζεται με ασφάλεια τις ρυθμίσεις σας από άκρο σε άκρο με άλλες εφαρμογές συμβατές με την αυτόματη κρυπτογράφηση. Η εγκατάσταση θα κρυπτογραφηθεί από έναν κωδικό ρύθμισης που εμφανίζεται εδώ και πρέπει να πληκτρολογηθεί στην άλλη συσκευή.</string>
     <string name="select_group_image_desktop">Επιλέξτε Εικόνας Ομάδας</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Δημιουργία Αντιγράφων Ασφαλείας</string>
     <string name="export_backup_desktop">Εξαγωγή Αντιγράφων Ασφαλείας</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Το κλειδί σας έχει σταλεί στον εαυτό σας. Μεταβείτε στην άλλη συσκευή και ανοίξτε το μήνυμα ρύθμισης. Θα πρέπει να σας ζητηθεί κωδικός ρύθμισης. Εισαγάγετε τα ακόλουθα ψηφία:</string>
     <string name="autocrypt_correct_desktop">Η ρύθμιση αυτόματης κρυπτογράφησης μεταφέρθηκε.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Λανθασμένος κωδικός ρύθμισης. Παρακαλώ προσπαθησε ξανά.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Αδυναμία δημιουργίας συνομιλίας.</string>
     <string name="forget_login_confirmation_desktop">Διαγραφή αυτής της σύνδεσης; Τα πάντα θα διαγραφούν, συμπεριλαμβανομένων των ρυθμίσεων από άκρο σε άκρο, επαφών, συνομιλιών, μηνυμάτων και πολυμέσων. Αυτή η πράξη δε μπορεί να αναιρεθεί.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nΜέγεθος: %2$s\n Αναγνωριστικό Λογαριασμού: %3$s</string>
     <string name="message_detail_sent_desktop">Στάλθηκε</string>

--- a/res/values-eo/strings.xml
+++ b/res/values-eo/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Bone</string>
     <string name="cancel">Nuligi</string>
-    <string name="clear_search">Forviŝi Serĉon</string>
+   <string name="clear_search">Forviŝi Serĉon</string>
     <string name="yes">Jes</string>
     <string name="no">Ne</string>
     <string name="select">Elekti</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancelar</string>
-    <string name="clear_search">Borrar búsqueda</string>
+   <string name="clear_search">Borrar búsqueda</string>
     <string name="yes">Sí</string>
     <string name="no">No</string>
     <string name="select">Seleccionar</string>
@@ -799,7 +799,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Recibo de lectura</string>
     <string name="systemmsg_read_receipt_body">El mensaje \"%1$s\" que enviaste se mostró en la pantalla del destinatario.\n\nEsto no garantiza que el contenido haya sido leído.</string>
-    <string name="systemmsg_cannot_decrypt">Este mensaje no puede ser descifrado.\n\n• Es posible que sea útil simplemente responderlo y pedirle al remitente que lo envíe nuevamente.\n\n• En caso de que haya reinstalado Delta Chat u otro programa de correo en este u otro dispositivo, puede que quiera enviar un Mensaje de Configuración de Autocrypt desde allí.</string>
     <string name="systemmsg_unknown_sender_for_chat">Remitente desconocido. Mira \"info\" para más detalles.</string>
     <string name="systemmsg_subject_for_new_contact">Mensaje de %1$s</string>
     <string name="systemmsg_failed_sending_to">Falla en enviar el mensaje a %1$s.</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -979,8 +979,6 @@
     <string name="about_offical_app_desktop">Esta es la aplicación oficial de Delta Chat para escritorio.</string>
     <string name="about_licensed_under_desktop">Este programa está licenciado bajo GNU GPL versión 3 y el código está disponible en GitHub.</string>
     <string name="welcome_desktop">Bienvenido a Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Cuentas conocidas</string>
     <string name="global_menu_preferences_language_desktop">Idioma</string>
     <string name="global_menu_file_desktop">Archivo</string>
     <string name="global_menu_file_quit_desktop">Salir</string>
@@ -1007,26 +1005,12 @@
     <string name="delete_message_desktop">Eliminar mensaje</string>
     <string name="more_info_desktop">Más información</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Mostrar información de cifrado</string>
     <string name="remove_desktop">Eliminar</string>
     <string name="save_desktop">Guardar</string>
     <string name="name_desktop">Nombre</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transferencia de clave Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Un Mensaje de Configuración Autocrypt comparte de forma segura su configuración de extremo a extremo con otras aplicaciones compatibles con Autocrypt. La configuración se cifrará mediante un código de configuración que se muestra aquí y debe escribirse en el otro dispositivo.</string>
     <string name="select_group_image_desktop">Seleccionar imagen de grupo</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Progreso de copia de respaldo</string>
     <string name="export_backup_desktop">Exportar copia de respaldo</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Tu llave ha sido enviada a ti mismo. Cámbiate al otro dispositivo y abre el mensaje de configuración. Se te debe pedir un código de configuración. Escribe los siguientes dígitos:</string>
     <string name="autocrypt_correct_desktop">Configuración de Autocrypt transferida exitosamente!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Código de configuración incorrecto. Por favor, inténtalo de nuevo.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">No se pudo crear el chat.</string>
     <string name="forget_login_confirmation_desktop">¿Borrar esta sesión? Todo se eliminará, incluida la configuración de extremo a extremo, contactos, chats, mensajes y multimedia. Esta acción es definitiva y no puede ser revertida.</string>
     <string name="account_info_hover_tooltip_desktop2">Correo: %1$s\nTamaño: %2$s\nID de la cuenta: %3$s</string>
     <string name="message_detail_sent_desktop">enviado</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Ados</string>
     <string name="cancel">Utzi</string>
-    <string name="yes">Bai</string>
+   <string name="yes">Bai</string>
     <string name="no">Ez</string>
     <string name="on">Bai</string>
     <string name="off">Ez</string>
@@ -441,7 +441,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Irakurragiria</string>
     <string name="systemmsg_read_receipt_body">Hau \"%1$s\" mezuaren irakurragiri bat da.\n\nHonek mezua jasotzailearen gailuan bistaratu dela esan nahi du, ez edukia irakurri dela.</string>
-    <string name="systemmsg_cannot_decrypt">Ezin da mezu hau deszifratu.\n\n• Mezuari erantzun diezaiokezu eta berriro bidaltzea eskatu.\n\n• Delta Chat berrinstalatu baduzu edo beste posta programa bat instalatu baduzu gailu honetan edo beste batean, AutoCrypt ezarpen mezua handik hona birbidaltzen saiatu zaitezke.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Nik: Taldearen izena \"%1$s\" izatetik \"%2$s\" izatera aldatu da</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -507,8 +507,6 @@
     <string name="encrypted_message">Zifratutako mezua</string>
 
     <string name="welcome_desktop">Ongi etorri Delta Chat-era</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Kontu ezagunak</string>
     <string name="global_menu_preferences_language_desktop">Hautatu hizkuntza...</string>
     <string name="global_menu_file_desktop">Fitxategia</string>
     <string name="global_menu_file_quit_desktop">Irten</string>
@@ -533,26 +531,12 @@
     <string name="delete_message_desktop">Ezabatu mezua</string>
     <string name="more_info_desktop">Informazio gehiago</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Erakutsi zifratzeari buruzko informazioa</string>
     <string name="remove_desktop">Kendu</string>
     <string name="save_desktop">Gorde</string>
     <string name="name_desktop">Izena</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt gakoaren transferentzia</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Autocrypt ezarpen mezu batek modu seguruan partekatzen du zure muturretik muturrerako ezarpena Autocryptekin bateragarriak diren beste aplikazioekin. Ezarpena hemen bistaratutako ezarpen kodearekin zifratuko  da, eta beste gailuan kode hau sartu beharko da.</string>
     <string name="select_group_image_desktop">Hautatu taldearen irudia</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Babes-kopia abian</string>
     <string name="export_backup_desktop">Esportatu babes-kopia</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Zure gakoa  bidali zaizu. Joan beste gailura eta ireki ezarpen mezua. Ezarpen kode bat eskatuko zaizu. Idatzi honako zenbaki hauek han. Behin eginda, zure beste gailua Autocrypt erabiltzeko prest egongo da.</string>
     <string name="autocrypt_correct_desktop">Ongi igorri da Autocrypt ezarpena!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Ezarpen kode okerra. Saiatu berriro.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Ezin izan da txata sortu.</string>
     <string name="forget_login_confirmation_desktop">Ezabatu erabiltzaile-izen hau? Dena ezabatuko da, muturretik muturrerako ezarpena, txatak, mezuak eta multimedia barne. Ekintza hau behin betikoa da eta ezin da desegin.</string>
     <string name="message_detail_sent_desktop">bidalita</string>
     <string name="message_detail_received_desktop">jasota</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -948,8 +948,6 @@ GNU GPL ورژن ۳
  GitHub
  در دسترس است.</string>
     <string name="welcome_desktop">به دلتاچت خوش‌آمدید</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">اکانت‌های شناخته شده</string>
     <string name="global_menu_preferences_language_desktop">زبان</string>
     <string name="global_menu_file_desktop">پرونده</string>
     <string name="global_menu_file_quit_desktop">خروج</string>
@@ -976,26 +974,12 @@ GNU GPL ورژن ۳
     <string name="delete_message_desktop">حذف پیام</string>
     <string name="more_info_desktop">جزئیات بیشتر </string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">نمایش مشخصات رمزگذاری</string>
     <string name="remove_desktop">حذف</string>
     <string name="save_desktop">ذخیره</string>
     <string name="name_desktop">نام</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">انتقال کلید اتوکریپت</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">یک پیام برپاسازی اتوکریپت، برپاسازی رمزگذاری سرتاسرتان را به‌امنی با دیگر برنامه‌های سازگار با اتوکریپت هم‌رسانی می‌کند. برپاسازی با یک کد برپاسازی رمزگذاری خواهند شد که در اینجا نمایش داده می‌شود که باید آن  را در دستگاه دیگر وارد کنید. </string>
     <string name="select_group_image_desktop">انتخاب تصویر گروه</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">فرایند تهیه نسخه پشتیبان</string>
     <string name="export_backup_desktop">صادر کردن نسخه پشتیبان</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">کلید برایتان ارسال شد. به دستگاه دیگر رفته و پیام نصب را باز کنید. از شما یک کد نصب خواسته می‌شود. این ارقام را آن‌جا وارد کنید:</string>
     <string name="autocrypt_correct_desktop">برپاسازی اتوکریپت انتقال یافت.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">کد نصب نادرست. لطفا دوباره امتحان کنید. </string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">امکان ایجاد گپ وجود ندارد. </string>
     <string name="forget_login_confirmation_desktop">پاک کردن این ورود؟ همه‌چیز پاک می‌شود که شامل رمزگذاری سرتاسر، مخاطبین، گپ‌ها، پیام‌ها و رسانه می‌شود. این عملیات قابل بازگردانی نیست.</string>
     <string name="account_info_hover_tooltip_desktop2">رایانامه: %1$s
 فضا: %2$s

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">دلتاچت</string>
     <string name="ok">تأیید</string>
     <string name="cancel">لغو</string>
-    <string name="clear_search">پاک کردن جست‌وجو</string>
+   <string name="clear_search">پاک کردن جست‌وجو</string>
     <string name="yes">بله</string>
     <string name="no">خیر</string>
     <string name="select">انتخاب</string>
@@ -760,7 +760,6 @@ https://meet.jit.si/$ROOM
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">پیام باز شد</string>
     <string name="systemmsg_read_receipt_body">پیام\"%1$s\" که ارسال کرده بودید در ثفحه گیرنده نمایش داده شد\n\n. تضمینی وجود ندارد که محتوای پیام را خوانده باشد. </string>
-    <string name="systemmsg_cannot_decrypt">این پیام را نمی‌توان رمزگشایی کرد.\n\n• ممکن است بهتر باشد که به همین پیام پاسخ داده و از ارسال کننده بخواهید دوباره آن را بفرستد. \n\n• اگر دوباره دلتاچت را نصب کرده‌اید یا از یک رایانامه دیگر هم روی این دستگاه یا دستگاه دیگر استفاده می‌کنید ممکن است لازم باشد یک پیام برپاسازی اتوکریپت از آن دستگاه ارسال کنید. </string>
     <string name="systemmsg_unknown_sender_for_chat">فرستنده در این گفت و گو ناشناس است. برای جزئیات بیشتر به \"اطلاعات\" مراجعه کنید.</string>
     <string name="systemmsg_subject_for_new_contact">پیام از%1$s</string>
     <string name="systemmsg_failed_sending_to">ارسال ناموفق پیام به %1$s.</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -868,8 +868,6 @@
     <string name="about_offical_app_desktop">Tämä on virallinen Delta Chat -työpöytäsovellus.</string>
     <string name="about_licensed_under_desktop">Tämä ohjelmisto on GNU GPL v3 -lisensoitu, ja lähdekoodi on saatavilla GitHubissa.</string>
     <string name="welcome_desktop">Tervetuloa Delta Chatiin</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Tunnetut tilit</string>
     <string name="global_menu_preferences_language_desktop">Kieli</string>
     <string name="global_menu_file_desktop">Tiedosto</string>
     <string name="global_menu_file_quit_desktop">Sulje</string>
@@ -896,26 +894,12 @@
     <string name="delete_message_desktop">Poista viesti</string>
     <string name="more_info_desktop">Lisätietoja</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Näytä salaustiedot</string>
     <string name="remove_desktop">Poista</string>
     <string name="save_desktop">Tallenna</string>
     <string name="name_desktop">Nimi</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt-avainten siirto</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Autocrypt-asetusviesti jakaa turvallisesti päästä-päähän-salauksen asetukset toisten Autocrypt-yhteensopivien sovellusten kanssa. Asetukset salataan tässä näytettävällä asetuskoodilla, joka on syötettävä toiseen laitteeseen.</string>
     <string name="select_group_image_desktop">Valitse ryhmän kuva</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Varmuuskopioinnin tila</string>
     <string name="export_backup_desktop">Vie varmuuskopio</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Asetusviesti on lähetetty sinulle itsellesi. Avaa viesti toisella laitteella. Sinulta pyydetään asennuskoodia. Anna seuraavat numerot:</string>
     <string name="autocrypt_correct_desktop">Autocrypt-asetukset siirretty.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Virheellinen asennuskoodi. Yritä uudelleen.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Keskustelua ei voitu luoda.</string>
     <string name="forget_login_confirmation_desktop">Poista tämä kirjautuminen? Kaikki tiedot poistetaan, mukaan lukien päästä-päähän-salauksen asetukset, yhteystiedot, keskustelut, viestit ja media. Tämä toiminto on peruuttamaton.</string>
     <string name="account_info_hover_tooltip_desktop2">Sähköposti: %1$s\nKoko: %2$s\nTilin tunniste: %3$s</string>
     <string name="message_detail_sent_desktop">lähetetty</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Peruuta</string>
-    <string name="clear_search">Tyhjennä haku</string>
+   <string name="clear_search">Tyhjennä haku</string>
     <string name="yes">Kyllä</string>
     <string name="no">Ei</string>
     <string name="select">Valitse</string>
@@ -707,7 +707,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Viesti avattu</string>
     <string name="systemmsg_read_receipt_body">Lähettämäsi viesti \"%1$s\" näytettiin vastaanottajan näytöllä.\n\nTämä ei takaa, että sisältö luettiin.</string>
-    <string name="systemmsg_cannot_decrypt">Viestin salausta ei voi purkaa.\n\n• Pyydä lähettäjää lähettämään viesti uudelleen.\n\n• Jos asensit Delta Chatin tai toisen sähköpostisovelluksen uudelleen tälle tai toiselle laitteelle, Autocrypt-asetusviestin lähettäminen siitä sovelluksesta voi auttaa.</string>
     <string name="systemmsg_unknown_sender_for_chat">Tuntematon lähettäjä. Katso \"lisätietoja\".</string>
     <string name="systemmsg_subject_for_new_contact">Viesti lähettäjältä %1$s</string>
     <string name="systemmsg_failed_sending_to">Viestin lähettäminen kohteeseen %1$s epäonnistui.</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -983,8 +983,6 @@
     <string name="about_offical_app_desktop">Ceci est l\'application de bureau Delta Chat officielle.</string>
     <string name="about_licensed_under_desktop">Ce logiciel est sous licence GNU GPL version 3 et le code source est disponible sur GitHub.</string>
     <string name="welcome_desktop">Bienvenue sur Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Comptes connus</string>
     <string name="global_menu_preferences_language_desktop">Choisissez la langue...</string>
     <string name="global_menu_file_desktop">Fichier</string>
     <string name="global_menu_file_quit_desktop">Quitter</string>
@@ -1011,26 +1009,12 @@
     <string name="delete_message_desktop">Supprimer le message</string>
     <string name="more_info_desktop">En savoir plus</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Afficher les informations de chiffrement</string>
     <string name="remove_desktop">Retirer</string>
     <string name="save_desktop">Sauvegardez</string>
     <string name="name_desktop">Nom</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transfert de la clé Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Un message de configuration Autocrypt partage en toute sécurité votre configuration de bout en bout avec d\'autres applications compatibles Autocrypt. La configuration est chiffrée par un code de configuration qui s\'affiche ici et doit être tapé sur l\'autre appareil.</string>
     <string name="select_group_image_desktop">Choisir l\'image de groupe</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Avancement de la sauvegarde</string>
     <string name="export_backup_desktop">Exporter la sauvegarde</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Votre clé vous a été envoyée. Passez à l\'autre appareil et ouvrez le message de configuration. Vous devriez être invité à entrer un code de configuration. Tapez les chiffres suivants:</string>
     <string name="autocrypt_correct_desktop">Configuration Autocrypt transférée.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Code de configuration incorrect. Veuillez réessayer.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">La discussion n’a pas pu être créée.</string>
     <string name="forget_login_confirmation_desktop">Supprimer cette connexion ? Tout sera effacé, y compris vos paramètres de chiffrement de bout en bout, vos contacts, discussions, messages et fichiers multimédia. Cette action est irrévocable.</string>
     <string name="account_info_hover_tooltip_desktop2">Adresse: %1$s\nTaille: %2$s\nID du compte: %3$s</string>
     <string name="message_detail_sent_desktop">envoyé</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Annuler</string>
-    <string name="clear_search">Effacer la recherche</string>
+   <string name="clear_search">Effacer la recherche</string>
     <string name="yes">Oui</string>
     <string name="no">Non</string>
     <string name="select">Sélectionner</string>
@@ -803,7 +803,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Accusé de lecture</string>
     <string name="systemmsg_read_receipt_body">Ceci est un accusé de lecture pour le message \"%1$s\".\n\nCela signifie que le message a été affiché sur l\'appareil du destinataire, pas forcément que le contenu ait été lu.</string>
-    <string name="systemmsg_cannot_decrypt">Ce message ne peut pas être déchiffré.\n\n• Il peut déjà être utile de simplement répondre à ce message et demander à l\'expéditeur de l\'envoyer à nouveau.\n\n• Au cas où vous auriez réinstallé Delta Chat ou un autre programme de messagerie sur cet appareil ou un autre, vous voudrez peut-être envoyer un message de configuration d\'Autocrypt depuis ce dernier.</string>
     <string name="systemmsg_unknown_sender_for_chat">Expéditeur inconnu de cette discussion. Voir « Info » pour plus de détails.</string>
     <string name="systemmsg_subject_for_new_contact">Message de %1$s</string>
     <string name="systemmsg_failed_sending_to">Échec de l\'envoi du message à %1$s.</string>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancelar</string>
-    <string name="clear_search">Eliminar busca</string>
+   <string name="clear_search">Eliminar busca</string>
     <string name="yes">Si</string>
     <string name="no">Non</string>
     <string name="select">Seleccionar</string>
@@ -714,7 +714,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Mensaxe aberta</string>
     <string name="systemmsg_read_receipt_body">A mensaxe \"%1$s\" que enviaches mostrouse na pantalla do correspondente.\n\nNon hai garantía de que o contido fose lido.</string>
-    <string name="systemmsg_cannot_decrypt">Esta mensaxe non se pode descifrar.\n\n• Podería axudar que respondas a mensaxe pedindo ao remitente que a volte a enviar.\n\n• En caso dunha reinstalación Delta Chat ou outro programa de correo en este ou outro dispositivo igual debes enviar unha Mensaxe de Configuración Autocrypt desde alí.</string>
     <string name="systemmsg_unknown_sender_for_chat">Remitente descoñecido para esta convers. Mira en \'info\' para saber máis.</string>
     <string name="systemmsg_subject_for_new_contact">Mensaxe de %1$s</string>
     <string name="systemmsg_failed_sending_to">Fallou o envío para %1$s.</string>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -844,8 +844,6 @@
     <string name="about_offical_app_desktop">Esta é a app oficial de Escritorio para Delta Chat</string>
     <string name="about_licensed_under_desktop">Este software está baixo licenza GNU GPL versión 3 e o código fonte está dispoñible en GitHub.</string>
     <string name="welcome_desktop">Benvida a Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Contas coñecidas</string>
     <string name="global_menu_preferences_language_desktop">Idioma</string>
     <string name="global_menu_file_desktop">Ficheiro</string>
     <string name="global_menu_file_quit_desktop">Saír</string>
@@ -872,26 +870,12 @@
     <string name="delete_message_desktop">Eliminar mensaxe</string>
     <string name="more_info_desktop">Máis info</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Mostrar info de cifrado</string>
     <string name="remove_desktop">Eliminar</string>
     <string name="save_desktop">Gardar</string>
     <string name="name_desktop">Nome</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transferir chave Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Unha Mensaxe de Configuración Autocrypt comparte de xeito seguro o teu cifrado extremo-a-extremo con outras apps compatibles con Autocrypt. O axuste cífrase cun código seguro que se mostra aquí e debes escribir no outro dispositivo.</string>
     <string name="select_group_image_desktop">Escoller imaxe do grupo</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Progreso do respaldo</string>
     <string name="export_backup_desktop">Exportar respaldo</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Enviaches a chave a ti mesma. Vaite ao outro dispositivo e abre a mensaxe de Configuración. Pedirache o código de configuración. Introduce os seguintes díxitos:</string>
     <string name="autocrypt_correct_desktop">Axuste Autocrypt transferido.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Código incorrecto. Inténtao outra vez.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Non se puido crear a conversa.</string>
     <string name="forget_login_confirmation_desktop">Eliminar esta conexión? Borrarase todo, incluíndo os axustes de cifrado, contactos, conversas, mensaxes e ficheiros de medios. Esta acción non ten volta atrás.</string>
     <string name="account_info_hover_tooltip_desktop2">Email: %1$s \nTamaño: %2$s \nId. da conta: %3$s</string>
     <string name="message_detail_sent_desktop">enviado</string>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Otkaži</string>
-    <string name="yes">Da</string>
+   <string name="yes">Da</string>
     <string name="no">Ne</string>
     <string name="on">Uključeno</string>
     <string name="off">Isključeno</string>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Mégse</string>
-    <string name="yes">Igen</string>
+   <string name="yes">Igen</string>
     <string name="no">Nem</string>
     <string name="on">Be</string>
     <string name="off">Ki</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Batalkan</string>
-    <string name="clear_search">Hapus pencarian</string>
+   <string name="clear_search">Hapus pencarian</string>
     <string name="yes">Ya</string>
     <string name="no">Tidak</string>
     <string name="select">Pilih</string>
@@ -558,7 +558,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Pesan dibuka</string>
     <string name="systemmsg_read_receipt_body">Pesan \"%1$s\" yang Anda kirimkan tampak di layar penerima.\n\nIni bukan jaminan kalau isinya dibaca.</string>
-    <string name="systemmsg_cannot_decrypt">Pesan ini tidak bisa dienkripsi.\n\n• Ada baiknya menjawab pesan ini dan meminta pengirimnya untuk kirim ulang.\n\n• Dalam kasus Anda menginstal ulang Delta Chat atau program surel lain di perangkat ini atau perangkat lain, sebaiknya Anda mengirim Pengaturan Pesan Autocrypt dari sana.</string>
     <string name="systemmsg_unknown_sender_for_chat">Pengirim tidak dikenal untuk obrolan ini. Lihat \'info\' untuk lebih jelasnya.</string>
     <string name="systemmsg_subject_for_new_contact">Pesan dari %1$s</string>
     <string name="systemmsg_failed_sending_to">Gagal mengirim pesan ke %1$s.</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -633,8 +633,6 @@
     <string name="about_offical_app_desktop">Ini adalah aplikasi resmi Delta Chat Desktop.</string>
     <string name="about_licensed_under_desktop">Perangkat lunak ini berlisensi di bawah GNU GPL versi 3 dan kode sumber tersedia di GitHub.</string>
     <string name="welcome_desktop">Selamat Datang di Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Akun yang dikenal</string>
     <string name="global_menu_preferences_language_desktop">Bahasa</string>
     <string name="global_menu_file_desktop">Berkas</string>
     <string name="global_menu_file_quit_desktop">Keluar</string>
@@ -658,23 +656,11 @@
     <string name="delete_message_desktop">Hapus pesan</string>
     <string name="more_info_desktop">Info lebih lanjut</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Tampilkan info enkripsi</string>
     <string name="remove_desktop">Menghapus</string>
     <string name="save_desktop">Menyimpan</string>
     <string name="name_desktop">Nama</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transfer kunci Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Pengaturan Pesan Autocrypt secara aman membagikan pengaturan ujung ke ujung Anda dengan aplikasi lain yang sesuai dengan Autocrypt. Pengaturan akan dienkripsi dengan kode pengaturan yang ditampilkan di sini dan harus diketik di perangkat lain.</string>
     <string name="select_group_image_desktop">Pilih gambar grup</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Kunci Anda sudah dikirim ke Anda sendiri. Lihat pesan pengaturan di perangkat yang lain. Seharusnya Anda akan diminta kode pengaturan. Masukkan angka berikut:</string>
     <string name="autocrypt_correct_desktop">Pengaturan Autocrypt ditransfer.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Kode pengaturan salah. Coba lagi.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Tidak dapat membuat obrolan.</string>
     <string name="forget_login_confirmation_desktop">Hapus login ini? Semuanya akan dihapus, termasuk pengaturan ujung ke ujung, kontak, obrolan, pesan dan media. Kalau diklik tidak bisa balik lagi.</string>
     <string name="message_detail_sent_desktop">kirim</string>
     <string name="message_detail_received_desktop">diterima</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -983,8 +983,6 @@
     <string name="about_offical_app_desktop">Questa è l\'app Desktop Delta Chat ufficiale.</string>
     <string name="about_licensed_under_desktop">Questo software è concesso in licenza con GNU GPL versione 3 e il codice sorgente è disponibile su GitHub.</string>
     <string name="welcome_desktop">Benvenuto in Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Account Conosciuti</string>
     <string name="global_menu_preferences_language_desktop">Lingua</string>
     <string name="global_menu_file_desktop">File</string>
     <string name="global_menu_file_quit_desktop">Esci</string>
@@ -1011,26 +1009,12 @@
     <string name="delete_message_desktop">Elimina Messaggio</string>
     <string name="more_info_desktop">Maggiori Informazioni</string>
     <string name="timestamp_format_m_desktop">D MMM</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Mostra Info Cifratura</string>
     <string name="remove_desktop">Rimuovi</string>
     <string name="save_desktop">Salva</string>
     <string name="name_desktop">Nome</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Trasferimento chiave Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Un Messaggio di Configurazione Autocrypt condivide in modo sicuro la tua configurazione end-to-end con altre applicazioni compatibili con Autocrypt. La configurazione sarà criptata da un codice di configurazione visualizzato qui e deve essere digitato sull\'altro dispositivo.</string>
     <string name="select_group_image_desktop">Seleziona Immagine Gruppo</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Avanzamento Backup</string>
     <string name="export_backup_desktop">Esporta Backup</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">La tua chiave ti è stata inviata. Passa all\'altro dispositivo, apri il messaggio di configurazione e inserisci il seguente codice quando richiesto. Una volta fatto, il dispositivo sarà pronto per usare Autocrypt.</string>
     <string name="autocrypt_correct_desktop">Configurazione di Autocrypt trasferita.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Codice di impostazione errato. Si prega di riprovare.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Impossibile creare una chat.</string>
     <string name="forget_login_confirmation_desktop">Eliminare questo accesso? Tutto verrà eliminato, inclusa la configurazione end-to-end, i contatti, le chat, i messaggi e i media. Questa azione non può essere annullata.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nDimensione: %2$s\nAccount Id: %3$s</string>
     <string name="message_detail_sent_desktop">inviato</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Annulla</string>
-    <string name="clear_search">Cancella Ricerca</string>
+   <string name="clear_search">Cancella Ricerca</string>
     <string name="yes">Sì</string>
     <string name="no">No</string>
     <string name="select">Seleziona</string>
@@ -803,7 +803,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Ricevuta di lettura</string>
     <string name="systemmsg_read_receipt_body">Questa è una ricevuta di lettura del messaggio \"%1$s\".\n\nCiò significa che il messaggio è stato mostrato nel dispositivo del destinatario, ma non necessariamente che il contenuto è stato letto.</string>
-    <string name="systemmsg_cannot_decrypt">Questo messaggio non può essere decrittato.\n\n• Potrebbe essere sufficiente rispondere a questo messaggio e chiedere al mittente di rispedirlo.\n\n• Se hai reinstallato Delta Chat o usi un altro client email dovresti inviare un Messaggio di configurazione Autocrypt dal dispositivo originario.</string>
     <string name="systemmsg_unknown_sender_for_chat">Mittente sconosciuto per questa chat. Vedi \'info\' per maggiori dettagli.</string>
     <string name="systemmsg_subject_for_new_contact">Messaggio da %1$s</string>
     <string name="systemmsg_failed_sending_to">Impossibile inviare il messaggio a %1$s.</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">了承</string>
     <string name="cancel">取消</string>
-    <string name="clear_search">検索履歴を消す</string>
+   <string name="clear_search">検索履歴を消す</string>
     <string name="yes">はい</string>
     <string name="no">いいえ</string>
     <string name="select">選択</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -651,8 +651,6 @@ https://delta.chat</string>
     <string name="encrypted_message">暗号化されたメッセージ</string>
 
     <string name="welcome_desktop">Delta Chatにようこそ</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">知り合い</string>
     <string name="global_menu_preferences_language_desktop">言語を選択して下さい</string>
     <string name="global_menu_file_desktop">ファイル</string>
     <string name="global_menu_file_quit_desktop">終了</string>
@@ -676,22 +674,12 @@ https://delta.chat</string>
     <string name="delete_message_desktop">メッセージを削除する</string>
     <string name="more_info_desktop">もっと詳しく</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">暗号化情報の表示</string>
     <string name="remove_desktop">削除</string>
     <string name="save_desktop">保存</string>
     <string name="name_desktop">名前</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">自動暗号化設定の転送</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">｢自動暗号化設定用メッセージ｣は安全に一対一暗号化設定を対応するアプリケーションとの間に設定します｡　受信側は設定時に表示されるパスコードを入力する必要が有ります｡</string>
     <string name="select_group_image_desktop">グループ画像を選択する</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">バックアップの進行状況</string>
     <string name="export_backup_desktop">バックアップをエクスポート</string>
     <string name="autocrypt_correct_desktop">自動暗号化設定が転送されました</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">チャットを作成できませんでした。</string>
     <string name="message_detail_sent_desktop">送信済み</string>
     <string name="message_detail_received_desktop">届きました</string>
     <string name="menu.view.developer.open.log.folder">ログフォルダを開く</string>

--- a/res/values-km/strings.xml
+++ b/res/values-km/strings.xml
@@ -787,8 +787,6 @@
     <string name="about_offical_app_desktop">នេះគឺជាសា Delta Chat ផ្លូវការ នៅលើកម្មវិធីកុំព្យូទ័រលើតុ</string>
     <string name="about_licensed_under_desktop">សូហ្វវែ Delta Chat នេះគឺបានអាជ្ញាប័ណ្ណនៅក្រោម GNU GPL ជំនាន់ ៣ និងប្រភពកូដ គឺអាចរកបាននៅលើ GitHub</string>
     <string name="welcome_desktop">ស្វាគមន៍មកកាន់សា Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">គណនីដែលបានស្គាល់</string>
     <string name="global_menu_preferences_language_desktop">ភាសា</string>
     <string name="global_menu_file_desktop">ឯកសារ</string>
     <string name="global_menu_file_quit_desktop">ឈប់</string>
@@ -815,26 +813,12 @@
     <string name="delete_message_desktop">លុបសារ</string>
     <string name="more_info_desktop">ពត៌មានបន្ថែម</string>
     <string name="timestamp_format_m_desktop">ខែ ថ្ងៃ</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">បង្ហាញពត៌មានដែលការធ្វើឲ្យសារជាសម្ងាត់</string>
     <string name="remove_desktop">យកចេញ</string>
     <string name="save_desktop">រក្សាទុក</string>
     <string name="name_desktop">ឈ្មោះ</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">ការផ្ទេរសោរអ៊ិនគ្រីបស្វ័យប្រវត្តិ</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">សាររៀបចំអ៊ិនគ្រីបស្វ័យប្រវត្តិដោយសុវត្ថិភាព ចែករំលែកការរៀបចំឧបករណ៍ដល់ឧបករណ៍ ដល់ឧបករណ៍ជាមួយកម្មវិធី ដែលមានអ៊ិនគ្រីបស្វ័យប្រវត្តិផ្សេងទៀត។ ការចាត់នឹងបានអ៊ិនគ្រីប (ការធ្វើឲ្យការផ្ញើសារជាសារដាយសញ្ញាសម្ងាត់) នៅទីនេះ នឹងត្រូវតែបានវាយបញ្ចូលនៅលើឧបករណ៍ផ្សេង។</string>
     <string name="select_group_image_desktop">ជ្រើសរើសរូបភាពរបស់ក្រុម</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">វឌ្ឍនភាពការបម្រុងទុក</string>
     <string name="export_backup_desktop">នាំចេញការបម្រុងទុក</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">កូនសោររបស់អ្នកបានផ្ញើទៅខ្លួនអ្នក។ ប្តូរឆ្លាស់ទៅឧបករណ៍ផ្សេងទៀត និងបើកការរៀបចំសារ។ អ្នកនឹងទទួលសំណួរពីកូដរៀបចំ។ បញ្ចូលតូលេខដូចខាងក្រោម:</string>
     <string name="autocrypt_correct_desktop">ការរៀវចំចាក់អ៊ិនគ្រីបស្វ័យប្រវត្តិបានផ្ទេរហើយ។</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">ការរៀបចំកូដមិនត្រឹមត្រូវទេ។ សូមព្យាយាមម្តងទៀត។</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">មិនអាចបានបង្កើតការសន្ទនា</string>
     <string name="forget_login_confirmation_desktop">លុបការកត់ចូលនេះ? គ្រប់យ៉ាងនឹងត្រូវបានលុប រួមបញ្ចូលទាំងការរៀបចំ ទៅបញ្ចប់ការអុិនគ្រឹបឧបករណ៍ដល់ឧបករណ៍ ទំនាក់ទំនង សន្ទនា សារ និងប្រពន្ធ័ផ្សព្វផ្សាយ។ សកម្មភាពនេះមិនអាចធ្វើឡើងវិញបានទេ។</string>
     <string name="message_detail_sent_desktop">បានផ្ញើ</string>
     <string name="message_detail_received_desktop">បានទទួល</string>

--- a/res/values-km/strings.xml
+++ b/res/values-km/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">យល់ព្រម</string>
     <string name="cancel">ចោល</string>
-    <string name="clear_search">លុបការស្វែងរក</string>
+   <string name="clear_search">លុបការស្វែងរក</string>
     <string name="yes">បាទ/ចាស</string>
     <string name="no">ទេ</string>
     <string name="select">សំរាំង</string>
@@ -645,7 +645,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">សារត្រូវបានបើក</string>
     <string name="systemmsg_read_receipt_body">\"%1$s\" សារដែលអ្នកបានផ្ញើត្រូវបានបង្ហាញនៅលើ អេក្រង់របស់អ្នកទទួល\n\nនេះមិនមែនជាការធានាថា មាតិកាត្រួវបានអានទេ។</string>
-    <string name="systemmsg_cannot_decrypt">សារនេះមិនអាចត្រូវបានឌិគ្រីប\n\n• វាអាចជួយឆ្លើយតបជំនួសសារនេះ និងសួរអ្នកផ្ញើដើម្បីផ្ញើសារម្តងទៀត\n\n• ក្នុងករណីអ្នកបានតម្លើងសា Delta Chat ម្តងទៀត ឬកម្មវិធីអុីម៉េលមួយទៀត លើឧបករណ៍នេះ ឬឧបករណ៍មួយផ្សេងទៀត អ្នកប្រហែលជាចង់ផ្ញើ សារការតម្លើងអ៊ិនគ្រីបស្វ័យប្រវត្តិ  (ផ្ញើនិងទទួលដោយសម្ងាត់) ពីទីនោះ។</string>
     <string name="systemmsg_unknown_sender_for_chat">មិនស្គាល់អ្នកផ្ញើការសន្ទនានេះ។ មើល \'ពត៌មាន\' សម្រាប់ពត៌មានលំអិត</string>
     <string name="systemmsg_subject_for_new_contact">សារពី %1$s</string>
     <string name="systemmsg_failed_sending_to">បានបរាបានក្នុងការផ្ញើសារទៅ %1$s</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">확인</string>
     <string name="cancel">취소</string>
-    <string name="clear_search">검색 지우기</string>
+   <string name="clear_search">검색 지우기</string>
     <string name="yes">예</string>
     <string name="no">아니오</string>
     <string name="select">선택</string>
@@ -671,7 +671,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">메시지 열림</string>
     <string name="systemmsg_read_receipt_body">보낸 \"%1$s\" 메시지가 수신자의 화면에 표시되었습니다.\n\n이것은 내용이 읽혔다는 것을 보장하지 않습니다.</string>
-    <string name="systemmsg_cannot_decrypt">이 메시지의 암호를 해독할 수 없습니다.\n\n• 이 메시지에 회신하고 보낸 사람에게 메시지를 다시 보내도록 요청하는 것이 도움이 될 수 있습니다.\n\n• 이 장치나 다른 장치에 델타 채팅 또는 다른 전자 메일 프로그램을 다시 설치한 경우 자동 암호화 설치 메시지를 보낼 수 있습니다.</string>
     <string name="systemmsg_unknown_sender_for_chat">이 채팅의 발신자를 알 수 없습니다. 자세한 내용은 \'info\'를 확인하세요.</string>
     <string name="systemmsg_subject_for_new_contact">%1$s가 보낸 메시지</string>
     <string name="systemmsg_failed_sending_to">%1$s에게 메시지를 보내지 못했습니다.</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -830,8 +830,6 @@
     <string name="about_offical_app_desktop">이것은 Delta Chat 데스크톱 공식 앱입니다.</string>
     <string name="about_licensed_under_desktop">이 소프트웨어는 GNU GPL 버전 3에 따라 라이센스가 부여되며 소스 코드는 GitHub에서 사용할 수 있습니다.</string>
     <string name="welcome_desktop">Delta Chat에 오신 것을 환영합니다.</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">확인된 계정</string>
     <string name="global_menu_preferences_language_desktop">언어</string>
     <string name="global_menu_file_desktop">파일</string>
     <string name="global_menu_file_quit_desktop">그만두기</string>
@@ -856,26 +854,12 @@
     <string name="write_message_desktop">메시지 작성</string>
     <string name="delete_message_desktop">메시지 삭제</string>
     <string name="more_info_desktop">더 많은 정보</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">암호화 정보 표시</string>
     <string name="remove_desktop">삭제</string>
     <string name="save_desktop">저장</string>
     <string name="name_desktop">이름</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">자동 암호화 키 전송</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">자동 암호화 설치 메시지는 사용자의 설정을 다른 자동 암호화 호환 앱과 안전하게 공유합니다. 설정은 여기에 표시된 설정 코드로 암호화되며 다른 장치에 입력해야 합니다.</string>
     <string name="select_group_image_desktop">그룹 이미지 선택</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">백업 진행률</string>
     <string name="export_backup_desktop">백업 내보내기</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">키가 사용자 자신에게 전송되었습니다. 다른 장치로 전환하고 설정 메시지를 엽니다. 설정 코드를 입력하라는 메시지가 표시됩니다. 다음 숫자를 입력합니다.</string>
     <string name="autocrypt_correct_desktop">자동 암호화 설정이 전송되었습니다.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">잘못된 설정 코드입니다. 다시 시도하십시오.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">대화를 만들 수 없습니다.</string>
     <string name="forget_login_confirmation_desktop">이 로그인을 삭제하시겠습니까? 모든 설정, 연락처, 채팅, 메시지 및 미디어를 포함한 모든 것이 삭제됩니다. 이 작업은 취소할 수 없습니다.</string>
     <string name="account_info_hover_tooltip_desktop2">이메일: %1$s\n크기: %2$s\n계정 ID:%3$s</string>
     <string name="message_detail_sent_desktop">보냄</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Gerai</string>
     <string name="cancel">Atsisakyti</string>
-    <string name="clear_search">Išvalyti paiešką</string>
+   <string name="clear_search">Išvalyti paiešką</string>
     <string name="yes">Taip</string>
     <string name="no">Ne</string>
     <string name="on">Įjungta</string>
@@ -644,7 +644,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Pranešimas apie skaitymą</string>
     <string name="systemmsg_read_receipt_body">Tai yra pranešimas apie žinutės \"%1$s\" skaitymą.\n\nTai reiškia, kad žinutė buvo atvaizduota gavėjo įrenginyje, tačiau neužtikrina, kad jos turinys buvo perskaitytas.</string>
-    <string name="systemmsg_cannot_decrypt">Nepavyksta iššifruoti šios žinutės.\n\n• Galima, tiesiog, atsakyti į šią žinutę ir paprašyti siuntėjo dar kartą išsiųsti šią žinutę.\n\n• Tuo atveju, jeigu iš naujo įdiegėte Delta Chat ar kitą el. pašto programą šiame ar kitame įrenginyje, jūs galite pageidauti išsiųsti Autocrypt sąrankos žinutę iš to įrenginio.</string>
     <string name="systemmsg_subject_for_new_contact">Žinutė nuo %1$s</string>
     <!-- "left" in the meaning of "exited" -->
     <string name="group_left_by_you">Jūs išėjote iš grupės.</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -723,8 +723,6 @@
 
     <string name="about_licensed_under_desktop">Ši programinė įranga yra licencijuota pagal GNU GPL versiją 3, o pirminis kodas yra prieinamas „GitHub“ internetinėje svetainėje.</string>
     <string name="welcome_desktop">Sveiki atvykę į Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Žinomos paskyros</string>
     <string name="global_menu_preferences_language_desktop">Pasirinkti kalbą...</string>
     <string name="global_menu_file_desktop">Failas</string>
     <string name="global_menu_file_quit_desktop">Išeiti</string>
@@ -751,26 +749,12 @@
     <string name="delete_message_desktop">Ištrinti žinutę</string>
     <string name="more_info_desktop">Daugiau informacijos</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Rodyti šifravimo informaciją</string>
     <string name="remove_desktop">Šalinti</string>
     <string name="save_desktop">Išsaugoti</string>
     <string name="name_desktop">Vardas</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt rakto perdavimas</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Autocrypt sąrankos žinutė saugiai bendrina jūsų ištisinę sąranką su kitomis su Autocrypt suderinamomis programomis. Sąranka bus užšifruota sąrankos kodu, kuris yra rodomas čia ir privalės būti įvestas kitame įrenginyje.</string>
     <string name="select_group_image_desktop">Pasirinkti grupės paveikslą</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Atsarginės kopijos eiga</string>
     <string name="export_backup_desktop">Eksportuoti atsarginę kopiją</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Jūsų raktas išsiųstas jums patiems. Persijunkite į kitą įrenginį ir atverkite sąrankos žinutę. Jūsų turėtų būti prašoma įvesti sąrankos kodą. Įveskite šiuos skaitmenis:</string>
     <string name="autocrypt_correct_desktop">Autocrypt sąranka sėkmingai perduota!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Neteisingas sąrankos kodas. Bandykite dar kartą.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Nepavyko sukurti pokalbio.</string>
     <string name="forget_login_confirmation_desktop">Ištrinti šį prisijungimą? Viskas bus ištrinta, įskaitant jūsų ištisinę sąranką, adresatus, pokalbius, žinutes ir mediją. Šis veiksmas yra galutinis ir negalės būti panaikintas.</string>
     <string name="account_info_hover_tooltip_desktop2">El. paštas: %1$s\nDydis: %2$s\nPaskyros Id: %3$s</string>
     <string name="message_detail_sent_desktop">išsiųsta</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Avbryt</string>
-    <string name="yes">Ja</string>
+   <string name="yes">Ja</string>
     <string name="no">Nei</string>
     <string name="select">Velg</string>
     <string name="on">På</string>
@@ -370,7 +370,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Meldingskvittering</string>
     <string name="systemmsg_read_receipt_body">Dette er en meldingskvittering for meldingen \"%1$s\".\n\nDenne meldingskvitteringen bekrefter bare at meldingen ble vist på mottakerens enhet. Det finnes ingen garanti for at mottakeren har lest meldingsinnholdet.</string>
-    <string name="systemmsg_cannot_decrypt">Denne meldingen kan ikke dekrypteres.\n\n• Det kan hjelpe å svare på denne meldingen og spørre avsenderen om å sende den igjen.\n\n• I fall du har reinstallert Delta Chat eller et annet e-postprogram på denne eller en annen enhet, kan du sende en Autocrypt-oppsettsmelding derfra.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Gruppenavn endret fra \"%1$s\" til \"%2$s\" av meg.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -430,14 +430,8 @@
     <string name="encryption_info_title_desktop">Krypteringsinfo</string>
     <string name="delete_message_desktop">Slett melding</string>
     <string name="more_info_desktop">Mer informasjon</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Krypteringsinfo</string>
     <string name="remove_desktop">Fjerne</string>
     <string name="save_desktop">Lagre</string>
     <string name="name_desktop">Navn</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt-nøkkeloverføring</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">The Autocrypt-nøkkeloverføring krever at e-postklienten på den andre enheten er Autocrypt-kompatibel.\n\nDu kan så sende din hemmelige nøkkel til deg selv. Nøkkelen vil bli kryptert av en oppsettskode som vises her og må skrives inn på den andre enheten.</string>
     <string name="export_backup_desktop">Eksporter sikkerhetskopi</string>
     </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -968,8 +968,6 @@
     <string name="about_offical_app_desktop">Dit is de officiële Delta Chat-computerapp.</string>
     <string name="about_licensed_under_desktop">Deze software is vrijgegeven onder de GNU GPL versie 3 en de broncode is beschikbaar op GitHub.</string>
     <string name="welcome_desktop">Welkom bij Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Bekende accounts</string>
     <string name="global_menu_preferences_language_desktop">Taal</string>
     <string name="global_menu_file_desktop">Bestand</string>
     <string name="global_menu_file_quit_desktop">Afsluiten</string>
@@ -996,26 +994,12 @@
     <string name="delete_message_desktop">Bericht verwijderen</string>
     <string name="more_info_desktop">Meer informatie</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Versleutelingsinformatie tonen</string>
     <string name="remove_desktop">Verwijderen</string>
     <string name="save_desktop">Opslaan</string>
     <string name="name_desktop">Naam</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt-sleuteloverdracht</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Een ‘Autocrypt-instelbericht’ deelt je eind-tot-eindinstellingen veilig met andere Autocrypt-compatibele apps. De instellingen zijn versleuteld middels een code die hier wordt getoond en moet worden overgetypt op het andere apparaat.</string>
     <string name="select_group_image_desktop">Kies een groepsafbeelding</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Back-upvoortgang</string>
     <string name="export_backup_desktop">Back-up exporteren</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">D sleutel is aan jezelf verstuurd. Ga naar het andere apparaat en open het instelbericht. Je zou nu moeten worden gevraagd om een code. Typ de volgende getallen in het invoerveld:</string>
     <string name="autocrypt_correct_desktop">Autocrypt-instellingen overgedragen!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Onjuiste instelcode; probeer het opnieuw.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Kan geen gesprek beginnen.</string>
     <string name="forget_login_confirmation_desktop">Wil je dit account verwijderen? Alles wordt verwijderd: je eind-tot-eindinstellingen, contactpersonen, gesprekken, berichten en media. Deze actie kan niet ongedaan worden gemaakt.</string>
     <string name="account_info_hover_tooltip_desktop2">E-mail: %1$s\nGrootte: %2$s\nAccount-id: %3$s</string>
     <string name="message_detail_sent_desktop">verstuurd</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Oké</string>
     <string name="cancel">Annuleren</string>
-    <string name="clear_search">Zoekopdracht wissen</string>
+   <string name="clear_search">Zoekopdracht wissen</string>
     <string name="yes">Ja</string>
     <string name="no">Nee</string>
     <string name="select">Selecteren</string>
@@ -788,7 +788,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Leesbevestiging</string>
     <string name="systemmsg_read_receipt_body">Het door jou verstuurde bericht, “%1$s”, heeft het scherm van de ontvanger bereikt.\n\nDit betekent echter niet dat het ook gelezen is.</string>
-    <string name="systemmsg_cannot_decrypt">Dit bericht kan niet worden ontsleuteld.\n\n• Het kan helpen dit bericht te beantwoorden en de afzender te vragen het opnieuw te versturen.\n\n• Als je Delta Chat of een andere e-mailapp opnieuw hebt geïnstalleerd op dit of een ander apparaat, verstuur het instelbericht dan opnieuw.</string>
     <string name="systemmsg_unknown_sender_for_chat">Dit gesprek bevat een onbekende afzender. Zie ‘Informatie’ voor meer informatie.</string>
     <string name="systemmsg_subject_for_new_contact">Bericht van %1$s</string>
     <string name="systemmsg_failed_sending_to">Het bericht kan niet worden verstuurd aan %1$s.</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Anuluj</string>
-    <string name="clear_search">Wyczyść wyszukiwanie</string>
+   <string name="clear_search">Wyczyść wyszukiwanie</string>
     <string name="yes">Tak</string>
     <string name="no">Nie</string>
     <string name="select">Zaznacz</string>
@@ -789,7 +789,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Potwierdzenie odczytu</string>
     <string name="systemmsg_read_receipt_body">To jest potwierdzenie odczytu dla wiadomości ”%1$s„.\n\nTo potwierdzenie odczytu tylko informuje, że wiadomość została wyświetlona na urządzeniu odbiorcy. Nie ma gwarancji, że odbiorca przeczytał treść wiadomości.</string>
-    <string name="systemmsg_cannot_decrypt">Tej wiadomości nie można odszyfrować.\n\n• Możesz teraz pomóc odpowiadając po prostu na tą wiadomość i poprosić nadawcę o ponowne wysłanie wiadomości.\n\n• W przypadku ponownego zainstalowania Delta Chat lub innego programu mailowego na tym lub innym urządzeniu, może być konieczne wysłanie stąd klucza automatycznego szyfrowania.</string>
     <string name="systemmsg_unknown_sender_for_chat">Nieznany nadawca tego czatu. Więcej szczegółów znajdziesz w sekcji „Informacje”.</string>
     <string name="systemmsg_subject_for_new_contact">Wiadomość od %1$s</string>
     <string name="systemmsg_failed_sending_to">Nie udało się wysłać wiadomości do %1$s.</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -962,8 +962,6 @@
     <string name="about_offical_app_desktop">To jest oficjalna aplikacja Delta Chat Desktop.</string>
     <string name="about_licensed_under_desktop">To oprogramowanie jest objęte licencją GNU GPL w wersji 3, a kod źródłowy jest dostępny na GitHub.</string>
     <string name="welcome_desktop">Witaj w Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Znane konta</string>
     <string name="global_menu_preferences_language_desktop">Wybierz język</string>
     <string name="global_menu_file_desktop">Plik</string>
     <string name="global_menu_file_quit_desktop">Zamknij</string>
@@ -990,26 +988,12 @@
     <string name="delete_message_desktop">Usuń wiadomość</string>
     <string name="more_info_desktop">Więcej informacji</string>
     <string name="timestamp_format_m_desktop">D MMM</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Pokaż informacje o szyfrowaniu</string>
     <string name="remove_desktop">Usuń</string>
     <string name="save_desktop">Zapisz</string>
     <string name="name_desktop">Nazwa</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transfer klucza Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Wiadomość konfiguracyjna automatycznego szyfrowania bezpiecznie udostępnia twoją konfigurację end-to-end innym aplikacjom zgodnym z Autocrypt. Klucz zostanie zaszyfrowany za pomocą wyświetlonego tutaj kodu konfiguracyjnego, który należy wpisać na drugim urządzeniu.</string>
     <string name="select_group_image_desktop">Wybierz obraz grupy</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Postęp tworzenia kopii zapasowej </string>
     <string name="export_backup_desktop">Eksport kopii zapasowej</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Twój klucz został wysłany do ciebie. Przełącz się na inne urządzenie i otwórz komunikat konfiguracji. Powinieneś zostać poproszony o kod instalacyjny. Wpisz następujące cyfry w wierszu polecenia. Po zakończeniu Twoje drugie urządzenie będzie gotowe do użycia funkcji Autocrypt.</string>
     <string name="autocrypt_correct_desktop">Pomyślnie przetransferowano konfigurację Autocrypt!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Nieprawidłowy kod konfiguracji. Spróbuj ponownie.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Nie można utworzyć czatu.</string>
     <string name="forget_login_confirmation_desktop">Usunąć ten login? Wszystko zostanie usunięte, w tym kompletna konfiguracja, kontakty, czaty, wiadomości i multimedia. Ta akcja jest ostateczna i nie można jej odwrócić.</string>
     <string name="account_info_hover_tooltip_desktop2">E-mail: %1$s\nRozmiar: %2$s\nID konta: %3$s</string>
     <string name="message_detail_sent_desktop">wysłane</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancelar</string>
-    <string name="clear_search">Limpar busca</string>
+   <string name="clear_search">Limpar busca</string>
     <string name="yes">Sim</string>
     <string name="no">Não</string>
     <string name="select">Selecionar</string>
@@ -768,7 +768,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Confirmação de leitura</string>
     <string name="systemmsg_read_receipt_body">Confirmação de recebimento da mensagem \"%1$s\".\n\nEsta confirmação somente assegura que a mensagem foi exibida no aparelho do destinatário, mas não há garantia de que ele tenha lido o seu conteúdo.</string>
-    <string name="systemmsg_cannot_decrypt">Impossível descriptografar esta mensagem.\n\n• Pode resolver pedir que ela seja reenviada.\n\n• Caso você tenha reinstalado o Delta Chat ou outro programa de e-mail, neste ou noutro dispositivo, será necessário enviar uma \"mensagem de configuração do Autocrypt\".</string>
     <string name="systemmsg_unknown_sender_for_chat">Remetente desconhecido para esta conversa. Veja \'informações\' para mais detalhes.</string>
     <string name="systemmsg_subject_for_new_contact">Mensagem de %1$s</string>
     <string name="systemmsg_failed_sending_to">Falha ao enviar mensagem para %1$s.</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -931,8 +931,6 @@
     <string name="about_offical_app_desktop">Este é o aplicativo oficial Delta Chat Desktop.</string>
     <string name="about_licensed_under_desktop">Este software é licenciado sob a GNU GPL versão 3 e o código-fonte está disponível no GitHub.</string>
     <string name="welcome_desktop">Boas-vindas ao Delta Chat.</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Contas conhecidas</string>
     <string name="global_menu_preferences_language_desktop">Escolher língua...</string>
     <string name="global_menu_file_desktop">Arquivo</string>
     <string name="global_menu_file_quit_desktop">Sair</string>
@@ -959,26 +957,12 @@
     <string name="delete_message_desktop">Apagar mensagem</string>
     <string name="more_info_desktop">Mais informação</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Exibir informações de criptografia</string>
     <string name="remove_desktop">Remover</string>
     <string name="save_desktop">Salvar</string>
     <string name="name_desktop">Nome</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transferência de chaves do Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Uma \"mensagem de configuração do Autocrypt\" compartilha com segurança a sua configuração de ponta a ponta com outros aplicativos compatíveis. A configuração será criptografada por um código de configuração que será exibido aqui e deverá ser digitado no outro dispositivo.</string>
     <string name="select_group_image_desktop">Selecionar avatar de grupo</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Progresso do becape</string>
     <string name="export_backup_desktop">Exportar becape</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Sua chave foi enviada para você mesmo. Abra a mensagem de configuração no seu outro dispositivo. Lá será exibido uma solicitação de código. Digite-o lá. Depois disso, seu dispositivo estará pronto para usar o Autocrypt.</string>
     <string name="autocrypt_correct_desktop">Configuração Autocrypt completada!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Código errado. Tente de novo.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Impossível iniciar conversa.</string>
     <string name="forget_login_confirmation_desktop">Apagar este login? Tudo será apagado, incluindo sua configuração de criptografia, contatos, conversas, mensagens e mídia. Esta ação é final e irreversível.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nTamanho: %2$s\nConta Id: %3$s</string>
     <string name="message_detail_sent_desktop">enviado</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -382,8 +382,6 @@
     <!-- dc_str_* resources -->
     <string name="encrypted_message">Mensagem encriptada</string>
 
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Contas Conhecidas</string>
     <string name="global_menu_preferences_language_desktop">Escolha o seu idioma...</string>
     <string name="global_menu_file_desktop">Arquivo</string>
     <string name="global_menu_file_quit_desktop">Sair</string>
@@ -406,24 +404,12 @@
     <string name="delete_message_desktop">Apagar mensagem</string>
     <string name="more_info_desktop">Informação adicional</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Mostrar a informação de encriptação</string>
     <string name="remove_desktop">Apagar</string>
     <string name="save_desktop">Guardar</string>
     <string name="name_desktop">Nome</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Transferência da chave de Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Uma Mensagem de Configuração Autocrypt compartilha de forma segura sua configuração de ponta a ponta com outros aplicativos compatíveis com Autocrypt. A configuração será encriptada por um código de configuração que é exibido aqui e deve ser digitado no outro dispositivo.</string>
     <string name="select_group_image_desktop">Seleccionar a imagem para o grupo</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Progressão do backup</string>
     <string name="export_backup_desktop">Exportar o backup</string>
     <string name="autocrypt_correct_desktop">Configuração autocrypt transferida com sucesso!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Código de configuração incorreto. Por favor, tente novamente.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Não foi possível criar o Chat</string>
     <string name="forget_login_confirmation_desktop">Apagar este login? Tudo será apagado, incluindo sua configuração de ponta a ponta, contatos, chats, mensagens e mídia. Esta ação é final e não pode ser revertida.</string>
     <string name="message_detail_sent_desktop">enviado</string>
     <string name="message_detail_received_desktop">recebido</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancelar</string>
-    <string name="yes">Sim</string>
+   <string name="yes">Sim</string>
     <string name="no">Não</string>
     <string name="on">Ligado</string>
     <string name="off">Desligado</string>
@@ -324,7 +324,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Ler recibos</string>
     <string name="systemmsg_read_receipt_body">Este é um recibo de confirmação de leitura da mensagem \"%1$s\".\n\nEsta mensagem foi exibida no dispositivo do destinatário, não necessariamente que o conteúdo foi lido.</string>
-    <string name="systemmsg_cannot_decrypt">Esta mensagem não pode ser descriptada.\n\n • Talvez seja útil simplesmente responder a esta mensagem e solicitar que o remetente envie a mensagem novamente.\n\n • Caso você tenha re-instalado o Delta Chat ou outro programa de e-mail neste ou noutro dispositivo poderá querer enviar uma mensagem de configuração Autocrypt do dispositvo.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">O nome do grupo mudou de \"%1$s\" para \"%2$s\" por mim.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Anulați</string>
-    <string name="clear_search">Stergere Căutare</string>
+   <string name="clear_search">Stergere Căutare</string>
     <string name="yes">Da</string>
     <string name="no">Nu</string>
     <string name="select">Selectați</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -993,8 +993,6 @@
     <string name="about_offical_app_desktop">Это официальное приложение Delta Chat для ПК.</string>
     <string name="about_licensed_under_desktop">Это программное обеспечение под лицензией GNU GPL 3 версии, исходный код доступен на GitHub.</string>
     <string name="welcome_desktop">Добро пожаловать в Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Известные аккаунты</string>
     <string name="global_menu_preferences_language_desktop">Выбор языка</string>
     <string name="global_menu_file_desktop">Файл</string>
     <string name="global_menu_file_quit_desktop">Выйти</string>
@@ -1021,26 +1019,12 @@
     <string name="delete_message_desktop">Удалить сообщение</string>
     <string name="more_info_desktop">Больше информации</string>
     <string name="timestamp_format_m_desktop">МММ Д</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Показать информацию о шифровании</string>
     <string name="remove_desktop">Удалить</string>
     <string name="save_desktop">Сохранить</string>
     <string name="name_desktop">Имя</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Передача ключей Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Сообщение с параметрами Autocrypt служит для безопасной передачи параметров шифрования между собственными приложениями для работы с электронной почтой, поддерживающими протокол Autocrypt.\n\nЭти параметры шифруются с использованием специального кода, который показан здесь и должен быть введён в настраиваемом приложении.  </string>
     <string name="select_group_image_desktop">Выбрать изображение группы</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Состояние резевного копирования</string>
     <string name="export_backup_desktop">Экспорт резервной копии</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Ваш ключ был отправлен самому себе. Переключитесь на другое устройство и откройте настройки сообщения. Вам будет предложено ввести код установки. Введите следующие цифры в командной строке. Как только вы закончите, ваше другое устройство будет готово к использованию Autocrypt.</string>
     <string name="autocrypt_correct_desktop">Настройки Autocrypt успешно переданы!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Проверочный код указан неверно. Попробуйте ввести его повторно.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Не удалось создать чат.</string>
     <string name="forget_login_confirmation_desktop">Удалить эту учётную запись? Все данные будут удалены, включая настройки сквозного шифрования, контакты, чаты, сообщения и медиа файлы. Это действие нельзя будет отменить.</string>
     <string name="account_info_hover_tooltip_desktop2">Эл.почта: %1$s\nРазмер: %2$s\nПуть: %3$s</string>
     <string name="message_detail_sent_desktop">Отправлено</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Отмена</string>
-    <string name="clear_search">Очистить поиск</string>
+   <string name="clear_search">Очистить поиск</string>
     <string name="yes">Да</string>
     <string name="no">Нет</string>
     <string name="select">Выбрать</string>
@@ -816,7 +816,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Уведомление о прочтении</string>
     <string name="systemmsg_read_receipt_body">Это подтверждение того, что сообщение \"%1$s\" было открыто на устройстве получателя. Данное подтверждение не означает, что сообщение было прочитано.</string>
-    <string name="systemmsg_cannot_decrypt">Это сообщение не может быть расшифровано.\n\n• Возможно, поможет просто ответить на это сообщение и попросить отправителя отправить сообщение еще раз.\n\n • В случае, если вы переустановили Delta Chat или другую почтовую программу на этом или другом устройстве, возможно, вы захотите отправить сообщение с параметрами Autocrypt оттуда.</string>
     <string name="systemmsg_unknown_sender_for_chat">Неизвестный отправитель для данного чата. Смотрите \"информацию\" для подробностей.</string>
     <string name="systemmsg_subject_for_new_contact">Сообщение от %1$s</string>
     <string name="systemmsg_failed_sending_to">Не удалось отправить сообщение %1$s.</string>

--- a/res/values-sc/strings.xml
+++ b/res/values-sc/strings.xml
@@ -493,8 +493,6 @@
     <string name="write_message_desktop">Iscrie unu messàgiu</string>
     <string name="encryption_info_title_desktop">Informatziones de tzifradura</string>
     <string name="more_info_desktop">Àteras informatziones</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Ammustra sas informatziones de tzifradura</string>
     <string name="a11y_encryption_padlock">Luchete de tzifradura</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="pref_reliable_service">Connessione de isfundu de fide</string>

--- a/res/values-sc/strings.xml
+++ b/res/values-sc/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">AB</string>
     <string name="cancel">Annulla</string>
-    <string name="yes">Eja</string>
+   <string name="yes">Eja</string>
     <string name="no">Nono</string>
     <string name="select">Ischerta</string>
     <string name="on">Allutu</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Zrušiť</string>
-    <string name="clear_search">Zrušiť hľadanie</string>
+   <string name="clear_search">Zrušiť hľadanie</string>
     <string name="yes">Áno</string>
     <string name="no">Nie</string>
     <string name="select">Vybrať</string>
@@ -733,7 +733,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Správa otvorená</string>
     <string name="systemmsg_read_receipt_body">%1$s Správa, ktorú ste poslali, sa zobrazila na obrazovke príjemcu.\n\nZaručujeme, že obsah nebol prečítaný.</string>
-    <string name="systemmsg_cannot_decrypt">Túto správu nie je možné dešifrovať.\n\n• Už by mohlo pomôcť jednoducho odpovedať na túto správu a požiadať odosielateľa, aby správu odoslal znova.\n\n• V prípade, že ste na ňu znova nainštalovali program Delta Chat alebo iný e-mailový program alebo iné zariadenie, z ktorého budete pravdepodobne chcieť odoslať správu o nastavení automatického šifrovania.</string>
     <string name="systemmsg_unknown_sender_for_chat">Neznámy odosielateľ pre túto konverzáciu. Ďalšie informácie nájdete v časti „Informácie“.</string>
     <string name="systemmsg_subject_for_new_contact">Správa od %1$s</string>
     <string name="systemmsg_failed_sending_to">Správu sa nepodarilo odoslať %1$s .</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -892,8 +892,6 @@
     <string name="about_offical_app_desktop">Toto je oficiálna aplikácia Delta Chat Desktop.</string>
     <string name="about_licensed_under_desktop">Tento softvér je licencovaný pod GNU GPL verzie 3 a zdrojový kód je k dispozícii na GitHub-e.</string>
     <string name="welcome_desktop">Víta vás Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Známe účty</string>
     <string name="global_menu_preferences_language_desktop">Jazyk</string>
     <string name="global_menu_file_desktop">Súbor</string>
     <string name="global_menu_file_quit_desktop">Skončiť</string>
@@ -920,26 +918,12 @@
     <string name="delete_message_desktop">Odstrániť správu</string>
     <string name="more_info_desktop">Viac informácií</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Zobraziť informácie o šifrovaní</string>
     <string name="remove_desktop">Odstrániť</string>
     <string name="save_desktop">Uložiť</string>
     <string name="name_desktop">Názov</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocryptujte prenos kľúčov</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Správa o nastavení automatického šifrovania bezpečne zdieľa vaše komplexné nastavenie s inými aplikáciami kompatibilnými s automatickým šifrovaním. Nastavenie bude šifrované tu zobrazeným nastavovacím kódom a musí byť zadané na druhom zariadení.</string>
     <string name="select_group_image_desktop">Vyberte obrázok skupiny</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Priebeh zálohovania</string>
     <string name="export_backup_desktop">Exportovať zálohu</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Váš kľúč vám bol odoslaný. Prepnite na druhé zariadenie a otvorte správu o nastavení. Mala by vám prísť požiadavka na kód. Zadajte nasledujúce číslice:</string>
     <string name="autocrypt_correct_desktop">Nastavenie automatického šifrovania bolo prenesené.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Nesprávny kód nastavenia. Prosím skúste znova.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Nepodarilo sa vytvoriť konverzáciu.</string>
     <string name="forget_login_confirmation_desktop">Odstrániť tieto prihlasovacie údaje? Odstráni sa všetko vrátane vášho kompletného nastavenia, kontaktov, konverzácií, správ a médií. Túto akciu nie je možné vrátiť späť.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nVeľkosť: %2$s\n ID Účtu: %3$s</string>
     <string name="message_detail_sent_desktop">odoslané</string>

--- a/res/values-sq/strings.xml
+++ b/res/values-sq/strings.xml
@@ -965,8 +965,6 @@
     <string name="about_offical_app_desktop">Ky është aplikacioni zyrtar Delta Chat Desktop.</string>
     <string name="about_licensed_under_desktop">Ky program licencohet sipar GNU GPL version 3 dhe kodi burim mund të kihet që prej GitHub-i.</string>
     <string name="welcome_desktop">Mirë se vini në Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Llogari të njohura</string>
     <string name="global_menu_preferences_language_desktop">Zgjidhni Gjuhë…</string>
     <string name="global_menu_file_desktop">Kartelë</string>
     <string name="global_menu_file_quit_desktop">Dilni</string>
@@ -993,26 +991,12 @@
     <string name="delete_message_desktop">Fshije mesazhin</string>
     <string name="more_info_desktop">Më tepër të dhëna</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Shfaq të dhëna fshehtëzimi</string>
     <string name="remove_desktop">Hiqe</string>
     <string name="save_desktop">Ruaje</string>
     <string name="name_desktop">Emër</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Shpërngulje kyçi Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Një Mesazh Rregullimi Autocrypt-i ndan në mënyrë të sigurt formësimin tuaj skaj-më-skaj me aplikacione të tjera të përputhshme me Autocrypt-in. Formësimi do të fshehtëzohet përmes një kodi rregullimi, i cili shfaqet këtu dhe duhet dhënë në pajisjen tjetër.</string>
     <string name="select_group_image_desktop">Përzgjidhni figurë grupi</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Ecuri kopjeruajtjeje</string>
     <string name="export_backup_desktop">Eksportoni kopjeruajtje</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Kyçi juaj ju është dërguar. Kaloni te pajisja tjetër dhe hapni mesazhin e rregullimit. Do të duhej t\’ju kërkonte një kod rregullimi. Shtypi shifrat vijuese. Pasi të keni mbaruar, pajisja juaj tjetër do të jetë gati të përdorë Autocrypt-in.</string>
     <string name="autocrypt_correct_desktop">Rregullimi Autocrypt u shpërngul me sukses!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Kod i pasaktë rregullim. Ju lutemi, riprovoni.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">S\’u krijua dot fjalosje.</string>
     <string name="forget_login_confirmation_desktop">Të fshihet kjo hyrje? Do të fshihet gjithçka, përfshi rregullimin tuaj për skaj-më-skaj, kontaktet, fjalosjet, mesazhet dhe mediat. Ky veprim është përfundimtar dhe s\’mund të prapësohet.</string>
     <string name="account_info_hover_tooltip_desktop2">Email: %1$s\nMadhësi: %2$s\nID  Llogarie: %3$s</string>
     <string name="message_detail_sent_desktop">të dërguar</string>

--- a/res/values-sq/strings.xml
+++ b/res/values-sq/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Anuloje</string>
-    <string name="clear_search">Spastroje kërkimin</string>
+   <string name="clear_search">Spastroje kërkimin</string>
     <string name="yes">Po</string>
     <string name="no">Jo</string>
     <string name="select">Përzgjidhni</string>
@@ -785,7 +785,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Dëftesë leximi</string>
     <string name="systemmsg_read_receipt_body">Kjo është dëftesë leximi për mesazhin \"%1$s\".\n\nDo të thotë që mesazhi u shfaq te pajisja e marrësit, jo domosdo që lënda u lexua.</string>
-    <string name="systemmsg_cannot_decrypt">Ky mesazh s\’mund të shfshehtëzohet.\n\n• Mundet që të ndihmojë dërgimi thjesht i një përgjigjeje këtij mesazhi dhe t\’i kërkohet dërguesit ta ridërgojë mesazhin.\n\n• Në rast se ri-instaluat Delta Chat-in apo një tjetër program email-esh në këtë apo në një tjetër pajisje, mund të donit të dërgonit një Mesazh Rregullimi Autocrypt-i që prej andej.</string>
     <string name="systemmsg_unknown_sender_for_chat">Dërgues i panjohur për këtë fjalosje. Për më tepër hollësi, shihni \'info\'.</string>
     <string name="systemmsg_subject_for_new_contact">Mesazh nga %1$s</string>
     <string name="systemmsg_failed_sending_to">S’u arrit të dërgohej mesazh te %1$s.</string>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -898,8 +898,6 @@
     <string name="about_offical_app_desktop">Ово је званична Delta Chat апликација за рачунар.</string>
     <string name="about_licensed_under_desktop">Овај програм је лиценциран под ГНУ ГПЛ верзија 3 лиценцом и изворни код је доступан на Гитхабу.</string>
     <string name="welcome_desktop">Добродошли у Delta Chat.</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Познати налози</string>
     <string name="global_menu_preferences_language_desktop">Језик</string>
     <string name="global_menu_file_desktop">Фајл</string>
     <string name="global_menu_file_quit_desktop">Излаз</string>
@@ -926,26 +924,12 @@
     <string name="delete_message_desktop">Избриши поруку</string>
     <string name="more_info_desktop">Више података</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Прикажи податке о шифровању</string>
     <string name="remove_desktop">Уклони</string>
     <string name="save_desktop">Сачувај</string>
     <string name="name_desktop">Име</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Пошаљи кључ за аутошифровање</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Порука о подешавању аутоматског шифровања безбедно дели ваше комплетно подешавање са другим апликацијама компатибилним са аутоматским шифровањем. Подешавање ће бити шифровано кôдом за подешавање приказаним овде и мора се унети на другом уређају.</string>
     <string name="select_group_image_desktop">Изабери слику групе</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Напредак израде резервне копије</string>
     <string name="export_backup_desktop">Извези резервну копију</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Ваш кључ за шифровање сте послали самом себи. Пређите на други уређај и отворите поруку за подешавање. Када будете били питани за код за подешавање унесите следеће бројеве:</string>
     <string name="autocrypt_correct_desktop">Поставке за аутошифровање су послате.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Ваша подешавања су неисправна. Пробајте поново.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Није могуће креирати ћаскање.</string>
     <string name="forget_login_confirmation_desktop">Да ли желите да избришете овај налог? Све ће бити избрисано, укључујући и ваше подешавање с-краја-на-крај шифровања, контакти, ћаскања, поруке и медији. Ова радња се не може опозвати.</string>
     <string name="account_info_hover_tooltip_desktop2">Е-пошта: %1$s\nВеличина: %2$s\nИдентификатор налога: %3$s</string>
     <string name="message_detail_sent_desktop">послато</string>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">У реду</string>
     <string name="cancel">Откажи</string>
-    <string name="clear_search">Избриши претрагу</string>
+   <string name="clear_search">Избриши претрагу</string>
     <string name="yes">Да</string>
     <string name="no">Не</string>
     <string name="select">Изабери</string>
@@ -735,7 +735,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Порука је отворена</string>
     <string name="systemmsg_read_receipt_body">Порука „%1$s“ коју сте послали била је приказана на екрану примаоца.\n\nОво није гаранција да је садржај прочитан.</string>
-    <string name="systemmsg_cannot_decrypt">Ова порука се не може дешифровати.\n\n• Оно што може да помогне је да једноставно одговорите на ову поруку и замолите пошиљаоца да поново пошаље поруку.\n\n• У случају да сте поново инсталирали Delta Chat или неки други програм за е-пошту на овом или другом уређају најбоље је да одатле пошаљете поруку за подешавање аутоматског шифровања.</string>
     <string name="systemmsg_unknown_sender_for_chat">Непознати пошиљалац за ово ћаскање. Погледајте „информације“ за више детаља.</string>
     <string name="systemmsg_subject_for_new_contact">Поруке од %1$s</string>
     <string name="systemmsg_failed_sending_to">Слање поруке %1$s је било неуспешно.</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -633,8 +633,6 @@
     <string name="encrypted_message">Krypterat meddelande</string>
 
     <string name="welcome_desktop">Välkommen till Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Kända konton</string>
     <string name="global_menu_preferences_language_desktop">Språk</string>
     <string name="global_menu_file_desktop">Arkiv</string>
     <string name="global_menu_file_quit_desktop">Avsluta</string>
@@ -659,26 +657,12 @@
     <string name="delete_message_desktop">Ta bort meddelande</string>
     <string name="more_info_desktop">Mer information</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Visa krypteringsinfo</string>
     <string name="remove_desktop">Ta bort</string>
     <string name="save_desktop">Save</string>
     <string name="name_desktop">Namn</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt nyckelöverföring</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Ett Autocrypt inställningsmeddelande delar din slutpunkt-till-slutpunkt-inställning med andra Autocrypt-anpassade program på ett säkert sätt. Informationen krypteras med en kod som visas här och som måste matas in på den andra enheten.</string>
     <string name="select_group_image_desktop">Välj en gruppbild</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Säkerhetskopieringsförlopp</string>
     <string name="export_backup_desktop">Exportera säkerhetskopia</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Din nyckel har skickats till dig själv. Byt till den andra enheten och öppna inställningsmeddelandet. . Du kommer att tillfrågas om en inställningskod. Ange följande siffror:</string>
     <string name="autocrypt_correct_desktop">Autocrypt-inställning överförd.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Felaktig inställningskod. Försök igen.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Kunde inte skapa chatt.</string>
     <string name="forget_login_confirmation_desktop">Ta bort den här inloggningen? Allt kommer att raderas, inklusive din slutpunkt-till-slutpunkt-inställning, dina kontakter, media och meddelanden. Denna åtgärd kan inte ångras.</string>
     <string name="message_detail_sent_desktop">skickat</string>
     <string name="message_detail_received_desktop">mottaget</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Avbryt</string>
-    <string name="clear_search">Rensa sök</string>
+   <string name="clear_search">Rensa sök</string>
     <string name="yes">Ja</string>
     <string name="no">Nej</string>
     <string name="select">Välj</string>
@@ -542,7 +542,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Meddelande öppnat</string>
     <string name="systemmsg_read_receipt_body">\"%1$s\" meddelandet du skickade visades på mottagarens skärm.\n\nDet är ingen garanti för att innehållet har lästs.</string>
-    <string name="systemmsg_cannot_decrypt">Meddelandet kan inte avkrypteras.\n\n• Det kanske kan hjälpa, att svara på detta meddelande och be avsändaren skicka det igen.\n\n• Ifall du har ominstallerat Delta Chat eller något annat e-postprogram på denna eller någon annan enhet, kanske du behöver skicka ett nytt Autocryp inställningsmeddelande därifrån.</string>
     <string name="systemmsg_unknown_sender_for_chat">Okänd avsändare för denna chatt. Se info för fler detaljer.</string>
     <string name="systemmsg_subject_for_new_contact">Meddelande från %1$s</string>
     <string name="systemmsg_failed_sending_to">Kunde inte skicka meddelande till %1$s.</string>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">சரி</string>
     <string name="cancel">ரத்து செய்</string>
-    <string name="yes">ஆம்</string>
+   <string name="yes">ஆம்</string>
     <string name="no">இல்லை</string>
     <string name="on">இயக்கு</string>
     <string name="off">நிறுத்தவும்</string>

--- a/res/values-te/strings.xml
+++ b/res/values-te/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">సరే</string>
     <string name="cancel">రద్దు</string>
-    <string name="yes">అవును</string>
+   <string name="yes">అవును</string>
     <string name="no">కాదు</string>
     <string name="on">ఆన్</string>
     <string name="off">ఆఫ్</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Tamam</string>
     <string name="cancel">İptal</string>
-    <string name="clear_search">Aramayı Temizle</string>
+   <string name="clear_search">Aramayı Temizle</string>
     <string name="yes">Evet</string>
     <string name="no">Hayır</string>
     <string name="select">Seç</string>
@@ -788,7 +788,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">İleti açıldı</string>
     <string name="systemmsg_read_receipt_body">Gönderdiğiniz \"%1$s\" iletisi alıcının ekranında görüntülendi.\n\nBu, içeriğin okunduğunun güvencesi değildir.</string>
-    <string name="systemmsg_cannot_decrypt">Bu iletinin şifresi çözülemiyor.\n\n• Bu iletiye basitçe yanıt vermek ve gönderene iletiyi yeniden gönderip gönderemeyeceğini sormak zaten yardımcı olabilir.\n\n• Delta Chat\'i ya da başka bir e-posta programını bu ya da başka bir aygıta yeniden kurduysanız, oradan bir Autocrypt Ayarlama İletisi göndermek isteyebilirsiniz.</string>
     <string name="systemmsg_unknown_sender_for_chat">Bu sohbet için bilinmeyen gönderen. Daha fazla ayrıntı için \'bilgi\'ye bakın.</string>
     <string name="systemmsg_subject_for_new_contact">%1$s kişisinden gelen ileti</string>
     <string name="systemmsg_failed_sending_to">%1$s kişisine ileti gönderme başarısız.</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -968,8 +968,6 @@
     <string name="about_offical_app_desktop">Bu, resmî Delta Chat Masaüstü uygulamasıdır.</string>
     <string name="about_licensed_under_desktop">Bu yazılım, GNU GPL sürüm 3 altında lisanslıdır ve kaynak kodu GitHub\'da kullanılabilir.</string>
     <string name="welcome_desktop">Delta Chat\'e hoş geldiniz</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Bilinen Hesaplar</string>
     <string name="global_menu_preferences_language_desktop">Dil</string>
     <string name="global_menu_file_desktop">Dosya</string>
     <string name="global_menu_file_quit_desktop">Çık</string>
@@ -996,26 +994,12 @@
     <string name="delete_message_desktop">İletiyi Sil</string>
     <string name="more_info_desktop">Daha Fazla Bilgi</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Şifreleme Bilgisini Göster</string>
     <string name="remove_desktop">Kaldır</string>
     <string name="save_desktop">Kaydet</string>
     <string name="name_desktop">Ad</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt anahtar aktarımı</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Bir Autocrypt Ayarlama İletisi, uçtan uca ayarlamanızı diğer Autocrypt uyumlu uygulamalarla güvenli olarak paylaşır. Ayarlama, burada görüntülenen ve diğer aygıtta yazılması gereken bir ayarlama kodu tarafından şifrelenecek.</string>
     <string name="select_group_image_desktop">Öbek Görseli Seç</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Yedekleme İlerlemesi</string>
     <string name="export_backup_desktop">Yedeği Dışa Aktar</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Anahtarınız kendinize gönderildi. Diğer aygıta geçin ve ayarlama iletisini açın. Size bir ayarlama kodu sorulmalı. Aşağıdaki sayıları girin:</string>
     <string name="autocrypt_correct_desktop">Autocrypt ayarlaması aktarıldı.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Yanlış ayarlama kodu. Lütfen yeniden deneyin.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Sohbet oluşturulamadı.</string>
     <string name="forget_login_confirmation_desktop">Bu giriş silinsin mi? Uçtan uca ayarlamanızı, kişilerinizi, sohbetlerinizi, iletilerinizi ve ortamlarınızı kapsayarak her şey silinecek. Bu eylem geri alınamaz.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Posta: %1$s\nBoyut: %2$s\nHesap Kimliği: %3$s</string>
     <string name="message_detail_sent_desktop">gönderilme</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">Гаразд</string>
     <string name="cancel">Скасувати</string>
-    <string name="clear_search">Очистити пошук</string>
+   <string name="clear_search">Очистити пошук</string>
     <string name="yes">Так</string>
     <string name="no">Ні</string>
     <string name="select">Обрати</string>
@@ -818,7 +818,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">Сповіщення про прочитання.</string>
     <string name="systemmsg_read_receipt_body">Це підтвердження того, що повідомлення «%1$s» було відкрито на пристрої одержувача. Дане підтвердження не означає, що повідомлення було прочитано.</string>
-    <string name="systemmsg_cannot_decrypt">Це повідомлення не може бути розшифроване.\n\n• Можливо, має сенс просто відповісти на нього і попросити відправника повторно відправити повідомлення.\n\n• У випадку, якщо Ви переустановили Delta Chat або іншу поштову програму на цьому або іншому пристрої, Ви, можливо, захочете відправити повідомлення з параметрами Autocrypt звідти.</string>
     <string name="systemmsg_unknown_sender_for_chat">Невідомий відправник для цього чату. Дивіться \"Інформацію\" для деталей.</string>
     <string name="systemmsg_subject_for_new_contact">Повідомлення від %1$s</string>
     <string name="systemmsg_failed_sending_to">Неможлива надіслати повідомлення до %1$s.</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -998,8 +998,6 @@
     <string name="about_offical_app_desktop">Це офіційний додаток Delta Chat для ПК.</string>
     <string name="about_licensed_under_desktop">Це програмне забезпечення ліцензується за GNU GPL версії 3, а початковий код доступний на GitHub.</string>
     <string name="welcome_desktop">Вітаємо у Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Відомі облікові записи</string>
     <string name="global_menu_preferences_language_desktop">Вибір мови</string>
     <string name="global_menu_file_desktop">Файл</string>
     <string name="global_menu_file_quit_desktop">Вийти</string>
@@ -1026,26 +1024,12 @@
     <string name="delete_message_desktop">Видалити повідомлення</string>
     <string name="more_info_desktop">Більше інформації</string>
     <string name="timestamp_format_m_desktop">d MMMM</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Показати інформацію про шифрування</string>
     <string name="remove_desktop">Видалити</string>
     <string name="save_desktop">Зберегти</string>
     <string name="name_desktop">Ім\'я</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Передавання ключів Autocrypt</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Повідомлення з параметрами Autocrypt слугує для безпечного передавання параметрів наскрізного шифрування між власними додатками для роботи з електронною поштою, що підтримують протокол Autocrypt. Ці параметри шифруються з використанням спеціального інсталяційного коду, що показаний тут і повинен бути введений у налаштовуємому додатку.</string>
     <string name="select_group_image_desktop">Вибрати зображення групи</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Прогрес резервного копіювання</string>
     <string name="export_backup_desktop">Експорт резервної копії</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Ваш ключ було надіслано до вас. Перейдіть на інший пристрій та відкрийте установче повідомлення. Вас мають спитати установчий код. Введіть наступні цифри:</string>
     <string name="autocrypt_correct_desktop">Налаштування Autocrypt успішно передані!</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Невірний інсталяційний код. Спробуйте ввести його повторно.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Не вдалося створити чат.</string>
     <string name="forget_login_confirmation_desktop">Видалити цей обліковий запис? При цьому будуть видалені всі дані, включно з параметрами наскрізного шифрування, списками контактів, чатами, повідомленнями та медіафайлами. Цю дію не можна буде скасувати.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nРозмір: %2$s\nІдентиф. аккаунту: %3$s</string>
     <string name="message_detail_sent_desktop">Надіслано</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -953,8 +953,6 @@
     <string name="about_offical_app_desktop">这是 Delta Chat 官方桌面应用。</string>
     <string name="about_licensed_under_desktop">本软件在 GNU GPL 版本 3 下获得授权，其源代码可从 GitHub 获得。</string>
     <string name="welcome_desktop">欢迎使用 Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">已知账户</string>
     <string name="global_menu_preferences_language_desktop">语言</string>
     <string name="global_menu_file_desktop">文件</string>
     <string name="global_menu_file_quit_desktop">退出</string>
@@ -981,26 +979,12 @@
     <string name="delete_message_desktop">删除消息</string>
     <string name="more_info_desktop">更多信息</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">显示加密信息</string>
     <string name="remove_desktop">移除</string>
     <string name="save_desktop">保存</string>
     <string name="name_desktop">名称</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt 密钥传输</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">Autocrypt 设置消息安全地共享您的端到端设置至其他兼容 Autocrypt 的应用程序。该设置将通过在此显示的、必须在另一台设备上输入的设置码进行加密。</string>
     <string name="select_group_image_desktop">选择群组图像</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">备份进度</string>
     <string name="export_backup_desktop">导出备份</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">您的密钥已发送给您自己。切换到另一台设备并打开该设置消息。 您将被要求输入设置码。 输入以下数字：</string>
     <string name="autocrypt_correct_desktop">Autocrypt 设置已传输 。</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">不正确的设置码。请重试。</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">无法创建聊天。</string>
     <string name="forget_login_confirmation_desktop">删除此登录？ 一切都将被删除，包括您的端到端设置、联系人、聊天、消息及媒体。 此操作无法撤消。</string>
     <string name="account_info_hover_tooltip_desktop2">电子邮件：%1$s\n大小：%2$s\n账户 Id：%3$s</string>
     <string name="message_detail_sent_desktop">发送于</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">确定</string>
     <string name="cancel">取消</string>
-    <string name="clear_search">清除搜索</string>
+   <string name="clear_search">清除搜索</string>
     <string name="yes">是</string>
     <string name="no">否</string>
     <string name="select">选择</string>
@@ -773,7 +773,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">消息已被打开</string>
     <string name="systemmsg_read_receipt_body">您发送的“%1$s”消息已在接收者的屏幕上显示过。\n\n这并不保证内容已被阅读。</string>
-    <string name="systemmsg_cannot_decrypt">此消息无法解密。\n\n• 回复此消息并要求发送者重发该消息可能会有所帮助。\n\n• 如果您在此设备或其他设备上重新安装了 Delta Chat 或其他电子邮件程序，则可能需要从别处发送 Autocrypt 设置消息。</string>
     <string name="systemmsg_unknown_sender_for_chat">此聊天发送者未知。查看“信息”来获取更多详情。</string>
     <string name="systemmsg_subject_for_new_contact">来自 %1$s 的消息</string>
     <string name="systemmsg_failed_sending_to">发送消息给 %1$s 失败。</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">確定</string>
     <string name="cancel">取消</string>
-    <string name="clear_search">清除搜尋</string>
+   <string name="clear_search">清除搜尋</string>
     <string name="yes">是</string>
     <string name="no">否</string>
     <string name="select">選擇</string>
@@ -490,7 +490,6 @@
     <!-- system messages -->
     <string name="systemmsg_read_receipt_subject">收執回條</string>
     <string name="systemmsg_read_receipt_body">這是訊息 %1$s 的收執回條，表示本訊息已經顯示在收件人的裝置上了，但不代表收件人已讀。</string>
-    <string name="systemmsg_cannot_decrypt">本訊息無法解密。\n\n請試著回覆本訊息，並請發送者重發一遍。\n\n如果你曾經在本裝置或其它裝置重新安裝 Delta Chat 或其它郵件軟體的話，請重新發送AutoCrypt設定訊息。</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">我群組名稱已從 %1$s 更改為 %2$s</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name, %3$s will be replaced by name and address of the contact who did the action. -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -973,8 +973,6 @@
     <string name="about_offical_app_desktop">This is the official Delta Chat Desktop app.</string>
     <string name="about_licensed_under_desktop">This software is licensed under GNU GPL version 3 and the source code is available on GitHub.</string>
     <string name="welcome_desktop">Welcome to Delta Chat</string>
-    <!-- deprecated, use switch_account -->
-    <string name="login_known_accounts_title_desktop">Known Accounts</string>
     <string name="global_menu_preferences_language_desktop">Language</string>
     <string name="global_menu_file_desktop">File</string>
     <string name="global_menu_file_quit_desktop">Quit</string>
@@ -1001,26 +999,12 @@
     <string name="delete_message_desktop">Delete Message</string>
     <string name="more_info_desktop">More Info</string>
     <string name="timestamp_format_m_desktop">MMM D</string>
-    <!-- deprecated, use encryption_info_title_desktop or profile_encryption -->
-    <string name="encryption_info_desktop">Show Encryption Info</string>
     <string name="remove_desktop">Remove</string>
     <string name="save_desktop">Save</string>
     <string name="name_desktop">Name</string>
-    <!-- deprecated, use autocrypt_send_asm_title / autocrypt_continue_transfer_title -->
-    <string name="autocrypt_key_transfer_desktop">Autocrypt key transfer</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_before -->
-    <string name="initiate_key_transfer_desktop">An Autocrypt Setup Message securely shares your end-to-end setup with other Autocrypt-compliant apps. The setup will be encrypted by a setup code displayed here and must be typed on the other device.</string>
     <string name="select_group_image_desktop">Select Group Image</string>
-    <!-- deprecated, use export_backup_desktop instead -->
-    <string name="imex_progress_title_desktop">Backup Progress</string>
     <string name="export_backup_desktop">Export Backup</string>
-    <!-- deprecated, use autocrypt_send_asm_explain_after instead -->
-    <string name="show_key_transfer_message_desktop">Your key has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:</string>
     <string name="autocrypt_correct_desktop">Autocrypt setup transferred.</string>
-    <!-- deprecated, use autocrypt_bad_setup_code instead -->
-    <string name="autocrypt_incorrect_desktop">Incorrect setup code. Please try again.</string>
-    <!-- deprecated, rare errors should be english only for easier searchability -->
-    <string name="create_chat_error_desktop">Could not create chat.</string>
     <string name="forget_login_confirmation_desktop">Delete this login? Everything will be deleted, including your end-to-end setup, contacts, chats, messages and media. This action cannot be undone.</string>
     <string name="account_info_hover_tooltip_desktop2">E-Mail: %1$s\nSize: %2$s\nAccount Id: %3$s</string>
     <string name="message_detail_sent_desktop">sent</string>


### PR DESCRIPTION
these strings were removed by recent cleanup, esp. on desktop at https://github.com/deltachat/deltachat-desktop/pull/3472, https://github.com/deltachat/deltachat-desktop/pull/3474