### PR TITLE
tweak scripts/clean-core.sh

### DIFF
--- a/scripts/clean-core.sh
+++ b/scripts/clean-core.sh
@@ -1,1 +1,11 @@
+cd jni/deltachat-core-rust
+cargo clean
+cd -
+
 rm -rf jni/deltachat-core-rust/target
+rm jni/armeabi-v7a/libdeltachat.a
+rm jni/x86/libdeltachat.a
+rm jni/arm64-v8a/libdeltachat.a
+rm jni/x86_64/libdeltachat.a
+
+echo "now, in Android Studio, run 'Build / Clean Project'"


### PR DESCRIPTION
the idea of the script
is to prune all possible caches
that may cause problems when updating core.

it is run usually before a release
and to make sure a core is rebuild from scratch.