### PR TITLE
do not show addr in guaranteed-e2ee chat titles

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -103,7 +103,7 @@ public class ConversationTitleView extends RelativeLayout {
       }
       else {
         DcContact dcContact = dcContext.getContact(chatContacts[0]);
-        if (profileView) {
+        if (profileView || !dcChat.isProtected()) {
           subtitleStr = dcContact.getAddr();
         }
         isOnline = dcContact.wasSeenRecently();

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -103,12 +103,12 @@ public class ConversationTitleView extends RelativeLayout {
       }
       else {
         DcContact dcContact = dcContext.getContact(chatContacts[0]);
-        subtitleStr = dcContact.getAddr();
+        if (profileView) {
+          subtitleStr = dcContact.getAddr();
+        }
         isOnline = dcContact.wasSeenRecently();
       }
     }
-
-    subtitle.setText(subtitleStr);
 
     avatar.setAvatar(glideRequests, new Recipient(getContext(), dcChat), false);
     avatar.setSeenRecently(isOnline);


### PR DESCRIPTION
with chatmail, the address is less meaningful,
it seems sufficient to show it in the profiles.

this moves focus to name and avatar and leave the email address as a "handle" that is not that meaningful and also subject to change, you check it on issues, similar to keys, similar to most other messengers.

this PR is not really a requirement for chatmail, however, tuning down the address is also reasonable by other means as the idea of changing addresses (AEAP) or even using more addresses per account

before / after:

<img width="294" alt="Screenshot 2024-01-07 at 22 18 30" src="https://github.com/deltachat/deltachat-android/assets/9800740/1b991ca5-09ca-4377-96ca-85301309e61f"> &nbsp; <img width="294" alt="Screenshot 2024-01-07 at 22 21 02" src="https://github.com/deltachat/deltachat-android/assets/9800740/9cf72932-299e-483b-8517-990a5f6011c3">

