### PR TITLE
allow to mute/unmute from chatlist

### DIFF
--- a/res/menu/conversation_list.xml
+++ b/res/menu/conversation_list.xml
@@ -7,6 +7,10 @@
           android:icon="?menu_trash_icon"
           app:showAsAction="always" />
 
+    <item android:title="@string/menu_mute"
+          android:id="@+id/menu_mute_selected"
+          app:showAsAction="never"/>
+
     <item android:title="@string/menu_select_all"
           android:id="@+id/menu_select_all"
           app:showAsAction="never"/>


### PR DESCRIPTION
this allows to mute a noisy chat you can't attend to at the moment without entering it and marking as read messages you don't intend to read at the moment and sending read receipts to the peer

also allows to mute/unmute chats in batches without having to do it one by one