### PR TITLE
move 'pinned' indicator right for cleaner UI

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -154,8 +154,8 @@ public class ConversationListItem extends RelativeLayout
     }
 
     dateView.setCompoundDrawablesWithIntrinsicBounds(
-        thread.getVisibility()==DcChat.DC_CHAT_VISIBILITY_PINNED? R.drawable.ic_pinned_chatlist : 0, 0,
-        thread.isSendingLocations()? R.drawable.ic_location_chatlist : 0, 0
+      thread.isSendingLocations()? R.drawable.ic_location_chatlist : 0, 0,
+      thread.getVisibility()==DcChat.DC_CHAT_VISIBILITY_PINNED? R.drawable.ic_pinned_chatlist : 0, 0
     );
 
     setStatusIcons(thread.getVisibility(), state, unreadCount, thread.isContactRequest(), thread.isMuted() || chatId == DcChat.DC_CHAT_ID_ARCHIVED_LINK);


### PR DESCRIPTION
'pinned' chats are always shown together below each other; moving the 'pinned' indicator to the same position in each chat makes the UI a little less cluttered and nicer
(all pinned indicators will form a column if you will)

<img width="285" alt="Screenshot 2024-01-19 at 12 14 15" src="https://github.com/deltachat/deltachat-android/assets/9800740/79edb7c6-9c5d-406c-8d1f-9ee7c6c2df31">

this PR is an outcome of the feature-proposal at https://support.delta.chat/t/three-small-changes-to-make-delta-chat-better/2886