### PR TITLE
prepare 1.42.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Delta Chat Android Changelog
 
+## v1.42.5
+2023-11
+
+* fix more log in errors for providers as 163.com; this was introduced in 1.41
+* update translations and local help
+* update to core 1.131.8
+
+
 ## v1.42.4
 2023-11
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 675
-        versionName "1.42.4"
+        versionCode 676
+        versionName "1.42.5"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
this should get a small, on-point testing wrt https://github.com/deltachat/deltachat-core-rust/issues/5043 , in a few days, if things work out, 1.42.5 can replace 1.42.4

there are also potentially breaking [changes wrt webxdc-updates](https://github.com/deltachat/deltachat-core-rust/pull/5048) in, however, at first tests, this looks good 😅

🦆🦆🦆🦆