### PR TITLE
log if we receive onDeletedMessages()

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -82,6 +82,12 @@ public class FcmReceiveService extends FirebaseMessagingService {
   }
 
   @Override
+  public void onDeletedMessages() {
+    Log.i(TAG, "FCM push notifications dropped");
+    // nothing special to to as we're running now and notifications should be processed as usual.
+  }
+
+  @Override
   public void onNewToken(@NonNull String rawToken) {
     prefixedToken = addPrefix(rawToken);
     Log.i(TAG, "new FCM token: " + prefixedToken);

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -84,7 +84,7 @@ public class FcmReceiveService extends FirebaseMessagingService {
   @Override
   public void onDeletedMessages() {
     Log.i(TAG, "FCM push notifications dropped");
-    // nothing special to to as we're running now and notifications should be processed as usual.
+    // nothing special to do as we're running now and notifications should be processed as usual.
   }
 
   @Override


### PR DESCRIPTION
came over that, when trying to make sense why FCM onMessageReceived() is not called.

our current strategy is to just let the app run on received PUSH, however, it is useful to log this information for debugging

this is the corresponding code, btw ...

https://github.com/firebase/firebase-android-sdk/blob/2a75605db0cfac05c1634f911a0c1f7751599035/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java#L124

... i also tried to set a breakpoint in the handleIntent(), but even that is not called