### PR TITLE
tweak asking for "disable battery optimisations"

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -221,6 +221,8 @@ public class ConversationListFragment extends BaseConversationListFragment
                 dcContext.addDeviceMsg("android.notifications-disabled", msg);
               })
               .execute();
+          } else {
+            DozeReminder.maybeAskDirectly(activity);
           }
         } else {
           DozeReminder.maybeAskDirectly(activity);

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -45,6 +45,7 @@ import org.thoughtcrime.securesms.components.reminder.DozeReminder;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.notifications.FcmReceiveService;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.RelayUtil;
@@ -196,6 +197,7 @@ public class ConversationListFragment extends BaseConversationListFragment
           if (DozeReminder.isEligible(context)) {
             DozeReminder.addDozeReminderDeviceMsg(context);
           }
+          FcmReceiveService.waitForRegisterFinished();
         } catch (Exception e) {
           e.printStackTrace();
         }


### PR DESCRIPTION
do not ask for "disable battery optimisations" when all accounts are chatmail _and_ we got a push token.

with chatmail, we reduced the number of questions from three to only one (or zero for android<=12):

<img width="250" alt="Screenshot 2024-05-21 at 01 16 19" src="https://github.com/deltachat/deltachat-android/assets/9800740/3d49f796-2b59-4546-9578-94ffa3532202">

if classic mail is used, the following questions follow - either for the first account, but also anytime later when a non-chatmail is added:

<img width="250" alt="Screenshot 2024-05-21 at 01 16 30" src="https://github.com/deltachat/deltachat-android/assets/9800740/ce74acf2-741b-46be-b5fa-0fb782c3a462"> <img width="250" alt="Screenshot 2024-05-21 at 01 16 35" src="https://github.com/deltachat/deltachat-android/assets/9800740/b3af34d9-4cf8-4356-b50f-c1ca84111dbf">



the push token, however, is got unconditionally from the other states - it is a cheap call, the device is connected to the PUSH server anyways and we want to leave it up to core what to do with it