### PR TITLE
don't load contacts from phone address book

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -13,7 +13,6 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 
     <!-- dangerous permissions - we need to as the user with a PermissionsRequest -->
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />

--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -19,16 +19,12 @@ package org.thoughtcrime.securesms;
 
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 
-import android.Manifest;
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.Color;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
 import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -55,7 +51,6 @@ import com.b44t.messenger.DcEvent;
 import org.thoughtcrime.securesms.connect.DcContactsLoader;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.contacts.ContactAccessor;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListAdapter;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListItem;
 import org.thoughtcrime.securesms.contacts.NewContactActivity;
@@ -116,11 +111,6 @@ public class ContactSelectionListFragment extends    Fragment
   public void onStart() {
     super.onStart();
     this.getLoaderManager().initLoader(0, null, this);
-    Permissions.with(this)
-               .request(Manifest.permission.READ_CONTACTS)
-               .ifNecessary()
-               .onAllGranted(this::handleContactPermissionGranted)
-               .execute();
   }
 
   @Override
@@ -297,38 +287,6 @@ public class ContactSelectionListFragment extends    Fragment
   @Override
   public void onLoaderReset(Loader<DcContactsLoader.Ret> loader) {
     ((ContactSelectionListAdapter) recyclerView.getAdapter()).changeData(null);
-  }
-
-  @SuppressLint("StaticFieldLeak")
-  private void handleContactPermissionGranted() {
-    new AsyncTask<Void, Void, Void>() {
-
-      @Override
-      protected Void doInBackground(Void... voids) {
-        loadSystemContacts();
-        return null;
-      }
-
-    }.execute();
-  }
-
-  private void loadSystemContacts() {
-    Thread thread = new Thread() {
-      @Override
-      public void run() {
-        try {
-          ContactAccessor contactAccessor = ContactAccessor.getInstance();
-          String allSystemContacts = contactAccessor.getAllSystemContactsAsString(getContext());
-          if (!allSystemContacts.isEmpty()) {
-            dcContext.addAddressBook(allSystemContacts);
-          }
-        } catch (SecurityException e) {
-          Log.e(TAG, "Caught a weird bug in the Android OS https://github.com/deltachat/deltachat-android/issues/1639: " + e);
-          e.printStackTrace();
-        }
-      }
-    };
-    thread.start();
   }
 
   private class ListClickListener implements ContactSelectionListAdapter.ItemClickListener {


### PR DESCRIPTION
close #2915 

this removes the need for a "dangerous" permission that doesn't brings much value, more with chatmail where it is not possible to write unencrypted, encouraging users more in the direction of contact verification, also loading from contact address book was always a bit problematic and cause of some bugs/issues, ex. updating the contact in the phone contacts will not update it in Delta Chat until the (+) button is hit and then contacts are reloaded, 

also in multi-account this always caused me troubles, it would import all the contacts in all accounts, and for some accounts like chatmail or yggmail this didn't make any sense and cluttered the contact list

notice that, if wanted, user can still just go to the phone contacts and search contacts there and start a DC chat from there