### PR TITLE
fix bugs and some code cleanup

### DIFF
--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -20,6 +20,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -72,7 +73,6 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   private TextView privacyPolicyBtn;
   private Button signUpBtn;
 
-  private boolean fromWelcome;
   private boolean avatarChanged;
   private boolean imageLoaded;
   private String providerHost;
@@ -93,7 +93,19 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
     Objects.requireNonNull(getSupportActionBar()).setTitle(R.string.instant_onboarding_title);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-    fromWelcome  = getIntent().getBooleanExtra(FROM_WELCOME, false);
+    boolean fromWelcome  = getIntent().getBooleanExtra(FROM_WELCOME, false);
+    getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(!fromWelcome) {
+      @Override
+      public void handleOnBackPressed() {
+        AccountManager accountManager = AccountManager.getInstance();
+        if (accountManager.canRollbackAccountCreation(InstantOnboardingActivity.this)) {
+          accountManager.rollbackAccountCreation(InstantOnboardingActivity.this);
+        } else {
+          finish();
+        }
+      }
+    });
+
     isDcLogin = false;
     providerHost = DEFAULT_CHATMAIL_HOST;
     providerQrData = DCACCOUNT + ":https://" + providerHost + "/new";
@@ -116,16 +128,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   public boolean onOptionsItemSelected(@NonNull MenuItem item) {
     super.onOptionsItemSelected(item);
     if (item.getItemId() == android.R.id.home) {
-      if (fromWelcome) {
-        getOnBackPressedDispatcher().onBackPressed();
-      } else {
-        AccountManager accountManager = AccountManager.getInstance();
-        if (accountManager.canRollbackAccountCreation(this)) {
-          accountManager.rollbackAccountCreation(this);
-        } else {
-          getOnBackPressedDispatcher().onBackPressed();
-        }
-      }
+      getOnBackPressedDispatcher().onBackPressed();
       return true;
     }
     return false;

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -36,6 +36,7 @@ import com.google.zxing.integration.android.IntentResult;
 import com.soundcloud.android.crop.Crop;
 
 import org.thoughtcrime.securesms.components.AvatarSelector;
+import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.contacts.avatars.ResourceContactPhoto;
@@ -63,6 +64,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   private static final String DEFAULT_CHATMAIL_HOST = "nine.testrun.org";
 
   public static final String QR_ACCOUNT_EXTRA = "qr_account_extra";
+  public static final String FROM_WELCOME = "from_welcome";
   private static final int REQUEST_CODE_AVATAR = 1;
 
   private ImageView avatar;
@@ -70,6 +72,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   private TextView privacyPolicyBtn;
   private Button signUpBtn;
 
+  private boolean fromWelcome;
   private boolean avatarChanged;
   private boolean imageLoaded;
   private String providerHost;
@@ -90,6 +93,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
     Objects.requireNonNull(getSupportActionBar()).setTitle(R.string.instant_onboarding_title);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
+    fromWelcome  = getIntent().getBooleanExtra(FROM_WELCOME, false);
     isDcLogin = false;
     providerHost = DEFAULT_CHATMAIL_HOST;
     providerQrData = DCACCOUNT + ":https://" + providerHost + "/new";
@@ -112,7 +116,16 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   public boolean onOptionsItemSelected(@NonNull MenuItem item) {
     super.onOptionsItemSelected(item);
     if (item.getItemId() == android.R.id.home) {
-      getOnBackPressedDispatcher().onBackPressed();
+      if (fromWelcome) {
+        getOnBackPressedDispatcher().onBackPressed();
+      } else {
+        AccountManager accountManager = AccountManager.getInstance();
+        if (accountManager.canRollbackAccountCreation(this)) {
+          accountManager.rollbackAccountCreation(this);
+        } else {
+          getOnBackPressedDispatcher().onBackPressed();
+        }
+      }
       return true;
     }
     return false;

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -165,7 +165,9 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     }
 
     private void startInstantOnboardingActivity() {
-        startActivity(new Intent(this, InstantOnboardingActivity.class));
+        Intent intent = new Intent(this, InstantOnboardingActivity.class);
+        intent.putExtra(InstantOnboardingActivity.FROM_WELCOME, true);
+        startActivity(intent);
     }
 
     private void startAddAsSecondDeviceActivity() {

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -56,7 +56,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     public static final String TMP_BACKUP_FILE = "tmp-backup-file";
     public static final String DC_REQUEST_ACCOUNT_DATA = "chat.delta.DC_REQUEST_ACCOUNT_DATA";
 
-    private boolean manualConfigure = true; // false: configure by QR account creation
     private ProgressDialog progressDialog = null;
     private boolean imexUserAborted;
     DcContext dcContext;
@@ -161,7 +160,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     }
 
     private void startRegistrationActivity() {
-        manualConfigure = true;
         Intent intent = new Intent(this, RegistrationActivity.class);
         startActivity(intent);
     }
@@ -171,7 +169,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     }
 
     private void startAddAsSecondDeviceActivity() {
-        manualConfigure = false;
         new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class)
           .addExtra(RegistrationQrActivity.ADD_AS_SECOND_DEVICE_EXTRA, true)
           .initiateScan();

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class WelcomeActivity extends BaseActionBarActivity implements DcEventCenter.DcEventDelegate {
+    public static final String BACKUP_QR_EXTRA = "backup_qr_extra";
     public static final int PICK_BACKUP = 20574;
     private final static String TAG = WelcomeActivity.class.getSimpleName();
     public static final String TMP_BACKUP_FILE = "tmp-backup-file";
@@ -136,6 +137,16 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        String backupQr = getIntent().getStringExtra(BACKUP_QR_EXTRA);
+        if (backupQr != null) {
+            getIntent().removeExtra(BACKUP_QR_EXTRA);
+            startQrAccountCreation(backupQr);
+        }
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -144,7 +144,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         String backupQr = getIntent().getStringExtra(BACKUP_QR_EXTRA);
         if (backupQr != null) {
             getIntent().removeExtra(BACKUP_QR_EXTRA);
-            startQrAccountCreation(backupQr);
+            startBackupTransfer(backupQr);
         }
     }
 
@@ -301,38 +301,17 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         }
     }
 
-    private void startQrAccountCreation(String qrCode)
+    private void startBackupTransfer(String qrCode)
     {
         if (progressDialog!=null) {
             progressDialog.dismiss();
             progressDialog = null;
         }
 
-        if (dcContext.checkQr(qrCode).getState() == DcContext.DC_QR_BACKUP) {
-            Intent intent = new Intent(this, BackupTransferActivity.class);
-            intent.putExtra(BackupTransferActivity.TRANSFER_MODE, BackupTransferActivity.TransferMode.RECEIVER_SCAN_QR.getInt());
-            intent.putExtra(BackupTransferActivity.QR_CODE, qrCode);
-            startActivity(intent);
-            return;
-        }
-
-        progressDialog = new ProgressDialog(this);
-        progressDialog.setMessage(getResources().getString(R.string.one_moment));
-        progressDialog.setCanceledOnTouchOutside(false);
-        progressDialog.setCancelable(false);
-        progressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getResources().getString(android.R.string.cancel), (dialog, which) -> {
-            dcContext.stopOngoingProcess();
-        });
-        progressDialog.show();
-
-        DcHelper.getEventCenter(this).captureNextError();
-
-        if (!dcContext.setConfigFromQr(qrCode)) {
-            progressError(dcContext.getLastError());
-            return;
-        }
-        DcHelper.getAccounts(this).stopIo();
-        dcContext.configure();
+        Intent intent = new Intent(this, BackupTransferActivity.class);
+        intent.putExtra(BackupTransferActivity.TRANSFER_MODE, BackupTransferActivity.TransferMode.RECEIVER_SCAN_QR.getInt());
+        intent.putExtra(BackupTransferActivity.QR_CODE, qrCode);
+        startActivity(intent);
     }
 
     private void progressError(String data2) {
@@ -418,7 +397,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                     new AlertDialog.Builder(this)
                             .setTitle(R.string.multidevice_receiver_title)
                             .setMessage(R.string.multidevice_receiver_scanning_ask)
-                            .setPositiveButton(R.string.perm_continue, (dialog, which) -> startQrAccountCreation(qrRaw))
+                            .setPositiveButton(R.string.perm_continue, (dialog, which) -> startBackupTransfer(qrRaw))
                             .setNegativeButton(R.string.cancel, null)
                             .setCancelable(false)
                             .show();

--- a/src/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
 import com.b44t.messenger.DcAccounts;
@@ -116,6 +117,10 @@ public class AccountManager {
     }
 
     public void switchAccountAndStartActivity(Activity activity, int destAccountId) {
+        switchAccountAndStartActivity(activity, destAccountId, null);
+    }
+
+    private void switchAccountAndStartActivity(Activity activity, int destAccountId, @Nullable String backupQr) {
         if (destAccountId==0) {
             beginAccountCreation(activity);
         } else {
@@ -125,6 +130,9 @@ public class AccountManager {
         activity.finishAffinity();
         if (destAccountId==0) {
             Intent intent = new Intent(activity, WelcomeActivity.class);
+            if (backupQr != null) {
+                intent.putExtra(WelcomeActivity.BACKUP_QR_EXTRA, backupQr);
+            }
             activity.startActivity(intent);
         } else {
             activity.startActivity(new Intent(activity.getApplicationContext(), ConversationListActivity.class));
@@ -166,5 +174,9 @@ public class AccountManager {
         Intent intent = new Intent(activity, InstantOnboardingActivity.class);
         intent.putExtra(InstantOnboardingActivity.QR_ACCOUNT_EXTRA, qr);
         activity.startActivity(intent);
+    }
+
+    public void addAccountFromSecondDevice(Activity activity, String backupQr) {
+        switchAccountAndStartActivity(activity, 0, backupQr);
     }
 }

--- a/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -79,7 +79,7 @@ public class QrCodeHandler {
                 builder.setTitle(R.string.multidevice_receiver_title);
                 builder.setMessage(activity.getString(R.string.multidevice_receiver_scanning_ask) + "\n\n" + activity.getString(R.string.multidevice_same_network_hint));
                 builder.setPositiveButton(R.string.perm_continue, (dialog, which) -> {
-                  AccountManager.getInstance().addAccountFromQr(activity, rawString);
+                  AccountManager.getInstance().addAccountFromSecondDevice(activity, rawString);
                 });
                 builder.setNegativeButton(R.string.cancel, null);
                 builder.setCancelable(false);


### PR DESCRIPTION
- fix: when scanning "add as second device" QR code from chatlist's QR button open WelcomeActivity, not InstantOnboardingActivity
- fix: InstantOnboardingActivity: go back to chatlist when back button is pressed and we don't come from WelcomeActivity
- remove unused code in WelcomeActivity

followup of #3015 