### PR TITLE
move 'manual log in' to 'create profile'

### DIFF
--- a/res/layout/instant_onboarding_activity.xml
+++ b/res/layout/instant_onboarding_activity.xml
@@ -101,24 +101,12 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           app:layout_constraintStart_toEndOf="@+id/other_options_button"
-          app:layout_constraintEnd_toStartOf="@+id/scan_qr_button"
+          app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
           app:layout_constraintBottom_toBottomOf="parent"
           android:paddingLeft="16dp"
           android:paddingRight="16dp" />
 
-      <TextView
-          android:id="@+id/scan_qr_button"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          app:layout_constraintStart_toEndOf="@+id/separator"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintTop_toTopOf="parent"
-          app:layout_constraintBottom_toBottomOf="parent"
-          android:gravity="end"
-          android:padding="16dp"
-          android:text="@string/qrscan_title"
-          android:textColor="@color/gray50"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
   </LinearLayout>

--- a/res/layout/instant_onboarding_activity.xml
+++ b/res/layout/instant_onboarding_activity.xml
@@ -71,24 +71,17 @@
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
         android:layout_marginTop="20dp"
-        android:layout_marginBottom="16dp"
         android:text="@string/instant_onboarding_create"/>
 
-    <androidx.legacy.widget.Space
-        android:layout_weight="2"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"/>
-
-    <TextView
+    <Button
+        style="@style/ButtonSecondary"
         android:id="@+id/other_options_button"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:layout_marginBottom="16dp"
-        android:padding="16dp"
-        android:text="@string/instant_onboarding_show_more_instances"
-        android:textColor="@color/delta_accent"
-        android:textSize="16sp"/>
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:layout_margin="16dp"
+        android:text="@string/instant_onboarding_show_more_instances" />
 
   </LinearLayout>
 

--- a/res/layout/instant_onboarding_activity.xml
+++ b/res/layout/instant_onboarding_activity.xml
@@ -79,35 +79,16 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"/>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-      <TextView
-          android:id="@+id/other_options_button"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintEnd_toStartOf="@+id/separator"
-          app:layout_constraintTop_toTopOf="parent"
-          app:layout_constraintBottom_toBottomOf="parent"
-          android:gravity="start"
-          android:padding="16dp"
-          android:text="@string/instant_onboarding_show_more_instances"
-          android:textColor="@color/gray50"/>
-
-      <androidx.legacy.widget.Space
-          android:id="@+id/separator"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          app:layout_constraintStart_toEndOf="@+id/other_options_button"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintTop_toTopOf="parent"
-          app:layout_constraintBottom_toBottomOf="parent"
-          android:paddingLeft="16dp"
-          android:paddingRight="16dp" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    <TextView
+        android:id="@+id/other_options_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginBottom="16dp"
+        android:padding="16dp"
+        android:text="@string/instant_onboarding_show_more_instances"
+        android:textColor="@color/delta_accent"
+        android:textSize="16sp"/>
 
   </LinearLayout>
 

--- a/res/layout/instant_onboarding_activity.xml
+++ b/res/layout/instant_onboarding_activity.xml
@@ -57,7 +57,7 @@
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
         android:layout_marginTop="16dp"
-        android:text="@string/instant_onboarding_agree_default"
+        android:text=""
         android:textColor="@color/delta_accent"
         android:textSize="16sp"/>
 

--- a/res/layout/login_options_view.xml
+++ b/res/layout/login_options_view.xml
@@ -35,15 +35,6 @@
         android:layout_marginBottom="16dp"
         android:text="@string/import_backup_title"/>
 
-    <Button
-        style="@style/ButtonSecondary"
-        android:id="@+id/login_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingLeft="24dp"
-        android:paddingRight="24dp"
-        android:text="@string/manual_account_setup_option"/>
-
   </LinearLayout>
 
 </ScrollView>

--- a/res/layout/signup_options_view.xml
+++ b/res/layout/signup_options_view.xml
@@ -32,7 +32,17 @@
         android:layout_height="wrap_content"
         android:paddingLeft="24dp"
         android:paddingRight="24dp"
+        android:layout_marginBottom="16dp"
         android:text="@string/manual_account_setup_option"/>
+
+    <Button
+        style="@style/ButtonSecondary"
+        android:id="@+id/scan_qr_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="24dp"
+        android:paddingRight="24dp"
+        android:text="@string/qrscan_title"/>
 
   </LinearLayout>
 

--- a/res/layout/signup_options_view.xml
+++ b/res/layout/signup_options_view.xml
@@ -42,7 +42,7 @@
         android:layout_height="wrap_content"
         android:paddingLeft="24dp"
         android:paddingRight="24dp"
-        android:text="@string/qrscan_title"/>
+        android:text="@string/scan_invitation_code"/>
 
   </LinearLayout>
 

--- a/res/layout/signup_options_view.xml
+++ b/res/layout/signup_options_view.xml
@@ -17,23 +17,13 @@
 
     <Button
         style="@style/ButtonSecondary"
-        android:id="@+id/add_as_second_device_button"
+        android:id="@+id/use_other_server"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingLeft="24dp"
         android:paddingRight="24dp"
         android:layout_marginBottom="16dp"
-        android:text="@string/multidevice_receiver_title"/>
-
-    <Button
-        style="@style/ButtonSecondary"
-        android:id="@+id/backup_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingLeft="24dp"
-        android:paddingRight="24dp"
-        android:layout_marginBottom="16dp"
-        android:text="@string/import_backup_title"/>
+        android:text="@string/instant_onboarding_other_server"/>
 
     <Button
         style="@style/ButtonSecondary"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -563,6 +563,7 @@
     <string name="instant_onboarding_create">Agree &amp; Create Profile</string>
     <!-- Secondary, link-like button to open a page with other possible instances -->
     <string name="instant_onboarding_show_more_instances">Explore Other Options</string>
+    <string name="instant_onboarding_other_server">Browse Other Servers</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by the group name -->
     <string name="instant_onboarding_group_info">Create a profile to join the group \"%1$s\".</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by contact name and/or address -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -549,10 +549,10 @@
     <!-- welcome and login -->
     <!-- Primary button on the welcome screen, allows to create an instant profile -->
     <string name="onboarding_create_instant_account">Create New Profile</string>
-    <!-- Secondary button on the welcome screen, allows to "Add as Second Device", "Restore from Backup", "Manual Login"  -->
+    <!-- Secondary button on the welcome screen, allows to "Add as Second Device", "Restore from Backup"  -->
     <string name="onboarding_alternative_logins">I Already Have a Profile</string>
     <!-- Button, allows to log in to existing email accounts, setting ports, passwords and so on -->
-    <string name="manual_account_setup_option">Log In Manually</string>
+    <string name="manual_account_setup_option">Classic Login</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
     <string name="instant_onboarding_title">Your Profile</string>
     <!-- This is a link to the default Privacy Policy -->
@@ -562,8 +562,8 @@
     <!-- Confirmation button on the instant onboarding screen -->
     <string name="instant_onboarding_create">Agree &amp; Create Profile</string>
     <!-- Secondary, link-like button to open a page with other possible instances -->
-    <string name="instant_onboarding_show_more_instances">Explore Other Options</string>
-    <string name="instant_onboarding_other_server">Browse Other Servers</string>
+    <string name="instant_onboarding_show_more_instances">Use Other Server</string>
+    <string name="instant_onboarding_other_server">List in Browser</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by the group name -->
     <string name="instant_onboarding_group_info">Create a profile to join the group \"%1$s\".</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by contact name and/or address -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -565,7 +565,7 @@
     <string name="instant_onboarding_create">Agree &amp; Create Profile</string>
     <!-- Secondary, link-like button to open a page with other possible instances -->
     <string name="instant_onboarding_show_more_instances">Use Other Server</string>
-    <string name="instant_onboarding_other_server">List in Browser</string>
+    <string name="instant_onboarding_other_server">List Chatmail Servers</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by the group name -->
     <string name="instant_onboarding_group_info">Create a profile to join the group \"%1$s\".</string>
     <!-- Hint about what happens when "Create Profile" button in pressed; the placeholder will be replaced by contact name and/or address -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -552,7 +552,7 @@
     <!-- Secondary button on the welcome screen, allows to "Add as Second Device", "Restore from Backup"  -->
     <string name="onboarding_alternative_logins">I Already Have a Profile</string>
     <!-- Button, allows to log in to existing email accounts, setting ports, passwords and so on -->
-    <string name="manual_account_setup_option">Classic Login</string>
+    <string name="manual_account_setup_option">Classic E-Mail Login</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
     <string name="instant_onboarding_title">Your Profile</string>
     <!-- deprecated -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -555,8 +555,10 @@
     <string name="manual_account_setup_option">Classic Login</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
     <string name="instant_onboarding_title">Your Profile</string>
-    <!-- This is a link to the default Privacy Policy -->
+    <!-- deprecated -->
     <string name="instant_onboarding_agree_default">Read the Privacy Policy</string>
+    <!-- The placeholder will be replaced by the default onboarding server -->
+    <string name="instant_onboarding_agree_default2">Privacy Policy for %1$s</string>
     <!-- The placeholder will be replaced by instance name, the whole text will link to the instance page -->
     <string name="instant_onboarding_agree_instance">About profiles on %1$s</string>
     <!-- Confirmation button on the instant onboarding screen -->

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -283,10 +283,15 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
       signUpDialog.dismiss();
     });
     view.findViewById(R.id.login_button).setOnClickListener((v) -> {
-      // startRegistrationActivity();
+      startRegistrationActivity();
       signUpDialog.dismiss();
     });
     signUpDialog.show();
+  }
+
+  private void startRegistrationActivity() {
+    Intent intent = new Intent(this, RegistrationActivity.class);
+    startActivity(intent);
   }
 
   private void updateProvider() {

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -14,6 +14,7 @@ import android.text.TextUtils;
 import android.text.util.Linkify;
 import android.util.Log;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -265,9 +266,27 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
     signUpBtn.setOnClickListener(view -> createProfile());
 
     TextView otherOptionsBtn = findViewById(R.id.other_options_button);
-    otherOptionsBtn.setOnClickListener(view -> WebViewActivity.openUrlInBrowser(this, INSTANCES_URL));
+    otherOptionsBtn.setOnClickListener(view -> showOtherOptionsDialog());
     TextView scanQrBtn = findViewById(R.id.scan_qr_button);
     scanQrBtn.setOnClickListener(view -> new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan());
+  }
+
+  private void showOtherOptionsDialog() {
+    View view = View.inflate(this, R.layout.signup_options_view, null);
+    AlertDialog signUpDialog = new AlertDialog.Builder(this)
+      .setView(view)
+      .setTitle(R.string.pref_profile_info_headline)
+      .setNegativeButton(R.string.cancel, null)
+      .create();
+    view.findViewById(R.id.use_other_server).setOnClickListener((v) -> {
+      WebViewActivity.openUrlInBrowser(this, INSTANCES_URL);
+      signUpDialog.dismiss();
+    });
+    view.findViewById(R.id.login_button).setOnClickListener((v) -> {
+      // startRegistrationActivity();
+      signUpDialog.dismiss();
+    });
+    signUpDialog.show();
   }
 
   private void updateProvider() {

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -267,8 +267,6 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
 
     TextView otherOptionsBtn = findViewById(R.id.other_options_button);
     otherOptionsBtn.setOnClickListener(view -> showOtherOptionsDialog());
-    TextView scanQrBtn = findViewById(R.id.scan_qr_button);
-    scanQrBtn.setOnClickListener(view -> new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan());
   }
 
   private void showOtherOptionsDialog() {
@@ -278,6 +276,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
       .setTitle(R.string.onboarding_create_instant_account)
       .setNegativeButton(R.string.cancel, null)
       .create();
+
     view.findViewById(R.id.use_other_server).setOnClickListener((v) -> {
       WebViewActivity.openUrlInBrowser(this, INSTANCES_URL);
       signUpDialog.dismiss();
@@ -286,6 +285,10 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
       startRegistrationActivity();
       signUpDialog.dismiss();
     });
+    view.findViewById(R.id.scan_qr_button).setOnClickListener((v) ->
+      new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan()
+    );
+
     signUpDialog.show();
   }
 

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -116,6 +116,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
     initializeResources();
     initializeProfileAvatar();
     handleIntent();
+    updateProvider();
   }
 
   @Override
@@ -306,7 +307,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
       signUpBtn.setText(R.string.instant_onboarding_create);
       privacyPolicyBtn.setTextColor(getResources().getColor(R.color.delta_accent));
       if (DEFAULT_CHATMAIL_HOST.equals(providerHost)) {
-        privacyPolicyBtn.setText(R.string.instant_onboarding_agree_default);
+        privacyPolicyBtn.setText(getString(R.string.instant_onboarding_agree_default2, providerHost));
       } else {
         privacyPolicyBtn.setText(getString(R.string.instant_onboarding_agree_instance, providerHost));
       }

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -265,7 +265,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
 
     signUpBtn.setOnClickListener(view -> createProfile());
 
-    TextView otherOptionsBtn = findViewById(R.id.other_options_button);
+    Button otherOptionsBtn = findViewById(R.id.other_options_button);
     otherOptionsBtn.setOnClickListener(view -> showOtherOptionsDialog());
   }
 

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -273,7 +273,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
     View view = View.inflate(this, R.layout.signup_options_view, null);
     AlertDialog signUpDialog = new AlertDialog.Builder(this)
       .setView(view)
-      .setTitle(R.string.onboarding_create_instant_account)
+      .setTitle(R.string.instant_onboarding_show_more_instances)
       .setNegativeButton(R.string.cancel, null)
       .create();
 

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -286,9 +286,10 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
       startRegistrationActivity();
       signUpDialog.dismiss();
     });
-    view.findViewById(R.id.scan_qr_button).setOnClickListener((v) ->
-      new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan()
-    );
+    view.findViewById(R.id.scan_qr_button).setOnClickListener((v) -> {
+      new IntentIntegrator(this).setCaptureActivity(RegistrationQrActivity.class).initiateScan();
+      signUpDialog.dismiss();
+    });
 
     signUpDialog.show();
   }

--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -91,7 +91,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
 
     setContentView(R.layout.instant_onboarding_activity);
 
-    Objects.requireNonNull(getSupportActionBar()).setTitle(R.string.instant_onboarding_title);
+    Objects.requireNonNull(getSupportActionBar()).setTitle(R.string.onboarding_create_instant_account);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
     boolean fromWelcome  = getIntent().getBooleanExtra(FROM_WELCOME, false);
@@ -275,7 +275,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
     View view = View.inflate(this, R.layout.signup_options_view, null);
     AlertDialog signUpDialog = new AlertDialog.Builder(this)
       .setView(view)
-      .setTitle(R.string.pref_profile_info_headline)
+      .setTitle(R.string.onboarding_create_instant_account)
       .setNegativeButton(R.string.cancel, null)
       .create();
     view.findViewById(R.id.use_other_server).setOnClickListener((v) -> {

--- a/src/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -83,10 +83,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
           startImportBackup();
           signInDialog.dismiss();
         });
-        view.findViewById(R.id.login_button).setOnClickListener((v) -> {
-          startRegistrationActivity();
-          signInDialog.dismiss();
-        });
 
         signUpButton.setOnClickListener((v) -> startInstantOnboardingActivity());
         signInButton.setOnClickListener((v) -> signInDialog.show());
@@ -157,11 +153,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
         Permissions.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
-    }
-
-    private void startRegistrationActivity() {
-        Intent intent = new Intent(this, RegistrationActivity.class);
-        startActivity(intent);
     }
 
     private void startInstantOnboardingActivity() {


### PR DESCRIPTION
after some internal discussion with @link2xt @hpk42 @adbenitez, "Manual Log In" still creates a client-side profile on the client, and therefore it makes some sense to move it to the first "Create New Profile" button.

this makes the "i already have a log in" pretty bulletproof, also, it seems less probable ppl will try to somehow manually login there. idea is also that ppl will less often "just so manually log in" - as the "create new profile" is sth else than "log in". but well, user testing will tell.

moreover, this PR takes the chance to move the "scan qr code" button to "other options" as well.

"explorer other options" is a bit more visible as before (where the text was smaller and gray), however, by its position still  pretty much tuned down; this is on purpose as the user really needs to know what to do or it is sth where we do not want to push users to.

however, we can also easily make the "explorer other options" a regular secondary button if we get feedback that it is too hard to discover.

in a subsequent PR we may refine the menu or so, but it seems already a good start if we still think it is a good idea tomorrow :)

<img width="230" alt="Screenshot 2024-05-18 at 00 22 55" src="https://github.com/deltachat/deltachat-android/assets/9800740/8eb850c4-2d80-4829-922e-7577e416672d">
<img width="230" alt="Screenshot 2024-05-18 at 13 26 46" src="https://github.com/deltachat/deltachat-android/assets/9800740/07c994e1-3d93-48b9-99a9-8dbd88a400ed">
<img width="230" alt="Screenshot 2024-05-18 at 13 56 41" src="https://github.com/deltachat/deltachat-android/assets/9800740/115f3f38-2265-41a8-8149-91b4f9a018bf">

cc @kermoshina 