### PR TITLE
add strings for new 'please wait' securejoin flow

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -960,7 +960,7 @@
     <!-- placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_replies">%1$s replied, waiting for being added to the group…</string>
     <string name="secure_join_wait">Establishing guaranteed end-to-end encryption, please wait…</string>
-    <string name="secure_join_wait_timeout">Could not yet establish guaranteed end-to-end encryption, but you may already send a message</string>
+    <string name="secure_join_wait_timeout">Could not yet establish guaranteed end-to-end encryption, but you may already send a message.</string>
     <string name="contact_verified">%1$s introduced.</string>
     <string name="contact_not_verified">Cannot establish guaranteed end-to-end encryption with %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -959,6 +959,8 @@
     <string name="secure_join_started">%1$s invited you to join this group.\n\nWaiting for the device of %2$s to reply…</string>
     <!-- placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_replies">%1$s replied, waiting for being added to the group…</string>
+    <string name="secure_join_wait">Establishing guaranteed end-to-end encryption, please wait…</string>
+    <string name="secure_join_wait_timeout">Could not yet establish guaranteed end-to-end encryption, but you may already send a message</string>
     <string name="contact_verified">%1$s introduced.</string>
     <string name="contact_not_verified">Cannot establish guaranteed end-to-end encryption with %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->

--- a/src/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -258,6 +258,8 @@ public class DcHelper {
     dcContext.setStockTranslation(174, context.getString(R.string.invalid_unencrypted_tap_to_learn_more));
     dcContext.setStockTranslation(176, context.getString(R.string.reaction_by_you));
     dcContext.setStockTranslation(177, context.getString(R.string.reaction_by_other));
+    dcContext.setStockTranslation(190, context.getString(R.string.secure_join_wait));
+    dcContext.setStockTranslation(191, context.getString(R.string.secure_join_wait_timeout));
   }
 
   public static File getImexDir() {


### PR DESCRIPTION
this PR adds the strings for the new 'please wait' securejoin flow.

background: when https://github.com/deltachat/deltachat-core-rust/pull/5550 gets merged, a one-to-one chat is read only the first seconds:

 - **either** until the protocol finishes. if both devices are line and connection is fine already after 1 or 2 seconds, this should be how things should usually go:<br><img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/55519a34-6c8f-4024-a20b-2c86f22faa76>
 
 - **or**, on bad network or if devices are offline, we start with the same "please wait" message (we do not know yet that things will last) - after 15 seconds sending is allowed, but ppl will get a warning and can message already - if devices get online again or network gets better, also then in the "guaranteed e2ee" is shown. this looks as follows: <img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/dbc29ea4-5319-4a9d-b0b8-6596272cee16> <img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/da987a30-07e4-452c-97d5-595e90bc700e> <img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/0d6f14ec-a504-4db2-b599-cd03506e76d1>


