### PR TITLE
remove old hack to update seen-recently indicator

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -249,8 +249,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (!isMultiUser()) {
       eventCenter.addObserver(DcContext.DC_EVENT_INCOMING_MSG, this);
       eventCenter.addObserver(DcContext.DC_EVENT_MSG_READ, this);
-      // handle DC_EVENT_MSG_DELIVERED to hide the seen-recently indicator if needed:
-      eventCenter.addObserver(DcContext.DC_EVENT_MSG_DELIVERED, this);
     }
 
     handleRelaying();
@@ -1536,8 +1534,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       setComposePanelVisibility();
       initializeContactRequest();
     } else if ((eventId == DcContext.DC_EVENT_INCOMING_MSG
-                || eventId == DcContext.DC_EVENT_MSG_READ
-                || eventId == DcContext.DC_EVENT_MSG_DELIVERED)
+                || eventId == DcContext.DC_EVENT_MSG_READ)
                && event.getData1Int() == chatId) {
         DcContact contact = recipient.getDcContact();
         titleView.setSeenRecently(contact!=null? dcContext.getContact(contact.getId()).wasSeenRecently() : false);


### PR DESCRIPTION
this was a hack I added to try to compensate the lack of event for "contact is not longer seen-recently" and to update the seen-recently indicator (green dot) after that core was improved to emit contact-changed event to properly update the seen-recently status