### PR TITLE
prepare f-droid 1.42.6

### DIFF
--- a/metadata/en-US/changelogs/6774.txt
+++ b/metadata/en-US/changelogs/6774.txt
@@ -1,0 +1,6 @@
+- sync changes on "Your Profile Name", "Show Class Mails", "Read Receipts" options across devices
+- remove receiver limit on .xdc size
+- fix log in errors for providers as 163.com
+- fix decryption errors when using multiple private keys
+- fix database locked errors on webxdc updates
+- update translations


### PR DESCRIPTION
i think, 1.42.6 was tested enough for f-droid, play store, amazon updates, it i also released on get.delta.chat since a week and the changes are comparable small

according to [RELEASE.md](https://github.com/deltachat/deltachat-android/blob/main/RELEASE.md#release-on-f-droid):
- changelog created
- after merging this pr,  
  `git tag v1.42.6; git push --tags`
  needs to be called on branch `main`