### PR TITLE
hide IMAP folder options on chatmail

### DIFF
--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -136,8 +136,6 @@ public class DcContext {
     public native boolean      setConfigFromQr      (String qr);
     public native String       getConfig            (String key);
     public int                 getConfigInt         (String key) { try{return Integer.parseInt(getConfig(key));} catch(Exception e) {} return 0; }
-    @Deprecated public String  getConfig            (String key, String def) { return getConfig(key); }
-    @Deprecated public int     getConfigInt         (String key, int def) { return getConfigInt(key); }
     public native String       getInfo              ();
     public native int          getConnectivity      ();
     public native String       getConnectivityHtml  ();

--- a/src/com/b44t/messenger/DcContext.java
+++ b/src/com/b44t/messenger/DcContext.java
@@ -230,6 +230,10 @@ public class DcContext {
       return ret.trim();
     }
 
+    public boolean isChatmail() {
+      return getConfigInt("is_chatmail") == 1;
+    }
+
     /**
      * @return true if at least one chat has location streaming enabled
      */

--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -116,7 +116,7 @@ public class ContactSelectionListFragment extends    Fragment
   public void onStart() {
     super.onStart();
     this.getLoaderManager().initLoader(0, null, this);
-    if (dcContext.getConfigInt("ui.android.show_system_contacts") != 0) {
+    if (dcContext.getConfigInt("ui.android.show_system_contacts") != 0 && !dcContext.isChatmail()) {
       Permissions.with(this)
         .request(Manifest.permission.READ_CONTACTS)
         .ifNecessary()

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -207,6 +207,13 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       }
       return true;
     }));
+
+    if (dcContext.isChatmail()) {
+      sentboxWatchCheckbox.setVisible(false);
+      bccSelfCheckbox.setVisible(false);
+      mvboxMoveCheckbox.setVisible(false);
+      onlyFetchMvboxCheckbox.setVisible(false);
+    }
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -209,6 +209,8 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     }));
 
     if (dcContext.isChatmail()) {
+      preferE2eeCheckbox.setVisible(false);
+      showSystemContacts.setVisible(false);
       sentboxWatchCheckbox.setVisible(false);
       bccSelfCheckbox.setVisible(false);
       mvboxMoveCheckbox.setVisible(false);


### PR DESCRIPTION
this PR makes use of the `is_chatmail` config introduced by https://github.com/deltachat/deltachat-core-rust/pull/5567 and hides the IMAP folder options.

~~for whatever reason, `is_chatmail` is currently always `0` (also in "View Log" which is generated by core directly),  might be things are not rolled out yet.~~ EDIT: works now, see below

this is what it will look like:

<img width="299" alt="Screenshot 2024-05-14 at 23 19 00" src="https://github.com/deltachat/deltachat-android/assets/9800740/c1544bcd-e824-46f3-a975-613187e2bfd6"> &nbsp; <img width="294" alt="Screenshot 2024-05-15 at 00 54 22" src="https://github.com/deltachat/deltachat-android/assets/9800740/862e115a-75b7-40da-ba86-006337033ed6"> <br><i>left: chatmail=0, right: chatmail=1</i>


targets https://github.com/deltachat/deltachat-core-rust/issues/5380

when this PR gets merged, we need to file issues/PR for the same change on desktop/ios