### PR TITLE
make 1to1-empty-hint working better with chatmail

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -385,7 +385,7 @@
         <item quantity="other">%d new messages</item>
     </plurals>
     <!-- The placeholder will be replaced by the name of the recipient in a one-to-one chat. -->
-    <string name="chat_new_one_to_one_hint">Send a message to %1$s; they can even receive it without Delta Chat.</string>
+    <string name="chat_new_one_to_one_hint">Send a message to %1$s.</string>
     <string name="chat_new_broadcast_hint">In a broadcast list, recipients will receive messages in a read-only chat with you.</string>
     <string name="chat_new_group_hint">Others will only see this group after you sent a first message.</string>
     <string name="chat_record_slide_to_cancel">Slide to cancel</string>


### PR DESCRIPTION
the hint already led to confusion on 37c3 testings of chatmail.

the hint that appears when a one-to-one-chat was just created manually (by entering an email address manually) is a bit misleading when using chatmail, as it says it 'does not matter if the other side uses Delta Chat'.

this is still true, however, with chatmail it is needed that messages outside the chatmail-server are encrypted,
which is arguably not so easy without delta chat and QR code scanning.

this PR therefore just removes the hint (alternative suggestions welcome);
it would still be great if the error message 'cannot encrypt' is improved, however, this is another thing.

before/after:

<img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/54f74a33-57b7-45b4-ada0-a4c5c609e17d> <img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/ab9cb0b8-6b6a-4e5b-8bf3-26a279b15be4>

once merged, `./scripts/tx-update-changed-sources.sh` needs to be executed; ios/desktop will get the updated string automatically

