### PR TITLE
add strings needed by core to show reactions in summaries

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -751,6 +751,10 @@
     <string name="reactions">Reactions</string>
     <!-- Verb, the action of adding a "Reaction" to a message. Used eg. in context menus, similar to "Reply" or "Forward" -->
     <string name="react">React</string>
+    <!-- %1$s will be replaced by an emoji. %2$s will be replaced by message summary. Eg. 'You reacted 👍 to "Found my suitcase"'. Use less than 20 characters, otherwise the string will be truncated too soon and no summary will be shown. Do not try to translate "reacted to" too strict. Depending on the language, "added 👍 to" or "gave 👍 to" or just "👍 to" may be shorter and/or clearer and work as well. -->
+    <string name="reaction_by_you">You reacted %1$s to \"%2$s\"</string>
+    <!-- %1$s will be replaced a name. %2$s will be replaced by an emoji. %3$s will be replaced by message summary. Eg. 'Alice reacted 👍 to "Nice photos"'. Use less than 20 characters, otherwise the string will be truncated too soon and no summary will be shown. Do not try to translate "reacted to" too strict. Depending on the language, "added 👍 to" or "gave 👍 to" or just "👍 to" may be shorter and/or clearer work as well. -->
+    <string name="reaction_by_other">%1$s reacted %2$s to \"%3$s\"</string>
 
     <!-- automatically delete message -->
     <string name="delete_old_messages">Delete Old Messages</string>

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -256,6 +256,8 @@ public class DcHelper {
     dcContext.setStockTranslation(172, context.getString(R.string.chat_new_group_hint));
     dcContext.setStockTranslation(173, context.getString(R.string.member_x_added));
     dcContext.setStockTranslation(174, context.getString(R.string.invalid_unencrypted_tap_to_learn_more));
+    dcContext.setStockTranslation(176, context.getString(R.string.reaction_by_you));
+    dcContext.setStockTranslation(177, context.getString(R.string.reaction_by_other));
   }
 
   public static File getImexDir() {


### PR DESCRIPTION
this PR makes the strings `You reacted 🤘 to "Nice photos!"` etc. translatable and gives translations to core.

moreover, this PR picks up suggestions and alternatives wrt translations and adds them as translator's hints.

see for details https://github.com/deltachat/deltachat-core-rust/pull/5387