### PR TITLE
force a display name to be set

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -906,6 +906,8 @@
     <string name="qraccount_ask_create_and_login">Create new e-mail address on \"%1$s\" and log in there?</string>
     <string name="qraccount_ask_create_and_login_another">Create new e-mail address on \"%1$s\" and log in there?\n\nYour existing account will not be deleted. Use the \"Switch Account\" item to switch between your accounts.</string>
     <string name="qraccount_success_enter_name">Login successful—your e-mail address is %1$s\n\nIf you like, you can now enter a name and an profile image that will be displayed to people you write to.</string>
+    <string name="set_name_and_avatar_explain">Set a name for your new account that your contacts will recognize. You can also set a profile image.</string>
+    <string name="please_enter_name">Please enter a name.</string>
     <string name="qraccount_qr_code_cannot_be_used">The scanned QR code cannot be used to set up a new account.</string>
     <string name="qraccount_use_on_new_install">The scanned QR code is for setting up a new account. You can scan the QR code when setting up a new Delta Chat installation.</string>
     <!-- the placeholder will be replaced by the e-mail address of the account -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -905,8 +905,9 @@
     <string name="qrshow_join_contact_no_connection_toast">No internet connection, can\'t perform QR code setup.</string>
     <string name="qraccount_ask_create_and_login">Create new e-mail address on \"%1$s\" and log in there?</string>
     <string name="qraccount_ask_create_and_login_another">Create new e-mail address on \"%1$s\" and log in there?\n\nYour existing account will not be deleted. Use the \"Switch Account\" item to switch between your accounts.</string>
+    <!-- deprecated, use set_name_and_avatar_explain instead -->
     <string name="qraccount_success_enter_name">Login successful—your e-mail address is %1$s\n\nIf you like, you can now enter a name and an profile image that will be displayed to people you write to.</string>
-    <string name="set_name_and_avatar_explain">Set a name for your new account that your contacts will recognize. You can also set a profile image.</string>
+    <string name="set_name_and_avatar_explain">Set a name that your contacts will recognize. You can also set a profile image.</string>
     <string name="please_enter_name">Please enter a name.</string>
     <string name="qraccount_qr_code_cannot_be_used">The scanned QR code cannot be used to set up a new account.</string>
     <string name="qraccount_use_on_new_install">The scanned QR code is for setting up a new account. You can scan the QR code when setting up a new Delta Chat installation.</string>

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -226,7 +226,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
 
     if (fromWelcome) {
       String addr = DcHelper.get(this, "addr");
-      loginSuccessText.setText(getString(R.string.qraccount_success_enter_name, addr));
+      loginSuccessText.setText(R.string.set_name_and_avatar_explain);
       ViewUtil.findById(this, R.id.status_text_layout).setVisibility(View.GONE);
       ViewUtil.findById(this, R.id.information_label).setVisibility(View.GONE);
       passwordAccountSettings.setVisibility(View.GONE);
@@ -294,10 +294,11 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
   }
 
   private void handleUpload() {
-    final String        name;
-
-    if (TextUtils.isEmpty(this.name.getText().toString())) name = null;
-    else                                                   name = this.name.getText().toString();
+    if (TextUtils.isEmpty(this.name.getText())) {
+      Toast.makeText(this, R.string.please_enter_name, Toast.LENGTH_LONG).show();
+      return;
+    }
+    final String name = this.name.getText().toString();
 
     new AsyncTask<Void, Void, Boolean>() {
       @Override

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -109,7 +109,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
         onBackPressed();
         return true;
       case R.id.menu_create_profile:
-        handleUpload();
+        updateProfile();
         break;
     }
 
@@ -293,7 +293,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
     statusView.setText(status);
   }
 
-  private void handleUpload() {
+  private void updateProfile() {
     if (TextUtils.isEmpty(this.name.getText())) {
       Toast.makeText(this, R.string.please_enter_name, Toast.LENGTH_LONG).show();
       return;

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -121,8 +121,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
     if (container.isInputOpen()) {
       container.hideCurrentInput(name);
     } else if (fromWelcome) {
-      startActivity(new Intent(getApplicationContext(), ConversationListActivity.class));
-      finish();
+      updateProfile();
     } else {
       super.onBackPressed();
     }


### PR DESCRIPTION
with this PR, empty display names are no longer accepted. instead, a warning is shown.

moreover, the PR rewords the hint above the input field, which is also used by iOS and desktop soon; for review, there should be some focus on the text therefore.

(maybe the "for your new account" can be left out, that would make the scope of the name clearer)

re-layout etc. are out of scope of this PR.

<img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/44acdbb6-0936-4c1b-a293-5f8bc5164bf9>



closes #2913 