### PR TITLE
add 'cancel' button to 'manage keys'

### DIFF
--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -434,6 +434,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
                     }
                   }
               )
+              .setNegativeButton(R.string.cancel, null)
               .show();
         })
         .execute();


### PR DESCRIPTION
this PR  adds a 'cancel' button to 'manage keys'; that was somehow missing

<img width=320 src=https://github.com/deltachat/deltachat-android/assets/9800740/e59b6cf1-4d67-4653-bf10-4efd4cb5863a>
