### PR TITLE
add FCM PUSH notification support

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -381,6 +381,12 @@
         </intent-filter>
     </service>
 
+    <service android:name=".notifications.FcmReceiveService" android:exported="true">
+        <intent-filter>
+            <action android:name="com.google.firebase.MESSAGING_EVENT" />
+        </intent-filter>
+    </service>
+
     <receiver android:name=".notifications.MarkReadReceiver"
               android:enabled="true"
               android:exported="false">
@@ -412,6 +418,12 @@
         android:authorities="${applicationId}.attachments"
         android:grantUriPermissions="true"
         android:exported="false">
+    </provider>
+
+    <provider
+        android:name="com.google.firebase.provider.FirebaseInitProvider"
+        android:authorities="${applicationId}.firebaseinitprovider"
+        tools:node="remove">
     </provider>
 
     <receiver android:name=".service.BootReceiver"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -40,8 +40,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
-    <!-- force compiling emojipicker on sdk<21; we'll add a runtime switch to not use the picker in this case -->
-    <uses-sdk tools:overrideLibrary="androidx.emoji2.emojipicker"/>
+    <!-- force compiling emojipicker on sdk<21 and firebase on sdk<19; runtime checks are required then -->
+    <uses-sdk tools:overrideLibrary="androidx.emoji2.emojipicker, com.google.firebase.messaging, com.google.android.gms.cloudmessaging"/>
 
     <application android:name=".ApplicationContext"
                  android:icon="@mipmap/ic_launcher"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -57,6 +57,10 @@
                  android:hasFragileUserData="true"
         >
 
+    <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
+    <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+    <meta-data android:name="firebase_messaging_auto_init_enabled" android:value="false" />
+
     <!-- android car support, see https://developer.android.com/training/auto/start/,
          as this potentially blocks releases on gplay due to extra-checks,
          we disable this during the first gplay releases -->

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application' version '8.1.4'
-    id 'com.google.gms.google-services' version '4.4.1' apply false // TODO: apply below as needed using "apply plugin" or so
+    id 'com.google.gms.google-services' version '4.4.1'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ android {
         applicationId "com.b44t.messenger"
         multiDexEnabled true
 
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 33
 
         vectorDrawables.useSupportLibrary = true

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application' version '8.1.4'
-    id 'com.google.gms.google-services' version '4.4.1' apply false
+    id 'com.google.gms.google-services' version '4.4.1' apply false // TODO: apply below as needed using "apply plugin" or so
 }
 
 repositories {
@@ -194,6 +194,7 @@ android {
         gplay {
             dimension "none"
             applicationId "chat.delta"
+            apply plugin: "com.google.gms.google-services"
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application' version '8.1.4'
+    id 'com.google.gms.google-services' version '4.4.1' apply false
 }
 
 repositories {
@@ -55,6 +56,7 @@ dependencies {
     implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'  // number of unread messages,
          // the one-letter circle for the contacts (when there is not avatar) and a white background.
     implementation 'com.googlecode.mp4parser:isoparser:1.0.6' // MP4 recoding; upgrading eg. to 1.1.22 breaks recoding, however, i have not investigated further, just reset to 1.0.6
+    implementation 'com.google.firebase:firebase-messaging:23.4.1' // for PUSH notifications
     implementation ('com.davemorrissey.labs:subsampling-scale-image-view:3.6.0') { // for the zooming on photos / media
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,11 @@ dependencies {
     implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'  // number of unread messages,
          // the one-letter circle for the contacts (when there is not avatar) and a white background.
     implementation 'com.googlecode.mp4parser:isoparser:1.0.6' // MP4 recoding; upgrading eg. to 1.1.22 breaks recoding, however, i have not investigated further, just reset to 1.0.6
-    implementation 'com.google.firebase:firebase-messaging:23.4.1' // for PUSH notifications
+    implementation ('com.google.firebase:firebase-messaging:23.4.1') { // for PUSH notifications
+        exclude group: 'com.google.firebase', module: 'firebase-core'
+        exclude group: 'com.google.firebase', module: 'firebase-analytics'
+        exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'
+    }
     implementation ('com.davemorrissey.labs:subsampling-scale-image-view:3.6.0') { // for the zooming on photos / media
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ android {
         applicationId "com.b44t.messenger"
         multiDexEnabled true
 
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
 
         vectorDrawables.useSupportLibrary = true

--- a/google-services.json
+++ b/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "922391085500",
+    "project_id": "delta-chat-fcm",
+    "storage_bucket": "delta-chat-fcm.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:922391085500:android:938fa7a685ce74ba3e2bb9",
+        "android_client_info": {
+          "package_name": "chat.delta"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBYH8Iznh8btYX7g_udv_bu68VH30zzxho"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/google-services.json
+++ b/google-services.json
@@ -23,6 +23,63 @@
           "other_platform_oauth_client": []
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:922391085500:android:6f54e2c4e49405673e2bb9",
+        "android_client_info": {
+          "package_name": "chat.delta.beta"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBYH8Iznh8btYX7g_udv_bu68VH30zzxho"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:922391085500:android:92b4cf12669cc2083e2bb9",
+        "android_client_info": {
+          "package_name": "com.b44t.messenger"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBYH8Iznh8btYX7g_udv_bu68VH30zzxho"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:922391085500:android:228a205b8aa2bacc3e2bb9",
+        "android_client_info": {
+          "package_name": "com.b44t.messenger.beta"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBYH8Iznh8btYX7g_udv_bu68VH30zzxho"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -268,6 +268,14 @@ JNIEXPORT void Java_com_b44t_messenger_DcAccounts_maybeNetwork(JNIEnv *env, jobj
 }
 
 
+JNIEXPORT void Java_com_b44t_messenger_DcAccounts_setPushDeviceToken(JNIEnv *env, jobject obj, jstring token)
+{
+    CHAR_REF(token);
+        dc_accounts_set_push_device_token(get_dc_accounts(env, obj), tokenPtr);
+    CHAR_UNREF(token);
+}
+
+
 JNIEXPORT jint Java_com_b44t_messenger_DcAccounts_addAccount(JNIEnv *env, jobject obj)
 {
     return dc_accounts_add_account(get_dc_accounts(env, obj));

--- a/src/com/b44t/messenger/DcAccounts.java
+++ b/src/com/b44t/messenger/DcAccounts.java
@@ -24,6 +24,7 @@ public class DcAccounts {
     public native void            startIo              ();
     public native void            stopIo               ();
     public native void            maybeNetwork         ();
+    public native void            setPushDeviceToken   (String token);
 
     public native int             addAccount           ();
     public native int             addClosedAccount     ();

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -40,6 +40,7 @@ import org.thoughtcrime.securesms.crypto.DatabaseSecretProvider;
 import org.thoughtcrime.securesms.crypto.PRNGFixes;
 import org.thoughtcrime.securesms.geolocation.DcLocationManager;
 import org.thoughtcrime.securesms.jobmanager.JobManager;
+import org.thoughtcrime.securesms.notifications.FcmReceiveService;
 import org.thoughtcrime.securesms.notifications.InChatSounds;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
 import org.thoughtcrime.securesms.util.AndroidSignalProtocolLogger;
@@ -225,6 +226,7 @@ public class ApplicationContext extends MultiDexApplication {
             ExistingPeriodicWorkPolicy.KEEP,
             fetchWorkRequest);
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+    FcmReceiveService.register(this);
   }
 
   public JobManager getJobManager() {

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 public class ApplicationContext extends MultiDexApplication {
   private static final String TAG = ApplicationContext.class.getSimpleName();
 
-  public DcAccounts             dcAccounts;
+  public static DcAccounts      dcAccounts;
   public Rpc                    rpc;
   public DcContext              dcContext;
   public DcLocationManager      dcLocationManager;

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -41,6 +41,7 @@ import androidx.fragment.app.Fragment;
 import com.b44t.messenger.DcContext;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.notifications.FcmReceiveService;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.Prefs;
 
@@ -257,6 +258,8 @@ public class LogViewFragment extends Fragment {
         builder.append("rtl=").append(isRtl).append("\n");
       }
 
+      final String token = FcmReceiveService.getToken();
+      builder.append("push-token=").append(token == null ? "<empty>" : token).append("\n");
     } catch (Exception e) {
       builder.append("Unknown\n");
     }

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -19,7 +19,6 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class FcmReceiveService extends FirebaseMessagingService {
   private static final String TAG = FcmReceiveService.class.getSimpleName();
-  private static final String TOKEN_PREFIX = "fcm:";
   private static String prefixedToken;
 
   public static void register(Context context) {
@@ -41,19 +40,23 @@ public class FcmReceiveService extends FirebaseMessagingService {
         return;
       }
 
-      String prefixedToken = TOKEN_PREFIX + rawToken;
-      synchronized (FcmReceiveService.TOKEN_PREFIX) {
+      String prefixedToken = addPrefix(rawToken);
+      synchronized (FcmReceiveService.TAG) {
         FcmReceiveService.prefixedToken = prefixedToken;
       }
 
-      Log.w(TAG, "FCM token for " + BuildConfig.APPLICATION_ID + ": " + prefixedToken);
+      Log.w(TAG, "FCM token: " + prefixedToken);
       ApplicationContext.dcAccounts.setPushDeviceToken(prefixedToken);
     });
   }
 
+  private static String addPrefix(String rawToken) {
+    return "fcm-" + BuildConfig.APPLICATION_ID + ":" + rawToken;
+  }
+
   @Nullable
   public static String getToken() {
-    synchronized (FcmReceiveService.TOKEN_PREFIX) {
+    synchronized (FcmReceiveService.TAG) {
       return FcmReceiveService.prefixedToken;
     }
   }
@@ -65,12 +68,12 @@ public class FcmReceiveService extends FirebaseMessagingService {
 
   @Override
   public void onNewToken(@NonNull String rawToken) {
-    String prefixedToken = TOKEN_PREFIX + rawToken;
-    synchronized (FcmReceiveService.TOKEN_PREFIX) {
+    String prefixedToken = addPrefix(rawToken)  ;
+    synchronized (FcmReceiveService.TAG) {
       FcmReceiveService.prefixedToken = prefixedToken;
     }
 
-    Log.i(TAG, "new FCM token for" + BuildConfig.APPLICATION_ID + ": " + prefixedToken);
+    Log.i(TAG, "new FCM token: " + prefixedToken);
     ApplicationContext.dcAccounts.setPushDeviceToken(prefixedToken);
   }
 }

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -1,0 +1,76 @@
+package org.thoughtcrime.securesms.notifications;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import org.thoughtcrime.securesms.ApplicationContext;
+import org.thoughtcrime.securesms.BuildConfig;
+import org.thoughtcrime.securesms.util.Util;
+
+public class FcmReceiveService extends FirebaseMessagingService {
+  private static final String TAG = FcmReceiveService.class.getSimpleName();
+  private static final String TOKEN_PREFIX = "fcm:";
+  private static String prefixedToken;
+
+  public static void register(Context context) {
+    Util.runOnAnyBackgroundThread(() -> {
+      final String rawToken;
+
+      try {
+        // manual init: read tokens from `./google-services.json`;
+        // automatic init disabled in AndroidManifest.xml to skip FCM code completely.
+        FirebaseApp.initializeApp(context);
+        rawToken = Tasks.await(FirebaseMessaging.getInstance().getToken());
+      } catch (Exception e) {
+        // we're here usually when FCM is not available and initializeApp() or getToken() failed.
+        Log.w(TAG, "cannot get FCM token for " + BuildConfig.APPLICATION_ID + ": " + e);
+        return;
+      }
+      if (TextUtils.isEmpty(rawToken)) {
+        Log.w(TAG, "got empty FCM token for " + BuildConfig.APPLICATION_ID);
+        return;
+      }
+
+      String prefixedToken = TOKEN_PREFIX + rawToken;
+      synchronized (FcmReceiveService.TOKEN_PREFIX) {
+        FcmReceiveService.prefixedToken = prefixedToken;
+      }
+
+      Log.w(TAG, "FCM token for " + BuildConfig.APPLICATION_ID + ": " + prefixedToken);
+      ApplicationContext.dcAccounts.setPushDeviceToken(prefixedToken);
+    });
+  }
+
+  @Nullable
+  public static String getToken() {
+    synchronized (FcmReceiveService.TOKEN_PREFIX) {
+      return FcmReceiveService.prefixedToken;
+    }
+  }
+
+  @Override
+  public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+    Log.i(TAG, "FCM push notification received");
+  }
+
+  @Override
+  public void onNewToken(@NonNull String rawToken) {
+    String prefixedToken = TOKEN_PREFIX + rawToken;
+    synchronized (FcmReceiveService.TOKEN_PREFIX) {
+      FcmReceiveService.prefixedToken = prefixedToken;
+    }
+
+    Log.i(TAG, "new FCM token for" + BuildConfig.APPLICATION_ID + ": " + prefixedToken);
+    ApplicationContext.dcAccounts.setPushDeviceToken(prefixedToken);
+  }
+}

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.notifications;
 
 import android.content.Context;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -22,6 +23,10 @@ public class FcmReceiveService extends FirebaseMessagingService {
   private static String prefixedToken;
 
   public static void register(Context context) {
+    if (Build.VERSION.SDK_INT < 19) {
+      return;
+    }
+
     Util.runOnAnyBackgroundThread(() -> {
       final String rawToken;
 

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -69,6 +69,9 @@ public class FcmReceiveService extends FirebaseMessagingService {
   @Override
   public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
     Log.i(TAG, "FCM push notification received");
+    // the app is running (again) now and fetching and notifications should be processed as usual.
+    // to support accounts that do not send PUSH notifications and for simplicity,
+    // we just let the app run as long as possible.
   }
 
   @Override


### PR DESCRIPTION
this PR adds Firebase Clould Notifications (FCM), see #2998 for details and reasoning

the FCM token is get unconditionally currently. when the server pings us, we do nothing special - at that moment, the app should just be started (again) and process messages.

we should get this PR in to **gather feedback on a beta-version** if there are any issues of running on real devices (google and non-googles) - even if the server is not yet ready.

subsequent tasks in **another PR:** 

- init more gracefully together with POST_NOTIFICATION and other background-checks
- consider adding options and/or ask on startup
- reorganize `build.gradle`, so that `com.b44t.messenger` flavour (used for f-droid) is build without FCM - `chat.delta` and `com.b44t.messenger.beta` should stay as is

tasks done:

- [x] create firebase project linked to all used package ids
- [x] send tokens to core, depending on package ID, prefixed by `fcm-chat.delta:` (gplay and others), `fcm-com.b44t.messenger:` (fdroid), `fcm-com.b44t.messenger.beta:` (betas sent around), `fcm-chat.delta.beta:` (not used afaik)  
in general, similar to iOS it seems good if PUSH also works in betas etc., esp. as these are mainly used by devs, so if sth goes wrong it is easier noticable.  
for f-droid - idk, maybe they device to disable FCM, but for now, let's treat things the same if google-services are available on a phone anyways
- [x] show token in log
- [x] override `FirebaseMessagingService::onMessageReceived()` and add a notification-banner using existing code
- [x] check if we can run on on a device without FCM (if possible, avoid having different apps - note, it may not only be FCM in the future) - EDIT: works at least in the emulator, we need more in-the-wild-testing, however
- [x] check for analytics & co and exclude that
- [x] check if we can run on android sdk<19 - EDIT: checked - and android 4.1 - 4.3 should stays supported, [see below](https://github.com/deltachat/deltachat-android/pull/3000#issuecomment-2090656139)
- [x] check if we can build/run when using different package id - EDIT: checked, see 2nd point


useful links:

- https://console.firebase.google.com/
- https://firebase.google.com/docs/cloud-messaging
- https://github.com/deltachat/notifiers/issues/31

nb: fcm and related stuff adds about 0.5mb the the .apk size

closes #2998

