### PR TITLE
prepare 1.42.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Delta Chat Android Changelog
 
+## v1.42.4
+2023-11
+
+* fix battery draining due to active IMAP loop on some providers; this was introduced in 1.41
+* fix log in error on some providers as 163.com; this was introduced in 1.41
+* fix "Learn More" buttons that opened the help always in english
+* update local help
+* update to core 1.131.7
+
+
 ## v1.42.3
 2023-11
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 674
-        versionName "1.42.3"
+        versionCode 675
+        versionName "1.42.4"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true

--- a/metadata/en-US/changelogs/6754.txt
+++ b/metadata/en-US/changelogs/6754.txt
@@ -1,0 +1,6 @@
+- One-to-one chats guarantee end-to-end encryption for contacts with a green checkmark now
+- For everyone\'s simplicity, we also mark these chats with green checkmarks
+- Groups are created automatically with guaranteed end-to-end encryption if possible
+- Accept/Blocked, Archived, Pinned, Mute is synced across all your devices
+- More improvements in camera, voice messages, backup-all, screen reader, per-account wallpapers, gallery select-all, webxdc landscape
+- Tons of bug fixes


### PR DESCRIPTION
this mainly pulls in recent core.

as f-droid already read the 1.42.3 tag (but did not build yet), better add the 1.42.4 tag directly after merging using `git tag v1.42.4; git push --tags` (fdroid changelog summary can stay as is)