### PR TITLE
fix: allow to share attachments from one chat to another

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -409,6 +409,11 @@
         android:grantUriPermissions="true"
         android:exported="false">
 
+      <!--
+          tell SafeContentResolver to allow incoming share-file Intent pointing to files from
+          this content resolver, it could be the user sharing a file from one chat to another.
+          See: https://github.com/deltachat/deltachat-android/pull/3031
+      -->
       <meta-data
           android:name="de.cketti.safecontentresolver.ALLOW_INTERNAL_ACCESS"
           android:value="true" />

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -408,6 +408,11 @@
         android:authorities="${applicationId}.attachments"
         android:grantUriPermissions="true"
         android:exported="false">
+
+      <meta-data
+          android:name="de.cketti.safecontentresolver.ALLOW_INTERNAL_ACCESS"
+          android:value="true" />
+
     </provider>
 
     <receiver android:name=".service.BootReceiver"


### PR DESCRIPTION
close #2999 


the issue was introduced in #2975 

the new dependency [SafeContentResolver ](https://github.com/cketti/SafeContentResolver?tab=readme-ov-file) says:

> Replace all occurrences of ContentResolver.openInputStream() where URIs provided by other apps are opened with SafeContentResolver.openInputStream().
>
> SafeContentResolver will refuse to open file:// URIs pointing to files belonging to your app and content:// URIs belonging to content providers of your app.
If you wish to allow access to certain content providers, add the following <meta-data> element to the appropriate <provider> entries in your manifest

so not only `file://` are rejected, also `content://` URIs are rejected if they point to content of the Delta Chat app, but this doesn't consider the situation when you want to share content from Delta Chat not to an outside app but to the app itself to share to another chat


SafeContentResolver says we can allow some content providers:

> If you wish to allow access to certain content providers, add the following <meta-data> element to the appropriate <provider> entries in your manifest:
```
<provider … >
    <meta-data
        android:name="de.cketti.safecontentresolver.ALLOW_INTERNAL_ACCESS"
        android:value="true" />
</provider>
```