### PR TITLE
do not add "Changelog" for new accounts

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -82,6 +82,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   private static final String NDK_ARCH_WARNED = "ndk_arch_warned";
   public static final String CLEAR_NOTIFICATIONS = "clear_notifications";
   public static final String ACCOUNT_ID_EXTRA = "account_id";
+  public static final String FROM_WELCOME   = "from_welcome";
 
   private ConversationListFragment conversationListFragment;
   public TextView                  title;
@@ -105,14 +106,17 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       DcContext dcContext = DcHelper.getContext(this);
       final String deviceMsgId = "update_1_42ai_android";
       if (!dcContext.wasDeviceMsgEverAdded(deviceMsgId)) {
-        DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_IMAGE);
+        DcMsg msg = null;
+        if (!getIntent().getBooleanExtra(FROM_WELCOME, false)) {
+          msg = new DcMsg(dcContext, DcMsg.DC_MSG_IMAGE);
 
-        InputStream inputStream = getResources().getAssets().open("device-messages/green-checkmark.jpg");
-        String outputFile = DcHelper.getBlobdirFile(dcContext, "green-checkmark", ".jpg");
-        Util.copy(inputStream, new FileOutputStream(outputFile));
-        msg.setFile(outputFile, "image/jpeg");
+          InputStream inputStream = getResources().getAssets().open("device-messages/green-checkmark.jpg");
+          String outputFile = DcHelper.getBlobdirFile(dcContext, "green-checkmark", ".jpg");
+          Util.copy(inputStream, new FileOutputStream(outputFile));
+          msg.setFile(outputFile, "image/jpeg");
 
-        msg.setText(getString(R.string.update_1_42_common) + "\n\n" + getString(R.string.update_1_42_android, "https://get.delta.chat/#changelogs"));
+          msg.setText(getString(R.string.update_1_42_common) + "\n\n" + getString(R.string.update_1_42_android, "https://get.delta.chat/#changelogs"));
+        }
         dcContext.addDeviceMsg(deviceMsgId, msg);
       }
     } catch(Exception e) {

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -326,7 +326,9 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
         if (result) {
           attachmentManager.cleanup();
           if (fromWelcome) {
-            startActivity(new Intent(getApplicationContext(), ConversationListActivity.class));
+            Intent intent = new Intent(getApplicationContext(), ConversationListActivity.class);
+            intent.putExtra(ConversationListActivity.FROM_WELCOME, true);
+            startActivity(intent);
           }
           finish();
         } else        {

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -364,7 +364,9 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
             intent.putExtra(CreateProfileActivity.FROM_WELCOME, true);
             startActivity(intent);
         } else {
-            startActivity(new Intent(getApplicationContext(), ConversationListActivity.class));
+            Intent intent = new Intent(getApplicationContext(), ConversationListActivity.class);
+            intent.putExtra(ConversationListActivity.FROM_WELCOME, true);
+            startActivity(intent);
         }
         finish();
     }


### PR DESCRIPTION
on new installations or accounts,
the "What's new?" messages only clutter the device messages with unimportant information (either the user is new to the app, so everyrhing is new and nothing is changed, or an existing user has created a new account, they have seen the changelog anyways)

in other words,
the changelog will be added only for updates.

when reading https://c.delta.chat/classdc__context__t.html#a1a2aad98bd23c1d21ee42374e241f389 , this was always the gist,
however, somehow forgotten or removed on the way :)

targets #2914