### PR TITLE
improve status message for "Invalid Unencrypted"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -864,6 +864,8 @@
     <string name="chat_protection_enabled_explanation">It is now guaranteed that all messages in this chat are end-to-end encrypted.\n\nEnd-to-end encryption keeps messages private between you and your chat partners. Not even your email provider can read them.</string>
     <string name="chat_protection_broken_tap_to_learn_more">%1$s sent a message from another device. Tap to learn more.</string>
     <string name="chat_protection_broken_explanation">End-to-end encryption cannot be guaranteed anymore, likely because %1$s reinstalled Delta Chat or sent a message from another device.\n\nYou may meet them in person and scan their QR code again to reestablish guaranteed end-to-end encryption.</string>
+    <string name="invalid_unencrypted_tap_to_learn_more">⚠️ %1$s requires end-to-end encryption which is not setup yet. Tap to learn more.</string>
+    <string name="invalid_unencrypted_explanation">To establish end-to-end-encryption, you may meet contacts in person and scan their QR Code to introduce them.</string>
     <string name="learn_more">Learn More</string>
 
     <string name="devicemsg_self_deleted">You deleted the \"Saved messages\" chat.\n\nℹ️ To use the \"Saved messages\" feature again, create a new chat with yourself.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -864,7 +864,7 @@
     <string name="chat_protection_enabled_explanation">It is now guaranteed that all messages in this chat are end-to-end encrypted.\n\nEnd-to-end encryption keeps messages private between you and your chat partners. Not even your email provider can read them.</string>
     <string name="chat_protection_broken_tap_to_learn_more">%1$s sent a message from another device. Tap to learn more.</string>
     <string name="chat_protection_broken_explanation">End-to-end encryption cannot be guaranteed anymore, likely because %1$s reinstalled Delta Chat or sent a message from another device.\n\nYou may meet them in person and scan their QR code again to reestablish guaranteed end-to-end encryption.</string>
-    <string name="invalid_unencrypted_tap_to_learn_more">⚠️ %1$s requires end-to-end encryption which is not setup yet. Tap to learn more.</string>
+    <string name="invalid_unencrypted_tap_to_learn_more">⚠️ %1$s requires end-to-end encryption which is not setup for this chat yet. Tap to learn more.</string>
     <string name="invalid_unencrypted_explanation">To establish end-to-end-encryption, you may meet contacts in person and scan their QR Code to introduce them.</string>
     <string name="learn_more">Learn More</string>
 

--- a/src/com/b44t/messenger/DcMsg.java
+++ b/src/com/b44t/messenger/DcMsg.java
@@ -33,6 +33,7 @@ public class DcMsg {
     public final static int DC_INFO_EPHEMERAL_TIMER_CHANGED   = 10;
     public final static int DC_INFO_PROTECTION_ENABLED        = 11;
     public final static int DC_INFO_PROTECTION_DISABLED       = 12;
+    public final static int DC_INFO_INVALID_UNENCRYPTED_MAIL  = 13;
     public final static int DC_INFO_WEBXDC_INFO_MESSAGE       = 32;
 
     public final static int DC_STATE_UNDEFINED =  0;

--- a/src/org/thoughtcrime/securesms/BaseConversationItem.java
+++ b/src/org/thoughtcrime/securesms/BaseConversationItem.java
@@ -82,7 +82,8 @@ public abstract class BaseConversationItem extends LinearLayout
     return batchSelected.isEmpty()
             && (messageRecord.isFailed()
                 || messageRecord.getInfoType() == DcMsg.DC_INFO_PROTECTION_DISABLED
-                || messageRecord.getInfoType() == DcMsg.DC_INFO_PROTECTION_ENABLED);
+                || messageRecord.getInfoType() == DcMsg.DC_INFO_PROTECTION_ENABLED
+                || messageRecord.getInfoType() == DcMsg.DC_INFO_INVALID_UNENCRYPTED_MAIL);
   }
 
   protected void onAccessibilityClick() {}
@@ -132,6 +133,8 @@ public abstract class BaseConversationItem extends LinearLayout
         DcHelper.showVerificationBrokenDialog(context, conversationRecipient.getName());
       } else if (messageRecord.getInfoType() == DcMsg.DC_INFO_PROTECTION_ENABLED) {
         DcHelper.showProtectionEnabledDialog(context);
+      } else if (messageRecord.getInfoType() == DcMsg.DC_INFO_INVALID_UNENCRYPTED_MAIL) {
+        DcHelper.showInvalidUnencryptedDialog(context);
       }
     }
   }

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -53,6 +53,9 @@ public class ConversationUpdateItem extends BaseConversationItem
     bodyText.setOnLongClickListener(passthroughClickListener);
     bodyText.setOnClickListener(passthroughClickListener);
 
+    // info messages do not contain links but domains (eg. invalid_unencrypted_tap_to_learn_more),
+    // however, they should not be linkified to not disturb eg. "Tap to learn more".
+    bodyText.setAutoLinkMask(0);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -255,6 +255,7 @@ public class DcHelper {
 
     dcContext.setStockTranslation(172, context.getString(R.string.chat_new_group_hint));
     dcContext.setStockTranslation(173, context.getString(R.string.member_x_added));
+    dcContext.setStockTranslation(174, context.getString(R.string.invalid_unencrypted_tap_to_learn_more));
   }
 
   public static File getImexDir() {

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -470,6 +470,16 @@ public class DcHelper {
       .show();
   }
 
+  public static void showInvalidUnencryptedDialog(Context context) {
+    new AlertDialog.Builder(context)
+      .setMessage(context.getString(R.string.invalid_unencrypted_explanation))
+      .setNeutralButton(R.string.learn_more, (d, w) -> openHelp(context, "#howtoe2ee"))
+      .setNegativeButton(R.string.qrscan_title, (d, w) -> context.startActivity(new Intent(context, QrActivity.class)))
+      .setPositiveButton(R.string.ok, null)
+      .setCancelable(true)
+      .show();
+  }
+
   public static void openHelp(Context context, String section) {
     Intent intent = new Intent(context, LocalHelpActivity.class);
     if (section != null) { intent.putExtra(LocalHelpActivity.SECTION_EXTRA, section); }


### PR DESCRIPTION
This PR refines the "Invalid Unencrypted" info messages that is added since  https://github.com/deltachat/deltachat-core-rust/pull/5198 when a message cannot be encrypted _and_ the provider does not allow unencrypted messages; this is true eg. for chatmail

In addition to stock core message:

- a "Tap to learn more" is added
- a tap shows a little dialog, allowing to perform a QR code scan or get more help about the scanning process (this seems mostly on-point to solve the user's problem at hand, and probably mostly good enough for now, we can always refine as needed)

@adbenitez this PR also removes linkifying info-messages in general - do we know of any info-messages that contain links _on purpose_? if so, we can make the linkify-removal conditional.

<img width="300" alt="Screenshot 2024-01-25 at 00 39 03" src="https://github.com/deltachat/deltachat-android/assets/9800740/4fd4ff62-5d15-4162-823c-fa4c17ccb762"> &nbsp; <img width="300" alt="Screenshot 2024-01-25 at 00 39 09" src="https://github.com/deltachat/deltachat-android/assets/9800740/1058d421-ea69-4e87-b1d2-cb086996a6f9">

