### PR TITLE
Add link to Weblate into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ You have 2 ways to do this:
 
 2. Or set them via environment variables.
 
+# Translations
+
+Android metadata and changelogs are translated using [Weblate](https://hosted.weblate.org/projects/deltachat/android-metadata/).
+
 # Credits
 
 The user interface classes are based on the Signal messenger.


### PR DESCRIPTION
This is required for hosted weblate "Libre hosting" plan.
We currently have a project on Codeberg, but many translators are registered on hosted.weblate.org instead and it has GitHub integration, so better switch to hosted weblate.