### PR TITLE
disable APNG decoder

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/SignalGlideModule.java
+++ b/src/org/thoughtcrime/securesms/mms/SignalGlideModule.java
@@ -11,6 +11,8 @@ import com.bumptech.glide.Registry;
 import com.bumptech.glide.annotation.GlideModule;
 import com.bumptech.glide.load.model.UnitModelLoader;
 import com.bumptech.glide.module.AppGlideModule;
+import com.bumptech.glide.request.RequestOptions;
+import com.github.penfeizhou.animation.glide.AnimationDecoderOption;
 
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.thoughtcrime.securesms.glide.ContactPhotoLoader;
@@ -30,6 +32,7 @@ public class SignalGlideModule extends AppGlideModule {
   @Override
   public void applyOptions(Context context, GlideBuilder builder) {
     builder.setLogLevel(Log.ERROR);
+    builder.setDefaultRequestOptions(new RequestOptions().set(AnimationDecoderOption.DISABLE_ANIMATION_APNG_DECODER, true));
 //    builder.setDiskCache(new NoopDiskCacheFactory());
   }
 


### PR DESCRIPTION
close #2957 

the APNG decoder is too problematic and has caused similar "blank images" due to other bugs in normal PNG in the past, as APNG images are kind of rare and not widely supported (they are animated PNG but also at the same time can be displayed as  normal still PNG) it is better to disable the decoder and just display APNG as normal PNG

I reported the bug to upstream in https://github.com/penfeizhou/APNG4Android/issues/217 if eventually it gets more stable or does fallback to PNG in case the APNG decoder  fails, we can reconsider enabling it again

## Before

![image](https://github.com/deltachat/deltachat-android/assets/24558636/383da8dc-3b2b-4dda-88b8-cb159fe1de13)

 ## After

![image](https://github.com/deltachat/deltachat-android/assets/24558636/5c561b09-9404-48e3-ad2d-17e814d8c5c0)
