### PR TITLE
react with any emoji

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -40,6 +40,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!-- force compiling emojipicker on sdk<21; we'll add a runtime switch to not use the picker in this case -->
+    <uses-sdk tools:overrideLibrary="androidx.emoji2.emojipicker"/>
+
     <application android:name=".ApplicationContext"
                  android:icon="@mipmap/ic_launcher"
                  android:label="@string/app_name"

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.6.2'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2'
     implementation 'androidx.work:work-runtime:2.8.1'
+    implementation 'androidx.emoji2:emoji2-emojipicker:1.4.0'
     implementation 'com.google.android.exoplayer:exoplayer-core:2.9.6' // plays video and audio
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.6'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2'
     implementation 'androidx.work:work-runtime:2.8.1'
     implementation 'androidx.emoji2:emoji2-emojipicker:1.4.0'
+    implementation 'com.google.guava:guava:29.0-android'
     implementation 'com.google.android.exoplayer:exoplayer-core:2.9.6' // plays video and audio
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.6'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -116,6 +116,7 @@
         <org.thoughtcrime.securesms.components.emoji.EmojiTextView
             android:id="@+id/reaction_any"
             android:text="•••"
+            android:textColor="?attr/pref_icon_tint"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/AddReaction"/>

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -113,6 +113,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/AddReaction"/>
+        <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+            android:id="@+id/reaction_any"
+            android:text="•••"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/AddReaction"/>
     </org.thoughtcrime.securesms.reactions.AddReactionView>
 
 </FrameLayout>

--- a/res/layout/reaction_picker.xml
+++ b/res/layout/reaction_picker.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
 
     <androidx.emoji2.emojipicker.EmojiPickerView
         android:id="@+id/emoji_picker"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:emojiGridColumns="9"/>
-</LinearLayout>
+</RelativeLayout>

--- a/res/layout/reaction_picker.xml
+++ b/res/layout/reaction_picker.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.emoji2.emojipicker.EmojiPickerView
+        android:id="@+id/emoji_picker"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:emojiGridColumns="9"/>
+</LinearLayout>

--- a/res/layout/reaction_picker.xml
+++ b/res/layout/reaction_picker.xml
@@ -10,5 +10,5 @@
         android:id="@+id/emoji_picker"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:emojiGridColumns="9"/>
+        app:emojiGridColumns="8"/>
 </RelativeLayout>

--- a/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
+++ b/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
@@ -51,8 +51,9 @@ public class AddReactionView extends LinearLayout {
           };
           for (int i = 0; i < defaultReactionViews.length; i++) {
               final int ii = i;
-              defaultReactionViews[i].setOnClickListener(v -> reactionClicked(ii));
+              defaultReactionViews[i].setOnClickListener(v -> defaultReactionClicked(ii));
           }
+          findViewById(R.id.reaction_any).setOnClickListener(v -> anyReactionClicked());
       }
     }
 
@@ -117,7 +118,7 @@ public class AddReactionView extends LinearLayout {
         return result;
     }
 
-    private void reactionClicked(int i) {
+    private void defaultReactionClicked(int i) {
         try {
             final String reaction = defaultReactionViews[i].getText().toString();
             if (reaction.equals(getSelfReaction())) {
@@ -130,6 +131,12 @@ public class AddReactionView extends LinearLayout {
             }
         } catch(Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    private void anyReactionClicked() {
+        if (listener != null) {
+            listener.onShallHide();
         }
     }
 

--- a/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
+++ b/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.reactions;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -57,7 +58,11 @@ public class AddReactionView extends LinearLayout {
               final int ii = i;
               defaultReactionViews[i].setOnClickListener(v -> defaultReactionClicked(ii));
           }
-          findViewById(R.id.reaction_any).setOnClickListener(v -> anyReactionClicked());
+          EmojiTextView reactionAny = findViewById(R.id.reaction_any);
+          reactionAny.setOnClickListener(v -> anyReactionClicked());
+          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+              reactionAny.setVisibility(View.GONE);
+          }
       }
     }
 

--- a/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
+++ b/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
@@ -2,10 +2,14 @@ package org.thoughtcrime.securesms.reactions;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
+import androidx.emoji2.emojipicker.EmojiPickerView;
 
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
@@ -119,24 +123,44 @@ public class AddReactionView extends LinearLayout {
     }
 
     private void defaultReactionClicked(int i) {
+        final String reaction = defaultReactionViews[i].getText().toString();
+        sendReaction(reaction);
+
+        if (listener != null) {
+            listener.onShallHide();
+        }
+    }
+
+    private void anyReactionClicked() {
+        // TODO: does not show emoji, crashes on select with "OOM allocating Bitmap with dimensions 16777211 x 16777211"
+        View pickerLayout = View.inflate(context, R.layout.reaction_picker, null);
+        EmojiPickerView pickerView = ViewUtil.findById(pickerLayout, R.id.emoji_picker);
+        pickerView.setOnEmojiPickedListener((it) -> {
+            final String reaction = it.getEmoji();
+            sendReaction(reaction);
+        });
+
+        new AlertDialog.Builder(context)
+              .setView(pickerLayout)
+              .setTitle(R.string.react)
+              .setPositiveButton(R.string.cancel, null)
+              .create()
+              .show();
+
+        if (listener != null) {
+            listener.onShallHide();
+        }
+    }
+
+    private void sendReaction(final String reaction) {
         try {
-            final String reaction = defaultReactionViews[i].getText().toString();
             if (reaction.equals(getSelfReaction())) {
                 rpc.sendReaction(dcContext.getAccountId(), msgToReactTo.getId(), "");
             } else {
                 rpc.sendReaction(dcContext.getAccountId(), msgToReactTo.getId(), reaction);
             }
-            if (listener != null) {
-                listener.onShallHide();
-            }
         } catch(Exception e) {
             e.printStackTrace();
-        }
-    }
-
-    private void anyReactionClicked() {
-        if (listener != null) {
-            listener.onShallHide();
         }
     }
 

--- a/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
+++ b/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
@@ -132,20 +132,22 @@ public class AddReactionView extends LinearLayout {
     }
 
     private void anyReactionClicked() {
-        // TODO: does not show emoji, crashes on select with "OOM allocating Bitmap with dimensions 16777211 x 16777211"
         View pickerLayout = View.inflate(context, R.layout.reaction_picker, null);
+
+        final AlertDialog alertDialog = new AlertDialog.Builder(context)
+              .setView(pickerLayout)
+              .setTitle(R.string.react)
+              .setPositiveButton(R.string.cancel, null)
+              .create();
+
         EmojiPickerView pickerView = ViewUtil.findById(pickerLayout, R.id.emoji_picker);
         pickerView.setOnEmojiPickedListener((it) -> {
             final String reaction = it.getEmoji();
             sendReaction(reaction);
+            alertDialog.dismiss();
         });
 
-        new AlertDialog.Builder(context)
-              .setView(pickerLayout)
-              .setTitle(R.string.react)
-              .setPositiveButton(R.string.cancel, null)
-              .create()
-              .show();
+        alertDialog.show();
 
         if (listener != null) {
             listener.onShallHide();

--- a/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
+++ b/src/org/thoughtcrime/securesms/reactions/AddReactionView.java
@@ -3,8 +3,6 @@ package org.thoughtcrime.securesms.reactions;
 import android.content.Context;
 import android.os.Build;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -21,13 +19,14 @@ import com.b44t.messenger.rpc.Rpc;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 import java.util.Map;
 
 public class AddReactionView extends LinearLayout {
     private EmojiTextView [] defaultReactionViews;
+    private EmojiTextView anyReactionView;
+    private boolean anyReactionClearsReaction;
     private Context context;
     private DcContext dcContext;
     private Rpc rpc;
@@ -58,10 +57,10 @@ public class AddReactionView extends LinearLayout {
               final int ii = i;
               defaultReactionViews[i].setOnClickListener(v -> defaultReactionClicked(ii));
           }
-          EmojiTextView reactionAny = findViewById(R.id.reaction_any);
-          reactionAny.setOnClickListener(v -> anyReactionClicked());
+          anyReactionView = findViewById(R.id.reaction_any);
+          anyReactionView.setOnClickListener(v -> anyReactionClicked());
           if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-              reactionAny.setVisibility(View.GONE);
+              anyReactionView.setVisibility(View.GONE); // EmojiPickerView requires SDK 21 or newer
           }
       }
     }
@@ -79,12 +78,24 @@ public class AddReactionView extends LinearLayout {
         this.listener = listener;
 
         final String existingReaction = getSelfReaction();
+        boolean existingHilited = false;
         for (EmojiTextView defaultReactionView : defaultReactionViews) {
             if (defaultReactionView.getText().toString().equals(existingReaction)) {
                 defaultReactionView.setBackground(ContextCompat.getDrawable(context, R.drawable.reaction_pill_background_selected));
+                existingHilited = true;
             } else {
                 defaultReactionView.setBackground(null);
             }
+        }
+
+        if (existingReaction != null && !existingHilited) {
+            anyReactionView.setText(existingReaction);
+            anyReactionView.setBackground(ContextCompat.getDrawable(context, R.drawable.reaction_pill_background_selected));
+            anyReactionClearsReaction = true;
+        } else {
+            anyReactionView.setText("•••");
+            anyReactionView.setBackground(null);
+            anyReactionClearsReaction = false;
         }
 
         final int offset = (int)(this.getHeight() * 0.666);
@@ -137,22 +148,25 @@ public class AddReactionView extends LinearLayout {
     }
 
     private void anyReactionClicked() {
-        View pickerLayout = View.inflate(context, R.layout.reaction_picker, null);
+        if (anyReactionClearsReaction) {
+            sendReaction(null);
+        } else {
+            View pickerLayout = View.inflate(context, R.layout.reaction_picker, null);
 
-        final AlertDialog alertDialog = new AlertDialog.Builder(context)
-              .setView(pickerLayout)
-              .setTitle(R.string.react)
-              .setPositiveButton(R.string.cancel, null)
-              .create();
+            final AlertDialog alertDialog = new AlertDialog.Builder(context)
+                .setView(pickerLayout)
+                .setTitle(R.string.react)
+                .setPositiveButton(R.string.cancel, null)
+                .create();
 
-        EmojiPickerView pickerView = ViewUtil.findById(pickerLayout, R.id.emoji_picker);
-        pickerView.setOnEmojiPickedListener((it) -> {
-            final String reaction = it.getEmoji();
-            sendReaction(reaction);
-            alertDialog.dismiss();
-        });
+            EmojiPickerView pickerView = ViewUtil.findById(pickerLayout, R.id.emoji_picker);
+            pickerView.setOnEmojiPickedListener((it) -> {
+                sendReaction(it.getEmoji());
+                alertDialog.dismiss();
+            });
 
-        alertDialog.show();
+            alertDialog.show();
+        }
 
         if (listener != null) {
             listener.onShallHide();
@@ -161,7 +175,7 @@ public class AddReactionView extends LinearLayout {
 
     private void sendReaction(final String reaction) {
         try {
-            if (reaction.equals(getSelfReaction())) {
+            if (reaction == null || reaction.equals(getSelfReaction())) {
                 rpc.sendReaction(dcContext.getAccountId(), msgToReactTo.getId(), "");
             } else {
                 rpc.sendReaction(dcContext.getAccountId(), msgToReactTo.getId(), reaction);


### PR DESCRIPTION
using the existing reaction picker seems to be a pain as it is bound very close to our keyboard - and would also need special casing if it is not used.

therefore, this PR goes for using https://developer.android.com/develop/ui/views/text-and-emoji/emoji-picker , which had some building issues (see commit messages), however, seems straight-forward.

also, only very few lines of codes are needed.

~~however, for whatever reason, emoji do not show up in the picker.  when tapping the empty space in the picker, the app crashes. might be because of kotlin, because of a missing dependency, or excluded bit, whatnot. @adbenitez can you try this as well and maybe have a closer look?~~ EDIT: thanks a lot for fixing and for taking over this PR, this is very welcome! 💯

size-wise, this PR adds about 1mb to the app, that seems okay for the given feature ;) also, we did not add dependencies to the old picker, so we can remove that at some point (or at least disable it by default).

this is the "..." button:

<img width=280 src=https://github.com/deltachat/deltachat-android/assets/9800740/abd29dac-558a-4fff-bdb1-cbedefdff27c>

this is the picker:

<img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/096f11e2-109c-40bc-bb09-92dc5bd36166>


closes #2978