### PR TITLE
Prepare 1.41.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Delta Chat Android Changelog
 
+## v1.41.8 Testrun
+2023-11
+
+* use local help for guaranteed end-to-end encryption "Learn More" links
+* do not post "NAME verified" messages on QR scan success
+* improve system message wording
+* fix: allow to QR scan groups when 1:1 chat with the inviter is a contact request
+* fix: add "Setup Changed" message before the message
+* fix: read receipts created or unblock 1:1 chats sometimes
+* add Vietnamese translation, update other translations and local help
+* update to core 1.131.2
+
+
 ## v1.41.7 Testrun
 2023-11
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 668
-        versionName "1.41.7"
+        versionCode 669
+        versionName "1.41.8"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
@link2xt if there is more in the queue, we should maybe better wait for a new core?

we can also brand this update as 1.42.0, however i'd update the help links before then (i think i prepare https://github.com/deltachat/deltachat-pages/pull/746 anyways now)