### PR TITLE
allow to delete the selected account

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
@@ -62,7 +62,7 @@ public class AccountSelectionListItem extends LinearLayout {
 
     Recipient recipient;
     if (accountId != DcContact.DC_CONTACT_ID_ADD_ACCOUNT) {
-      deleteBtn.setVisibility(selected? View.INVISIBLE : View.VISIBLE);
+      deleteBtn.setVisibility(View.VISIBLE);
       recipient = new Recipient(getContext(), self, name);
     } else {
       deleteBtn.setVisibility(View.GONE);


### PR DESCRIPTION
not allowing to delete the selected account forces users to switch to another account after reviewing that an account can be deleted - then, in the list, they have to pick the correct account to delete, which can be challenging and is error-prone.

it is better to just allow deletion of the selected account (i think it was introduced for technical reasons)

todo:

- [x] show the delete account button unconditionally
- [ ] handle last account deletion
- [ ] update chatlist after account deletion

no priority :)