### PR TITLE
handle in-chat clicks to invite-URLs

### DIFF
--- a/src/org/thoughtcrime/securesms/util/LongClickCopySpan.java
+++ b/src/org/thoughtcrime/securesms/util/LongClickCopySpan.java
@@ -16,6 +16,7 @@ import com.b44t.messenger.DcContext;
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.qr.QrCodeHandler;
 import org.thoughtcrime.securesms.util.Util;
 
 public class LongClickCopySpan extends ClickableSpan {
@@ -72,6 +73,9 @@ public class LongClickCopySpan extends ClickableSpan {
       } catch (Exception e) {
         e.printStackTrace();
       }
+    } else if (Util.isInviteURL(url)) {
+      QrCodeHandler qrCodeHandler = new QrCodeHandler((Activity) widget.getContext());
+      qrCodeHandler.handleQrData(url);
     } else {
       IntentUtils.showBrowserIntent(widget.getContext(), url);
     }

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -66,11 +66,11 @@ public class Util {
   }
 
   public static boolean isInviteURL(Uri uri) {
-    return INVITE_DOMAIN.equals(uri.getHost());
+    return INVITE_DOMAIN.equals(uri.getHost()) && uri.getEncodedFragment() != null;
   }
 
   public static boolean isInviteURL(String url) {
-    return url != null && url.startsWith("https://" + INVITE_DOMAIN + "/#");
+    return isInviteURL(Uri.parse(url));
   }
 
   public static String QrDataToInviteURL(String qrData) {

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -69,6 +69,10 @@ public class Util {
     return INVITE_DOMAIN.equals(uri.getHost());
   }
 
+  public static boolean isInviteURL(String url) {
+    return url != null && url.startsWith("https://" + INVITE_DOMAIN + "/#");
+  }
+
   public static String QrDataToInviteURL(String qrData) {
     return "https://" + INVITE_DOMAIN + "/#" + qrData.split(":", 2)[1].replaceFirst("#", "&");
   }


### PR DESCRIPTION
currently when user click a link in a message, the handling is passed to the system which then select the app that handles links, for invite-URLs that apps is Delta Chat itself so the chatlist activity is launched and user gets a dialog with a question "do you want to join group X?" even if user cancels the dialog, context is already lost and user has to re-enter the chat they were

with this PR, the invitation link is handled sooner, without the extra round-trips and the dialog appears in-place giving chance to the user to just cancel in case of a miss-click etc 