### PR TITLE
remove unused stock-string

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -620,8 +620,6 @@
     <string name="pref_your_name">Your Name</string>
     <!-- Translators: Visible only to recipients who DO NOT use Delta Chat, so it's the last line in an E-mail and not a "Status". -->
     <string name="pref_default_status_label">Signature Text</string>
-    <!-- Translators: The URL should not be localized as it is unclear which language the receiver prefers; the language will be automatically detected on the server -->
-    <string name="pref_default_status_text">Sent with my Delta Chat Messenger: https://delta.chat</string>
     <string name="pref_enter_sends">Enter Key Sends</string>
     <string name="pref_enter_sends_explain">Pressing the Enter key will send text messages</string>
     <string name="pref_outgoing_media_quality">Outgoing Media Quality</string>

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -154,7 +154,6 @@ public class DcHelper {
     dcContext.setStockTranslation(10, context.getString(R.string.video));
     dcContext.setStockTranslation(11, context.getString(R.string.audio));
     dcContext.setStockTranslation(12, context.getString(R.string.file));
-    dcContext.setStockTranslation(13, context.getString(R.string.pref_default_status_text));
     dcContext.setStockTranslation(23, context.getString(R.string.gif));
     dcContext.setStockTranslation(24, context.getString(R.string.encrypted_message));
     dcContext.setStockTranslation(29, context.getString(R.string.systemmsg_cannot_decrypt));


### PR DESCRIPTION
remove stock-string for old default signature.

ios/desktop also do not used that string, so even removing from translations is fine; on next "tx pull", the string will also be removed from all translations.

closes #2904 