### PR TITLE
add support for "reaction summaries"

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -119,6 +119,7 @@ public class ConversationListFragment extends Fragment
     eventCenter.addObserver(DcContext.DC_EVENT_MSG_DELIVERED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_MSG_FAILED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_MSG_READ, this);
+    eventCenter.addObserver(DcContext.DC_EVENT_REACTIONS_CHANGED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_CONNECTIVITY_CHANGED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_SELFAVATAR_CHANGED, this);
   }


### PR DESCRIPTION
next core will show reactions in the chatlist's summaries, see https://github.com/deltachat/deltachat-core-rust/pull/5387 for details and reasoning

there is not more to do in UI other than updating the chatlist on DC_EVENT_REACTIONS_CHANGED

<img src=https://github.com/deltachat/deltachat-android/assets/9800740/a175a386-0163-4d50-a6fe-e138c83b85fb>
