### PR TITLE
fix contact creation

### DIFF
--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -107,10 +107,13 @@ public class NewConversationActivity extends ContactSelectionActivity {
                 .setCancelable(true)
                 .setNegativeButton(android.R.string.cancel, null)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                  int contactId1 = dcContext.createContact(null, addr);
+                  int contactId1 = dcContext.lookupContactIdByAddr(addr);
                   if (contactId1 == 0) {
-                    Toast.makeText(NewConversationActivity.this, R.string.bad_email_address, Toast.LENGTH_LONG).show();
-                    return;
+                    contactId1 = dcContext.createContact(null, addr);
+                    if (contactId1 == 0) {
+                      Toast.makeText(NewConversationActivity.this, R.string.bad_email_address, Toast.LENGTH_LONG).show();
+                      return;
+                    }
                   }
                   openConversation(dcContext.createChatByContactId(contactId1));
                 }).show();

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -99,7 +99,7 @@ public class NewConversationActivity extends ContactSelectionActivity {
     else {
       int contactId = dcContext.lookupContactIdByAddr(addr);
       if (contactId!=0 && dcContext.getChatIdByContactId(contactId)!=0) {
-        openConversation(dcContext.createChatByContactId(contactId));
+        openConversation(dcContext.getChatIdByContactId(contactId));
       } else {
         String nameNAddr = contactId == 0 ? addr : dcContext.getContact(contactId).getNameNAddr();
         new AlertDialog.Builder(this)


### PR DESCRIPTION
this pr fixes my findings at https://github.com/deltachat/deltachat-android/issues/2871#issuecomment-1816239147 by looking up the contact-id before creating it with an empty name.

in general, it seems undefined if you call createContact() with an empty name on an existing address with a name set. as createContact() is really only for "user input", it is probably okay to reset the name (and it was wrong to use this function here, maybe a relict from the old UI; the code is also overcomplex as it passes addresses though where IDs should be good enough, but yes ...)

it need to be tested if this pr also fixes the issue @gerryfrancis reported at #2871 EDIT: closes #2871