### PR TITLE
show the device-update-message only once, not on every account switch

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -126,7 +126,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
             + "🔧 Old device users: It is known hat the app currently crashes on android4 - if you also encounter crashes on android5 or if it runs for you on android4 - please report, we really need feedback here as testing for us devs becomes harder and harder over time\n\n"
             + "For more changes worth testing see https://delta.chat/changelog");
         //}
-        int msgId = dcContext.addDeviceMsg(deviceMsgId, msg);
+        dcContext.addDeviceMsg(deviceMsgId, msg);
 
         if (Prefs.getStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, "").equals(deviceMsgId)) {
           int deviceChatId = dcContext.getChatIdByContactId(DcContact.DC_CONTACT_ID_DEVICE);

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -105,7 +105,8 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     try {
       DcContext dcContext = DcHelper.getContext(this);
       final String deviceMsgId = "update_1_45c_android";
-      if (!dcContext.wasDeviceMsgEverAdded(deviceMsgId)) {
+      if (!Prefs.getStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, "").equals(deviceMsgId)
+       && !dcContext.wasDeviceMsgEverAdded(deviceMsgId)) {
         DcMsg msg = null;
         //if (!getIntent().getBooleanExtra(FROM_WELCOME, false)) { -- UNCOMMENT on RELEASES
           msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
@@ -127,6 +128,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
             + "For more changes worth testing see https://delta.chat/changelog");
         //}
         dcContext.addDeviceMsg(deviceMsgId, msg);
+        Prefs.setStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, deviceMsgId);
       }
     } catch(Exception e) {
       e.printStackTrace();

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -105,8 +105,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     try {
       DcContext dcContext = DcHelper.getContext(this);
       final String deviceMsgId = "update_1_45c_android";
-      if (!Prefs.getStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, "").equals(deviceMsgId)
-       && !dcContext.wasDeviceMsgEverAdded(deviceMsgId)) {
+      if (!dcContext.wasDeviceMsgEverAdded(deviceMsgId)) {
         DcMsg msg = null;
         //if (!getIntent().getBooleanExtra(FROM_WELCOME, false)) { -- UNCOMMENT on RELEASES
           msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
@@ -127,7 +126,14 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
             + "🔧 Old device users: It is known hat the app currently crashes on android4 - if you also encounter crashes on android5 or if it runs for you on android4 - please report, we really need feedback here as testing for us devs becomes harder and harder over time\n\n"
             + "For more changes worth testing see https://delta.chat/changelog");
         //}
-        dcContext.addDeviceMsg(deviceMsgId, msg);
+        int msgId = dcContext.addDeviceMsg(deviceMsgId, msg);
+
+        if (Prefs.getStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, "").equals(deviceMsgId)) {
+          int deviceChatId = dcContext.getChatIdByContactId(DcContact.DC_CONTACT_ID_DEVICE);
+          if (deviceChatId != 0) {
+            dcContext.marknoticedChat(deviceChatId);
+          }
+        }
         Prefs.setStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, deviceMsgId);
       }
     } catch(Exception e) {

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -64,6 +64,8 @@ public class Prefs {
   public  static final String  ALWAYS_LOAD_REMOTE_CONTENT = "pref_always_load_remote_content";
   public  static final boolean ALWAYS_LOAD_REMOTE_CONTENT_DEFAULT = false;
 
+  public  static final String LAST_DEVICE_MSG_ID               = "pref_last_device_msg_id";
+
   public enum VibrateState {
     DEFAULT(0), ENABLED(1), DISABLED(2);
     private final int id;


### PR DESCRIPTION
otherwise, the message pops up again on every account switch, which is quite annoying