### PR TITLE
fix openOnlineUrl(), mailto/openpgp4fpr has to open externally

### DIFF
--- a/src/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/org/thoughtcrime/securesms/WebViewActivity.java
@@ -62,6 +62,7 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
 
     webView = findViewById(R.id.webview);
     webView.setWebViewClient(new WebViewClient() {
+      // IMPORTANT: this is will likely not be called inside iframes.
       // `shouldOverrideUrlLoading()` is called when the user clicks a URL,
       // returning `true` causes the WebView to abort loading the URL,
       // returning `false` causes the WebView to continue loading the URL as usual.

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -266,18 +266,16 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     }
   }
 
+  // This is only called when internetAccess == true or for mailto/openpgp4fpr scheme,
+  // because when internetAccess == false, the page is loaded inside an iframe,
+  // and WebViewClient.shouldOverrideUrlLoading is not called for HTTP(S) links inside the iframe
   @Override
   protected boolean openOnlineUrl(String url) {
-    if (internetAccess) {
-      // internet access enabled, continue loading in the WebView
-      return false;
-    }
-    if (url.startsWith("mailto:")) {
+    Log.i(TAG, "openOnlineUrl: " + url);
+    if (url.startsWith("mailto:") || url.startsWith("openpgp4fpr:")) {
       return super.openOnlineUrl(url);
     }
-
-    Toast.makeText(this, "Please embed needed resources.", Toast.LENGTH_LONG).show();
-    return true; // returning `true` causes the WebView to abort loading
+    return false; // continue loading in the WebView
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -266,7 +266,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     }
   }
 
-  // This is only called when internetAccess == true or for mailto/openpgp4fpr scheme,
+  // This is usually only called when internetAccess == true or for mailto/openpgp4fpr scheme,
   // because when internetAccess == false, the page is loaded inside an iframe,
   // and WebViewClient.shouldOverrideUrlLoading is not called for HTTP(S) links inside the iframe
   @Override

--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -275,7 +275,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     if (url.startsWith("mailto:") || url.startsWith("openpgp4fpr:")) {
       return super.openOnlineUrl(url);
     }
-    return false; // continue loading in the WebView
+    return !internetAccess; // returning `false` continues loading in WebView; returning `true` let WebView abort loading
   }
 
   @Override


### PR DESCRIPTION
fix bug recently introduced by #2988 

mailto/openpgp4fpr was not handled in openOnlineUrl() which caused it to be handled in interceptRequest() which only expects HTTP(S) requests

this also allows to open openpgp4fpr links (only mailto was supported in the past) as DC desktop does (what is needed by the [Public Bots Index](https://github.com/deltachat-bot/public-bots))

