### PR TITLE
adapt no-servers hint

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -576,7 +576,7 @@
     <string name="login_header">Log into your E-Mail Account</string>
     <string name="login_explain">Log in with an existing e-mail account</string>
     <string name="login_subheader">For known e-mail providers additional settings are set up automatically. Sometimes IMAP needs to be enabled in the web settings. Consult your e-mail provider or friends for help.</string>
-    <string name="login_no_servers_hint">There are no Delta Chat servers, your data stays on your device.</string>
+    <string name="login_no_servers_hint">Delta Chat does not collect user data, everything stays on your device.</string>
     <string name="login_inbox">Inbox</string>
     <string name="login_imap_login">IMAP Login Name</string>
     <string name="login_imap_server">IMAP Server</string>
@@ -597,7 +597,7 @@
     <string name="login_socks5_user">SOCKS5 User</string>
     <string name="login_socks5_password">SOCKS5 Password</string>
     <string name="login_info_oauth2_title">Continue with simplified setup?</string>
-    <string name="login_info_oauth2_text">The entered e-mail address supports a simplified setup (OAuth 2.0).\n\nIn the next step, please allow Delta Chat to act as your Chat over E-mail app.\n\nThere are no Delta Chat servers, your data stays on your device.</string>
+    <string name="login_info_oauth2_text">The entered e-mail address supports a simplified setup (OAuth 2.0).\n\nIn the next step, please allow Delta Chat to act as your Chat over E-mail app.\n\nDelta Chat does not collect user data, everything stays on your device.</string>
     <string name="login_certificate_checks">Certificate Checks</string>
     <string name="login_error_mail">Please enter a valid e-mail address</string>
     <string name="login_error_server">Please enter a valid server / IP address</string>


### PR DESCRIPTION
instead of saying that there are no Delta Chat servers, say that things are local only.

reason is the onboarding with the default chatmail server - and although they're probably not used when ppl go to this "Manual Setup", it is good to reword that in a form that cannot be misunderstood.

the key of the string stays as is, this makes changes in UI effortless - translators will see the change anyways.

before / after:

<img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/a9e7a802-edec-492d-8a41-b4bb837d6efd> <img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/a8b31985-f0fa-4afe-9b18-e4cde7a97e37>

closes https://github.com/deltachat/interface/issues/64