### PR TITLE
don't say 'Done' when we do not know we're done

### DIFF
--- a/src/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -396,9 +396,8 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         .setIntents(getWebxdcIntentWithParentStack(context, msgId))
         .build();
 
-      if (ShortcutManagerCompat.requestPinShortcut(context, shortcutInfoCompat, null)) {
-        Toast.makeText(context, R.string.done, Toast.LENGTH_SHORT).show();
-      } else {
+      Toast.makeText(context, R.string.one_moment, Toast.LENGTH_SHORT).show();
+      if (!ShortcutManagerCompat.requestPinShortcut(context, shortcutInfoCompat, null)) {
         Toast.makeText(context, "ErrAddToHomescreen: requestPinShortcut() failed", Toast.LENGTH_LONG).show();
       }
     } catch(Exception e) {


### PR DESCRIPTION
adding a webxdc-shortcut to the home screen is sometimes a request only,
the user has to confirm and/or there is a subsequent dialog.

so, when `requestPinShortcut()` returns successfully, saying "Done" as the result of "Add to Home Screen" is often wrong from the view of the user.

however, some feedback is still needed for the cases there are no dialogs.

saying "One moment..." covers both cases sufficiently.

<img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/af39a215-98f0-4fe7-8924-5bbe3db9a677><br>
<i>this is a bit misleading</i>


(came over that when playing with webxdc  during review of https://github.com/deltachat/deltachat-android/pull/3008 )