### PR TITLE
make 'Read Address Book' a per-account option

### DIFF
--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -117,7 +117,7 @@ public class ContactSelectionListFragment extends    Fragment
   public void onStart() {
     super.onStart();
     this.getLoaderManager().initLoader(0, null, this);
-    if (Prefs.showSystemContacts(getContext())) {
+    if (dcContext.getConfigInt("ui.android.show_system_contacts") != 0) {
       Permissions.with(this)
         .request(Manifest.permission.READ_CONTACTS)
         .ifNecessary()

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -59,6 +59,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   CheckBoxPreference bccSelfCheckbox;
   CheckBoxPreference mvboxMoveCheckbox;
   CheckBoxPreference onlyFetchMvboxCheckbox;
+  CheckBoxPreference showSystemContacts;
 
   @Override
   public void onCreate(Bundle paramBundle) {
@@ -117,6 +118,13 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
         return true;
       }
     }));
+
+    showSystemContacts = (CheckBoxPreference) this.findPreference("pref_show_system_contacts");
+    showSystemContacts.setOnPreferenceChangeListener((preference, newValue) -> {
+      boolean enabled = (Boolean) newValue;
+      dcContext.setConfigInt("ui.android.show_system_contacts", enabled? 1 : 0);
+      return true;
+    });
 
     Preference manageKeys = this.findPreference("pref_manage_keys");
     manageKeys.setOnPreferenceClickListener(new ManageKeysListener());
@@ -184,6 +192,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     bccSelfCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_BCC_SELF));
     mvboxMoveCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_MVBOX_MOVE));
     onlyFetchMvboxCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_ONLY_FETCH_MVBOX));
+    showSystemContacts.setChecked(0!=dcContext.getConfigInt("ui.android.show_system_contacts"));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -58,7 +58,6 @@ public class Prefs {
 
   public  static final String SYSTEM_EMOJI_PREF                = "pref_system_emoji";
   public  static final String BUILTIN_CAMERA_PREF              = "pref_builtin_camera";
-  public  static final String SHOW_SYSTEM_CONTACTS             = "pref_show_system_contacts";
   public  static final String DIRECT_CAPTURE_CAMERA_ID         = "pref_direct_capture_camera_id";
   private static final String PROFILE_AVATAR_ID_PREF           = "pref_profile_avatar_id";
   public  static final String INCOGNITO_KEYBORAD_PREF          = "pref_incognito_keyboard";
@@ -311,10 +310,6 @@ public class Prefs {
 
   public static boolean isBuiltInCameraPreferred(Context context) {
     return getBooleanPreference(context, BUILTIN_CAMERA_PREF, false);
-  }
-
-  public static boolean showSystemContacts(Context context) {
-    return getBooleanPreference(context, SHOW_SYSTEM_CONTACTS, false);
   }
 
   public static boolean getAlwaysLoadRemoteContent(Context context) {


### PR DESCRIPTION
while working on the [iOS counterpart](https://github.com/deltachat/deltachat-ios/pull/2069), i came to the conclusion that it is much better to have a per-account setting here

this fits better to chatmail:
- one can have chatmail=OFF and normal-mail=ON
- new accounts are most often chatmail, even if there is a normal-mail account, and get the setting OFF, which is better in most cases
- the option more "fades out" this way :)