### PR TITLE
add strings needed for instant onboarding

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -557,8 +557,8 @@
     <string name="manual_account_setup_option">Manual Login</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
     <string name="instant_onboarding_title">Your Profile</string>
-    <!-- The two placeholders mark beginning and end of a tappable link -->
-    <string name="instant_onboarding_agree_default">I agree to the %1$sPrivacy Policy%2$s</string>
+    <!-- The placeholder will be replaced by the tappable string "Privacy Policy" (privacy_policy) -->
+    <string name="instant_onboarding_agree_default">I agree to the %1$s</string>
     <!-- The placeholder will be replaced by the tappable name of the instance -->
     <string name="instant_onboarding_agree_instance">I agree to create a profile on %1$s</string>
     <!-- Confirmation button on the instant onboarding screen -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -549,6 +549,31 @@
 
 
     <!-- welcome and login -->
+    <!-- Primary button on the welcome screen, allows to create an instant account -->
+    <string name="onboarding_create_instant_account">Let\'s Get Started!</string>
+    <!-- Secondary button on the welcome screen, allows to "Add as Second Device", "Restore from Backup", "Manual Login"  -->
+    <string name="onboarding_alternative_logins">I Already Have a Login</string>
+    <!-- Button, allows to log in to existing email accounts, setting ports, passwords and so on -->
+    <string name="manual_account_setup_option">Manual Login</string>
+    <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
+    <string name="instant_onboarding_title">Your Profile</string>
+    <!-- Confirmation button on the instant onboarding screen -->
+    <string name="instant_onboarding_create">Create Profile</string>
+    <!-- Hint about on which instance (server) the account will be created -->
+    <string name="instant_onboarding_default_info">Your profile will be created on the default instance.</string>
+    <!-- Hint about on which instance (server) the account will be created; next line follows the instance domain name -->
+    <string name="instant_onboarding_instance_info">Your profile will be created on the following instance:</string>
+    <!-- Secondary, link-like button to open a page with other possible instances -->
+    <string name="instant_onboarding_show_more_instances">Show other instances</string>
+    <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by the group name -->
+    <string name="instant_onboarding_group_info">Create a profile to join the group \"%1$s\".</string>
+    <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by contact name and/or address -->
+    <string name="instant_onboarding_contact_info">Create a profile to chat with %1$s.</string>
+    <!-- Question shown when another user's QR code is scanned from onboarding screen -->
+    <string name="instant_onboarding_confirm_contact">Do you want to create a new profile and start chatting with %1$s?</string>
+    <!-- Question shown when group's QR code is scanned from onboarding screen -->
+    <string name="instant_onboarding_confirm_group">Do you want to create a new profile and join the \"%1$s\" chat group?</string>
+
     <string name="welcome_chat_over_email">Chat over E-Mail.</string>
     <string name="scan_invitation_code">Scan Invitation Code</string>
     <string name="login_title">Log In</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -557,8 +557,9 @@
     <string name="manual_account_setup_option">Manual Login</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
     <string name="instant_onboarding_title">Your Profile</string>
-    <!-- The placeholder will be replaced by the tappable string "Privacy Policy" (privacy_policy) -->
-    <string name="instant_onboarding_agree_default">I agree to the %1$s</string>
+    <!-- The string will be followed by a space and the tappable text "Privacy Policy" (instant_onboarding_agree_privacy_policy). We know, this is not optimal for all languages, but it is the easiest way for React for now :) -->
+    <string name="instant_onboarding_agree_default">I agree to the</string>
+    <string name="instant_onboarding_agree_privacy_policy">Privacy Policy</string>
     <!-- The placeholder will be replaced by the tappable name of the instance -->
     <string name="instant_onboarding_agree_instance">I agree to create a profile on %1$s</string>
     <!-- Confirmation button on the instant onboarding screen -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -560,7 +560,7 @@
     <!-- This is a link to the default Privacy Policy -->
     <string name="instant_onboarding_agree_default">Read the Privacy Policy</string>
     <!-- The placeholder will be replaced by instance name, the whole text will link to the instance page -->
-    <string name="instant_onboarding_agree_instance">Create profile on %1$s</string>
+    <string name="instant_onboarding_agree_instance">About profiles on %1$s</string>
     <!-- Confirmation button on the instant onboarding screen -->
     <string name="instant_onboarding_create">Agree &amp; Create Profile</string>
     <!-- Secondary, link-like button to open a page with other possible instances -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -557,14 +557,14 @@
     <string name="manual_account_setup_option">Manual Login</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
     <string name="instant_onboarding_title">Your Profile</string>
+    <!-- The two placeholders mark beginning and end of a tappable link -->
+    <string name="instant_onboarding_agree_default">I agree to the %1$sPrivacy Policy%2$s</string>
+    <!-- The placeholder will be replaced by the tappable name of the instance -->
+    <string name="instant_onboarding_agree_instance">I agree to create a profile on %1$s</string>
     <!-- Confirmation button on the instant onboarding screen -->
-    <string name="instant_onboarding_create">Create Profile</string>
-    <!-- Hint about on which instance (server) the account will be created -->
-    <string name="instant_onboarding_default_info">Your profile will be created on the default instance.</string>
-    <!-- Hint about on which instance (server) the account will be created; next line follows the instance domain name -->
-    <string name="instant_onboarding_instance_info">Your profile will be created on the following instance:</string>
+    <string name="instant_onboarding_create">Create New Profile</string>
     <!-- Secondary, link-like button to open a page with other possible instances -->
-    <string name="instant_onboarding_show_more_instances">Show other instances</string>
+    <string name="instant_onboarding_show_more_instances">Explore Other Options</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by the group name -->
     <string name="instant_onboarding_group_info">Create a profile to join the group \"%1$s\".</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by contact name and/or address -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -557,13 +557,12 @@
     <string name="manual_account_setup_option">Manual Login</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
     <string name="instant_onboarding_title">Your Profile</string>
-    <!-- The string will be followed by a space and the tappable text "Privacy Policy" (instant_onboarding_agree_privacy_policy). We know, this is not optimal for all languages, but it is the easiest way for React for now :) -->
-    <string name="instant_onboarding_agree_default">I agree to the</string>
-    <string name="instant_onboarding_agree_privacy_policy">Privacy Policy</string>
-    <!-- The placeholder will be replaced by the tappable name of the instance -->
-    <string name="instant_onboarding_agree_instance">I agree to create a profile on %1$s</string>
+    <!-- This is a link to the default Privacy Policy -->
+    <string name="instant_onboarding_agree_default">Read the Privacy Policy</string>
+    <!-- The placeholder will be replaced by instance name, the whole text will link to the instance page -->
+    <string name="instant_onboarding_agree_instance">Create profile on %1$s</string>
     <!-- Confirmation button on the instant onboarding screen -->
-    <string name="instant_onboarding_create">Create New Profile</string>
+    <string name="instant_onboarding_create">Agree &amp; Create Profile</string>
     <!-- Secondary, link-like button to open a page with other possible instances -->
     <string name="instant_onboarding_show_more_instances">Explore Other Options</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by the group name -->


### PR DESCRIPTION
this PR extracts  new strings from [deltachat/deltachat-desktop#3773](https://github.com/deltachat/deltachat-desktop/pull/3773/files#diff-5bd8446ffbbe28eb2eacda360fd1fa0640832786a9170440fe58275a4190102b).

the following strings were not added as they are existing already in a sufficient way (desktop PR needs to be changed):

`onboarding_title` -> `welcome_desktop` (exclamation mark can be added later)
`onboarding_subtitle` -> `welcome_chat_over_email` (dot can be removed later)
`onboarding_scan_qr_code` -> `qrscan_title`
`multidevice_setup_option` -> `multidevice_receiver_title`
`import_backup_option` -> `import_backup_title` (iirc, it was renamed to "restore" on purpose, let's stay with that for now)
`instant_onboarding_confirm_label` -> `ok` (this is used in a message box, right? i would stay calm there, otherwise use the other "Let's Get Started")

for the other strings, i stayed with existing keys - they're good enough and i did not want to add additional noise.

for upper/lower case: we voted for [capitalising titles and buttons](https://capitalizemytitle.com) at some point and do not want to change this currently; i adapted the strings accordingly.

@adzialocha will add some screenshots to https://github.com/deltachat/deltachat-desktop/pull/3773 so one can get a better idea

closes https://github.com/deltachat/deltachat-android/issues/2995