### PR TITLE
add 'Scan QR Code' to 'New Chat'

### DIFF
--- a/res/layout/contact_filter_toolbar.xml
+++ b/res/layout/contact_filter_toolbar.xml
@@ -21,7 +21,7 @@
                 android:contentDescription="@string/email_address"
                 android:fontFamily="sans-serif"
                 android:gravity="center_vertical"
-                android:hint="@string/contacts_enter_name_or_email"
+                android:hint="@string/search"
                 android:ellipsize="end"
                 android:inputType="textPersonName"
                 android:textSize="18sp" />

--- a/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
@@ -86,7 +86,7 @@ public class BlockedContactsActivity extends PassphraseRequiredActionBarActivity
 
     @Override
     public Loader<DcContactsLoader.Ret> onCreateLoader(int id, Bundle args) {
-      return new DcContactsLoader(getActivity(), -1, null, false, false, true);
+      return new DcContactsLoader(getActivity(), -1, null, false, false, false, true);
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -281,12 +281,13 @@ public class ContactSelectionListFragment extends    Fragment
 
   @Override
   public Loader<DcContactsLoader.Ret> onCreateLoader(int id, Bundle args) {
-    boolean allowCreation = getActivity().getIntent().getBooleanExtra(ALLOW_CREATION, true);
-    boolean addCreateContactLink = allowCreation && !isSelectVerfied();
-    boolean addCreateGroupLinks = allowCreation && !isRelayingMessageContent(getActivity()) && !isMulti();
+    final boolean allowCreation = getActivity().getIntent().getBooleanExtra(ALLOW_CREATION, true);
+    final boolean addCreateContactLink = allowCreation && !isSelectVerfied();
+    final boolean addCreateGroupLinks = allowCreation && !isRelayingMessageContent(getActivity()) && !isMulti();
+    final boolean addScanQRLink = allowCreation && !isMulti();
 
-    int listflags = DcContext.DC_GCL_ADD_SELF;
-    return new DcContactsLoader(getActivity(), listflags, cursorFilter, addCreateGroupLinks, addCreateContactLink, false);
+    final int listflags = DcContext.DC_GCL_ADD_SELF;
+    return new DcContactsLoader(getActivity(), listflags, cursorFilter, addCreateGroupLinks, addCreateContactLink, addScanQRLink, false);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -28,8 +28,10 @@ import androidx.appcompat.app.AlertDialog;
 
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
+import com.google.zxing.integration.android.IntentIntegrator;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.qr.QrActivity;
 import org.thoughtcrime.securesms.util.MailtoUtil;
 
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
@@ -95,6 +97,8 @@ public class NewConversationActivity extends ContactSelectionActivity {
       Intent intent = new Intent(this, GroupCreateActivity.class);
       intent.putExtra(GroupCreateActivity.CREATE_BROADCAST, true);
       startActivity(intent);
+    } else if (specialId == DcContact.DC_CONTACT_ID_QR_INVITE) {
+      new IntentIntegrator(this).setCaptureActivity(QrActivity.class).initiateScan();
     }
     else {
       int contactId = dcContext.lookupContactIdByAddr(addr);

--- a/src/org/thoughtcrime/securesms/connect/DcContactsLoader.java
+++ b/src/org/thoughtcrime/securesms/connect/DcContactsLoader.java
@@ -16,14 +16,16 @@ public class DcContactsLoader extends AsyncLoader<DcContactsLoader.Ret> {
 
     private final int     listflags;
     private final String  query;
+    private final boolean addScanQRLink;
     private final boolean addCreateGroupLinks;
     private final boolean addCreateContactLink;
     private final boolean blockedContacts;
 
-    public DcContactsLoader(Context context, int listflags, String query, boolean addCreateGroupLinks, boolean addCreateContactLink, boolean blockedContacts) {
+    public DcContactsLoader(Context context, int listflags, String query, boolean addCreateGroupLinks, boolean addCreateContactLink, boolean addScanQRLink, boolean blockedContacts) {
         super(context);
         this.listflags           = listflags;
         this.query               = (query==null||query.isEmpty())? null : query;
+        this.addScanQRLink       = addScanQRLink;
         this.addCreateGroupLinks = addCreateGroupLinks;
         this.addCreateContactLink= addCreateContactLink;
         this.blockedContacts     = blockedContacts;
@@ -40,11 +42,18 @@ public class DcContactsLoader extends AsyncLoader<DcContactsLoader.Ret> {
 
         int[] contact_ids = dcContext.getContacts(listflags, query);
         int[] additional_items = new int[0];
-        if (addCreateContactLink) additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_CONTACT);
+        if (query == null && addScanQRLink)
+        {
+          additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_QR_INVITE);
+        }
         if (query == null && addCreateGroupLinks) {
             additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_GROUP);
             final boolean broadcastsEnabled = Prefs.isNewBroadcastListAvailable(getContext());
             if (broadcastsEnabled) additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST);
+        }
+        if (addCreateContactLink)
+        {
+            additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_CONTACT);
         }
         int all_ids[] = new int[contact_ids.length + additional_items.length];
         System.arraycopy(additional_items, 0, all_ids, 0, additional_items.length);

--- a/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
@@ -278,6 +278,8 @@ public class ContactSelectionListAdapter extends RecyclerView.Adapter
       name = context.getString(R.string.menu_new_group);
     } else if (id == DcContact.DC_CONTACT_ID_NEW_BROADCAST_LIST) {
       name = context.getString(R.string.new_broadcast_list);
+    } else if (id == DcContact.DC_CONTACT_ID_QR_INVITE) {
+      name = context.getString(R.string.qrscan_title);
     } else {
       dcContact = getContact(i);
       name = dcContact.getDisplayName();


### PR DESCRIPTION
this PR add a 'Scan QR Code' button to 'New Chat' activity.

this makes setting up contacts easier when the best option is scanning a QR code (as for chatmail).

closes #2911 

EDIT: i think, best would be to combine "New Contact" and "QR Invite Code" to one item that offers QR code scanning by default and "Share Invite Link" an "Manual Setup" as option. we can also think over renaming the options. but that is another PR/discussion, the PR at hand already improves things

<img width="303" alt="Screenshot 2024-01-12 at 13 22 44" src="https://github.com/deltachat/deltachat-android/assets/9800740/c3e1e060-3075-4548-bd21-db3d0fff482b">


