### PR TITLE
catch errors thrown by Uri.parse()

### DIFF
--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -70,7 +70,12 @@ public class Util {
   }
 
   public static boolean isInviteURL(String url) {
-    return isInviteURL(Uri.parse(url));
+    try {
+      return isInviteURL(Uri.parse(url));
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return false;
   }
 
   public static String QrDataToInviteURL(String qrData) {


### PR DESCRIPTION
catch errors thrown by Uri.parse() to avoid crashes on tapping invite links