### PR TITLE
add generic 'body' text for new messages and add translators hints

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -954,6 +954,8 @@
     <string name="notify_no_name_or_message">No name or message</string>
     <string name="notifications_disabled">Notifications disabled</string>
     <string name="new_messages">New messages</string>
+    <!-- Body text for a generic "New messages" notification. Shown if we do not have more information about a new messages. Note, that the string is also referenced at https://github.com/deltachat/notifiers -->
+    <string name="new_messages_body">You have new messages</string>
     <string name="n_messages_in_m_chats">%1$d messages in %2$d chats</string>
 
 


### PR DESCRIPTION
`new_messages_body` is used for a generic notification message in case we do not know anything about the new message apart from the fact that there _is_  a new message. currently, this is used on iOS only and looks like the following:

<img width=300 src=https://github.com/deltachat/deltachat-android/assets/9800740/36a20888-031b-40c1-8119-09247a113ad9>
