### PR TITLE
reorder settings

### DIFF
--- a/res/layout/profile_create_activity.xml
+++ b/res/layout/profile_create_activity.xml
@@ -82,19 +82,6 @@
         android:text="@string/pref_who_can_see_profile_explain"
         android:textColor="@color/gray50" />
 
-
-    <TextView
-        android:id="@+id/password_account_settings_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/pref_password_and_account_settings"
-        android:textColor="@color/delta_accent"
-        android:textSize="16sp"/>
-
     <org.thoughtcrime.securesms.components.emoji.MediaKeyboard
             xmlns:android="http://schemas.android.com/apk/res/android"
             android:id="@+id/emoji_drawer"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -677,6 +677,7 @@
     <string name="pref_incognito_keyboard_explain">Request keyboard to disable personalized learning</string>
     <string name="pref_read_receipts">Read Receipts</string>
     <string name="pref_read_receipts_explain">If read receipts are disabled, you won\'t be able to see read receipts from others.</string>
+    <string name="pref_encryption">Encryption</string>
     <string name="pref_manage_keys">Manage Keys</string>
     <string name="pref_use_system_emoji">Use System Emoji</string>
     <string name="pref_use_system_emoji_explain">Turn off Delta Chat\'s built-in emoji support</string>
@@ -802,7 +803,9 @@
     <string name="autodel_after_1_year">After 1 year</string>
 
     <!-- autocrypt -->
+    <!-- deprecated, used "Encryption" if a headline is needed -->
     <string name="autocrypt">Autocrypt</string>
+    <!-- deprecated, the button "Send Autocrypt Setup Message" is enough -->
     <string name="autocrypt_explain">Autocrypt is a new and open specification for automatic end-to-end e-mail encryption.\n\nYour end-to-end setup is created automatically as needed and you can transfer it between devices with Autocrypt Setup Messages.</string>
     <string name="autocrypt_send_asm_title">Send Autocrypt Setup Message</string>
     <string name="autocrypt_send_asm_explain_before">An Autocrypt Setup Message securely shares your end-to-end setup with other Autocrypt-compliant apps.\n\nThe setup will be encrypted by a setup code displayed here and must be typed on the other device.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -677,6 +677,7 @@
     <string name="pref_incognito_keyboard_explain">Request keyboard to disable personalized learning</string>
     <string name="pref_read_receipts">Read Receipts</string>
     <string name="pref_read_receipts_explain">If read receipts are disabled, you won\'t be able to see read receipts from others.</string>
+    <string name="pref_server">Server</string>
     <string name="pref_encryption">Encryption</string>
     <string name="pref_manage_keys">Manage Keys</string>
     <string name="pref_use_system_emoji">Use System Emoji</string>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -82,7 +82,7 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/manual_account_setup_option">
+    <PreferenceCategory android:title="@string/pref_server">
 
         <Preference android:key="password_account_settings_button"
             android:title="@string/pref_password_and_account_settings"/>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <PreferenceCategory android:title="@string/autocrypt">
+    <PreferenceCategory android:title="@string/pref_encryption">
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="pref_prefer_e2ee"
             android:title="@string/autocrypt_prefer_e2ee"/>
 
-        <Preference android:key="pref_send_autocrypt_setup_message"
-            android:title="@string/autocrypt_send_asm_title"
-            android:summary="@string/autocrypt_explain"/>
 
         <Preference android:key="pref_manage_keys"
             android:title="@string/pref_manage_keys"/>
+
+        <Preference android:key="pref_send_autocrypt_setup_message"
+            android:title="@string/autocrypt_send_asm_title"/>
 
     </PreferenceCategory>
 

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -2,15 +2,17 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <PreferenceCategory>
+    <ListPreference
+        android:key="pref_show_emails"
+        android:title="@string/pref_show_emails"
+        android:entries="@array/pref_show_emails_entries"
+        android:entryValues="@array/pref_show_emails_values" />
 
-        <Preference android:key="pref_view_log"
-            android:title="@string/pref_view_log"/>
+    <Preference android:key="pref_self_reporting"
+        android:title="@string/send_stats_to_devs"/>
 
-        <Preference android:key="pref_self_reporting"
-            android:title="@string/send_stats_to_devs"/>
-
-    </PreferenceCategory>
+    <Preference android:key="pref_view_log"
+        android:title="@string/pref_view_log"/>
 
     <PreferenceCategory android:title="@string/pref_experimental_features">
 

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -82,7 +82,10 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/pref_password_and_account_settings">
+    <PreferenceCategory android:title="@string/manual_account_setup_option">
+
+        <Preference android:key="password_account_settings_button"
+            android:title="@string/pref_password_and_account_settings"/>
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="true"

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -1,6 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory>
+
+        <Preference android:key="pref_view_log"
+            android:title="@string/pref_view_log"/>
+
+        <Preference android:key="pref_self_reporting"
+            android:title="@string/send_stats_to_devs"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/pref_experimental_features">
+
+        <Preference android:key="pref_webrtc_instance"
+            android:title="@string/videochat_instance"
+            android:summary="@string/none"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_new_broadcast_list"
+            android:title="@string/broadcast_lists"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_location_streaming_enabled"
+            android:title="@string/pref_on_demand_location_streaming"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_developer_mode_enabled"
+            android:summary="@string/pref_developer_mode_explain"
+            android:title="@string/pref_developer_mode"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/pref_app_access">
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_screen_security"
+            android:summary="@string/pref_screen_security_explain"
+            android:title="@string/pref_screen_security" />
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_incognito_keyboard"
+            android:summary="@string/pref_incognito_keyboard_explain"
+            android:title="@string/pref_incognito_keyboard" />
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_builtin_camera"
+            android:title="@string/pref_use_inapp_camera"
+            android:summary="@string/pref_use_inapp_camera_explain"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_show_system_contacts"
+            android:title="@string/pref_show_system_contacts"
+            android:summary="@string/pref_show_system_contacts_explain"/>
+
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/pref_encryption">
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
@@ -17,8 +80,7 @@
 
     </PreferenceCategory>
 
-
-    <PreferenceCategory android:title="@string/pref_imap_folder_handling">
+    <PreferenceCategory android:title="@string/pref_password_and_account_settings">
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="true"
@@ -44,65 +106,4 @@
 
     </PreferenceCategory>
 
-
-    <PreferenceCategory android:title="@string/pref_app_access">
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_screen_security"
-            android:summary="@string/pref_screen_security_explain"
-            android:title="@string/pref_screen_security" />
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_incognito_keyboard"
-            android:summary="@string/pref_incognito_keyboard_explain"
-            android:title="@string/pref_incognito_keyboard" />
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_builtin_camera"
-            android:title="@string/pref_use_inapp_camera"
-            android:summary="@string/pref_use_inapp_camera_explain"/>
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_show_system_contacts"
-            android:title="@string/pref_show_system_contacts"
-            android:summary="@string/pref_show_system_contacts_explain"/>
-    </PreferenceCategory>
-
-
-    <PreferenceCategory android:title="@string/pref_experimental_features">
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_new_broadcast_list"
-            android:title="@string/broadcast_lists"/>
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_location_streaming_enabled"
-            android:title="@string/pref_on_demand_location_streaming"/>
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_developer_mode_enabled"
-            android:summary="@string/pref_developer_mode_explain"
-            android:title="@string/pref_developer_mode"/>
-
-        <Preference android:key="pref_webrtc_instance"
-            android:title="@string/videochat_instance"
-            android:summary="@string/none"/>
-
-        <Preference android:key="pref_self_reporting"
-            android:title="@string/send_stats_to_devs"/>
-
-    </PreferenceCategory>
-
-
-    <PreferenceCategory android:title="@string/pref_other">
-
-        <Preference android:key="pref_view_log"
-                    android:title="@string/pref_view_log"/>
-    </PreferenceCategory>
 </PreferenceScreen>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-                  xmlns:tools="http://schemas.android.com/tools">
-
-    <ListPreference
-        android:key="pref_show_emails"
-        android:title="@string/pref_show_emails"
-        android:dependency="pref_show_emails"
-        android:entries="@array/pref_show_emails_entries"
-        android:entryValues="@array/pref_show_emails_values" />
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <Preference
         android:key="preference_category_blocked"

--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -43,7 +43,6 @@ import org.thoughtcrime.securesms.profiles.AvatarHelper;
 import org.thoughtcrime.securesms.profiles.ProfileMediaConstraints;
 import org.thoughtcrime.securesms.scribbles.ScribbleActivity;
 import org.thoughtcrime.securesms.util.Prefs;
-import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 import java.io.File;
@@ -162,16 +161,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
       case Crop.REQUEST_CROP:
         setAvatarView(Crop.getOutput(data));
         break;
-
-      case ScreenLockUtil.REQUEST_CODE_CONFIRM_CREDENTIALS:
-        openRegistrationActivity();
-        break;
     }
-  }
-
-  private void openRegistrationActivity() {
-    Intent intent = new Intent(this, RegistrationActivity.class);
-    startActivity(intent);
   }
 
   private void setAvatarView(Uri output) {
@@ -208,7 +198,6 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
   }
 
   private void initializeResources() {
-    TextView passwordAccountSettings       = ViewUtil.findById(this, R.id.password_account_settings_button);
     TextView loginSuccessText              = ViewUtil.findById(this, R.id.login_success_text);
     this.avatar       = ViewUtil.findById(this, R.id.avatar);
     this.name         = ViewUtil.findById(this, R.id.name_text);
@@ -216,19 +205,11 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Emoj
     this.container    = ViewUtil.findById(this, R.id.container);
     this.statusView   = ViewUtil.findById(this, R.id.status_text);
 
-    passwordAccountSettings.setOnClickListener(view -> {
-      boolean result = ScreenLockUtil.applyScreenLock(this, getString(R.string.pref_password_and_account_settings), getString(R.string.enter_system_secret_to_continue), ScreenLockUtil.REQUEST_CODE_CONFIRM_CREDENTIALS);
-      if (!result) {
-        openRegistrationActivity();
-      }
-    });
-
     if (fromWelcome) {
       String addr = DcHelper.get(this, "addr");
       loginSuccessText.setText(R.string.set_name_and_avatar_explain);
       ViewUtil.findById(this, R.id.status_text_layout).setVisibility(View.GONE);
       ViewUtil.findById(this, R.id.information_label).setVisibility(View.GONE);
-      passwordAccountSettings.setVisibility(View.GONE);
     } else {
       loginSuccessText.setVisibility(View.GONE);
     }

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -37,6 +37,7 @@ import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.LogViewActivity;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.RegistrationActivity;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.AttachmentManager;
@@ -197,6 +198,15 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
 
       return true;
     }));
+
+    Preference passwordAndAccount = this.findPreference("password_account_settings_button");
+    passwordAndAccount.setOnPreferenceClickListener(((preference) -> {
+      boolean result = ScreenLockUtil.applyScreenLock(getActivity(), getString(R.string.pref_password_and_account_settings), getString(R.string.enter_system_secret_to_continue), REQUEST_CODE_CONFIRM_CREDENTIALS_ACCOUNT);
+      if (!result) {
+        openRegistrationActivity();
+      }
+      return true;
+    }));
   }
 
   @Override
@@ -241,6 +251,8 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       } catch (IOException e) {
         e.printStackTrace();
       }
+    } else if (requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_ACCOUNT) {
+      openRegistrationActivity();
     }
   }
 
@@ -316,6 +328,11 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       webrtcInstance.setSummary(DcHelper.isWebrtcConfigOk(dcContext)?
               dcContext.getConfig(DcHelper.CONFIG_WEBRTC_INSTANCE) : getString(R.string.none));
     }
+  }
+
+  private void openRegistrationActivity() {
+    Intent intent = new Intent(getActivity(), RegistrationActivity.class);
+    startActivity(intent);
   }
 
   /***********************************************************************************************

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -7,6 +7,7 @@ import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_E2EE_ENABLED;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_MVBOX_MOVE;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ONLY_FETCH_MVBOX;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SENTBOX_WATCH;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SHOW_EMAILS;
 import static org.thoughtcrime.securesms.connect.DcHelper.getRpc;
 
 import android.Manifest;
@@ -26,6 +27,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.CheckBoxPreference;
+import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 
 import com.b44t.messenger.DcContext;
@@ -43,6 +45,7 @@ import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.StorageUtil;
 import org.thoughtcrime.securesms.util.StreamUtil;
+import org.thoughtcrime.securesms.util.Util;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -57,6 +60,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   private static final String TAG = AdvancedPreferenceFragment.class.getSimpleName();
   public static final int PICK_SELF_KEYS = 29923;
 
+  private ListPreference showEmails;
   CheckBoxPreference preferE2eeCheckbox;
   CheckBoxPreference sentboxWatchCheckbox;
   CheckBoxPreference bccSelfCheckbox;
@@ -67,6 +71,13 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   @Override
   public void onCreate(Bundle paramBundle) {
     super.onCreate(paramBundle);
+
+    showEmails = (ListPreference) this.findPreference("pref_show_emails");
+    showEmails.setOnPreferenceChangeListener((preference, newValue) -> {
+      updateListSummary(preference, newValue);
+      dcContext.setConfigInt(CONFIG_SHOW_EMAILS, Util.objectToInt(newValue));
+      return true;
+    });
 
     Preference sendAsm = this.findPreference("pref_send_autocrypt_setup_message");
     sendAsm.setOnPreferenceClickListener(new SendAsmListener());
@@ -197,6 +208,10 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   public void onResume() {
     super.onResume();
     ((ApplicationPreferencesActivity) getActivity()).getSupportActionBar().setTitle(R.string.menu_advanced);
+
+    String value = Integer.toString(dcContext.getConfigInt("show_emails"));
+    showEmails.setValue(value);
+    updateListSummary(showEmails, value);
 
     preferE2eeCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_E2EE_ENABLED));
     sentboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_SENTBOX_WATCH));

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -1,7 +1,6 @@
 package org.thoughtcrime.securesms.preferences;
 
 import static android.app.Activity.RESULT_OK;
-import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SHOW_EMAILS;
 
 import android.Manifest;
 import android.content.Context;
@@ -29,7 +28,6 @@ import org.thoughtcrime.securesms.util.ScreenLockUtil;
 import org.thoughtcrime.securesms.util.Util;
 
 public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
-  private ListPreference showEmails;
   private ListPreference mediaQuality;
   private ListPreference autoDownload;
   private CheckBoxPreference readReceiptsCheckbox;
@@ -57,13 +55,6 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     });
     nicerAutoDownloadNames();
 
-    showEmails = (ListPreference) this.findPreference("pref_show_emails");
-    showEmails.setOnPreferenceChangeListener((preference, newValue) -> {
-      updateListSummary(preference, newValue);
-      dcContext.setConfigInt(CONFIG_SHOW_EMAILS, Util.objectToInt(newValue));
-      return true;
-    });
-
     readReceiptsCheckbox = (CheckBoxPreference) this.findPreference("pref_read_receipts");
     readReceiptsCheckbox.setOnPreferenceChangeListener(new ReadReceiptToggleListener());
 
@@ -89,11 +80,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     super.onResume();
     ((ApplicationPreferencesActivity)getActivity()).getSupportActionBar().setTitle(R.string.pref_chats_and_media);
 
-    String value = Integer.toString(dcContext.getConfigInt("show_emails"));
-    showEmails.setValue(value);
-    updateListSummary(showEmails, value);
-
-    value = Integer.toString(dcContext.getConfigInt(DcHelper.CONFIG_MEDIA_QUALITY));
+    String value = Integer.toString(dcContext.getConfigInt(DcHelper.CONFIG_MEDIA_QUALITY));
     mediaQuality.setValue(value);
     updateListSummary(mediaQuality, value);
 
@@ -164,15 +151,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     String readReceiptState = dcContext.getConfigInt("mdns_enabled")!=0? onRes : offRes;
     boolean deleteOld = (dcContext.getConfigInt("delete_device_after")!=0 || dcContext.getConfigInt("delete_server_after")!=0);
 
-    String showEmails = "?";
-    switch (dcContext.getConfigInt("show_emails")) {
-      case DcContext.DC_SHOW_EMAILS_OFF: showEmails = offRes; break;
-      case DcContext.DC_SHOW_EMAILS_ACCEPTED_CONTACTS: showEmails = context.getString(R.string.pref_show_emails_accepted_contacts); break;
-      case DcContext.DC_SHOW_EMAILS_ALL: showEmails = context.getString(R.string.pref_show_emails_all); break;
-    }
-
-    String summary = context.getString(R.string.pref_show_emails) + " " + showEmails + ", " +
-      context.getString(R.string.pref_read_receipts) + " " + readReceiptState;
+    String summary = context.getString(R.string.pref_read_receipts) + " " + readReceiptState;
     if (deleteOld) {
       summary += ", " + context.getString(R.string.delete_old_messages) + " " + onRes;
     }

--- a/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public abstract class ListSummaryPreferenceFragment extends CorrectedPreferenceFragment implements DcEventCenter.DcEventDelegate {
   protected static final int REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP = ScreenLockUtil.REQUEST_CODE_CONFIRM_CREDENTIALS + 1;
   protected static final int REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS = REQUEST_CODE_CONFIRM_CREDENTIALS_BACKUP + 1;
+  protected static final int REQUEST_CODE_CONFIRM_CREDENTIALS_ACCOUNT = REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS + 1;
   protected DcContext dcContext;
   private NotificationController notificationController;
 


### PR DESCRIPTION
this PR is an outcome of an discussion with @hpk42 :

with the new instant onboarding, classic email move from "recommended workflow" to "supported workflow", meaning that the corresponding options should go to "advanced".

concretely, these are the options "show classic email" and "password & account".

moreover, this PR resorts the advanced settings so that the more important ones are shown first - so we start with **show-classic-mail/send/stats/log**, followed by **experimental** (we want ppl to try things out to get feedback), **app-access/encryption** (discouraged things) and finally **account/password/imap-options** (discouraged, often not needed - but bottommost is also not that bad for these kind of settings) (i know, AEAP is there, but that is not bulletproof enough to become a recommended workflow)

in a followup, we may hide imap-options completely for chatmail

https://github.com/deltachat/deltachat-android/assets/9800740/1314c39a-8534-4341-9a79-edc39cb93c64

when this is merger, we need to do a PR onto pages wrt changed positions (at least "Show all E-Mail" is mentioned there)
