### PR TITLE
display last-seen information if address will not be shown

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -19,7 +19,11 @@ import org.thoughtcrime.securesms.components.AvatarView;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.DateUtils;
+import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.ViewUtil;
+
+import java.util.Locale;
 
 public class ConversationTitleView extends RelativeLayout {
 
@@ -105,6 +109,12 @@ public class ConversationTitleView extends RelativeLayout {
         DcContact dcContact = dcContext.getContact(chatContacts[0]);
         if (profileView || !dcChat.isProtected()) {
           subtitleStr = dcContact.getAddr();
+        } else {
+          long timestamp = dcContact.getLastSeen();
+          if (timestamp != 0) {
+            Locale locale = DynamicLanguage.getSelectedLocale(context);
+            subtitleStr = context.getString(R.string.last_seen_at, DateUtils.getExtendedTimeSpanString(context, locale, timestamp));
+          }
         }
         isOnline = dcContact.wasSeenRecently();
       }


### PR DESCRIPTION
with #2916 ( do not show addr in guaranteed-e2ee chat titles) now there are free space for more useful information, also without address it looks more ugly, specially for existing users that are used to the old look, this is also what is displayed in apps like Telegram

For bots I would like to show just "bot" there, there is already core API for that but just not exposed there, another situation is when user is "online" and the green dot is displayed, for that case maybe it is better to display "online" label or "last seen recently", but that needs a new string

this feature will leverage the push-back of users since not showing the address is removing a feature, while not displaying it  to display another useful information is a feature ;) in fact this makes one reconsider if always displaying this info instead the address for ALL contacts is not better than just doing so for verified contacts

![2024-01-20-00-28-1](https://github.com/deltachat/deltachat-android/assets/24558636/cbb013e4-59c4-44b0-9b79-3e98dacec613)
