### PR TITLE
add a switch for push notifications

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1137,7 +1137,6 @@
     <string name="pref_instant_delivery">Instant Delivery</string>
     <string name="pref_push_notifications">Use Push Service</string>
     <string name="pref_push_notifications_explain">Reliable Push Notifications for Chatmail-Servers</string>
-    <string name="pref_push_notifications_unavailable">Not available</string>
     <string name="pref_background_notifications">Use Background Connection</string>
     <string name="pref_background_notifications_explain">Requires ignored battery optimizations, use if Push Service is unavailable</string>
     <string name="pref_reliable_service">Force Background Connection</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1133,18 +1133,20 @@
     <string name="InfoPlist_NSPhotoLibraryAddUsageDescription">Delta Chat wants to save images to your photo library.</string>
 
 
-    <string name="pref_push_notifications">Use Push Service</string>
-    <string name="pref_push_notifications_explain">Reliable Push Notifications, available for Chatmail-Servers if supported by the system</string>
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
-    <string name="pref_background_notifications">Disable Battery Optimisations</string>
-    <string name="pref_background_notifications_explain">Required if no Push Service is available</string>
+    <string name="pref_instant_delivery">Instant Delivery</string>
+    <string name="pref_push_notifications">Use Push Service</string>
+    <string name="pref_push_notifications_explain">Reliable Push Notifications for Chatmail-Servers</string>
+    <string name="pref_push_notifications_unavailable">Not available</string>
+    <string name="pref_background_notifications">Use Background Connection</string>
+    <string name="pref_background_notifications_explain">Requires ignored battery optimizations, use if Push Service is unavailable</string>
+    <string name="pref_reliable_service">Visible Background Connection</string>
+    <string name="pref_reliable_service_explain">Helps with unreliable background connections</string>
+
     <string name="pref_background_notifications_rationale">To maintain connection to your e-mail server and receive messages in the background, ignore battery optimizations in the next step.\n\nDelta Chat uses few resources and takes care not to drain your battery.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
-    <string name="pref_reliable_service">Always Run in Background</string>
-    <string name="pref_reliable_service_explain">Required if no Push Service is available, shows a permanent notification</string>
     <string name="perm_enable_bg_reminder_title">Tap here to receive messages while Delta Chat is in the background.</string>
     <string name="perm_enable_bg_already_done">You already allowed Delta Chat to receive messages in the background.\n\nIf messages still do not arrive in background, please also check your system settings.</string>
-
 
     <!-- device messages for updates -->
     <string name="update_1_44_android">What\'s new:\n\n❤️ Yeah! This was long-awaited: Long tap a message to react\n\n🔗 If you cannot scan QR codes, share them as invite links\n\n🔵 Unread messages of all accounts are counted and shown in title now\n\n… and TONS of bugfixes … %1$s\n\nHelp improving the app: Use \"Settings / Advanced / Send statistics\" to help devs to optimize better for real-world usage. You can review the data before sending</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1133,13 +1133,15 @@
     <string name="InfoPlist_NSPhotoLibraryAddUsageDescription">Delta Chat wants to save images to your photo library.</string>
 
 
+    <string name="pref_push_notifications">Use Push Service</string>
+    <string name="pref_push_notifications_explain">Reliable Push Notifications, available for Chatmail-Servers if supported by the system</string>
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
-    <string name="pref_background_notifications">Background Notifications</string>
-    <string name="pref_background_notifications_explain">Uses a background connection to your server and requires ignored battery optimizations.</string>
+    <string name="pref_background_notifications">Disable Battery Optimisations</string>
+    <string name="pref_background_notifications_explain">Required if no Push Service is available</string>
     <string name="pref_background_notifications_rationale">To maintain connection to your e-mail server and receive messages in the background, ignore battery optimizations in the next step.\n\nDelta Chat uses few resources and takes care not to drain your battery.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
-    <string name="pref_reliable_service">Reliable Background Connection</string>
-    <string name="pref_reliable_service_explain">Requires a permanent notification</string>
+    <string name="pref_reliable_service">Always Run in Background</string>
+    <string name="pref_reliable_service_explain">Required if no Push Service is available, shows a permanent notification</string>
     <string name="perm_enable_bg_reminder_title">Tap here to receive messages while Delta Chat is in the background.</string>
     <string name="perm_enable_bg_already_done">You already allowed Delta Chat to receive messages in the background.\n\nIf messages still do not arrive in background, please also check your system settings.</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1140,8 +1140,8 @@
     <string name="pref_push_notifications_unavailable">Not available</string>
     <string name="pref_background_notifications">Use Background Connection</string>
     <string name="pref_background_notifications_explain">Requires ignored battery optimizations, use if Push Service is unavailable</string>
-    <string name="pref_reliable_service">Visible Background Connection</string>
-    <string name="pref_reliable_service_explain">Helps with unreliable background connections</string>
+    <string name="pref_reliable_service">Force Background Connection</string>
+    <string name="pref_reliable_service_explain">Causes a permanent notification</string>
 
     <string name="pref_background_notifications_rationale">To maintain connection to your e-mail server and receive messages in the background, ignore battery optimizations in the next step.\n\nDelta Chat uses few resources and takes care not to drain your battery.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -52,9 +52,9 @@
 
         <PreferenceCategory android:title="@string/pref_instant_delivery">
                 <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-                    android:key="pref_push_optimizations"
+                    android:key="pref_push_enabled"
                     android:dependency="pref_key_enable_notifications"
-                    android:defaultValue="false"
+                    android:defaultValue="true"
                     android:title="@string/pref_push_notifications"
                     android:summary="@string/pref_push_notifications_explain"/>
 

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -10,6 +10,13 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:dependency="pref_key_enable_notifications"
             android:defaultValue="false"
+            android:key="pref_push_optimizations"
+            android:title="@string/pref_push_notifications"
+            android:summary="@string/pref_push_notifications_explain"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:dependency="pref_key_enable_notifications"
+            android:defaultValue="false"
             android:key="pref_ignore_battery_optimizations"
             android:title="@string/pref_background_notifications"
             android:summary="@string/pref_background_notifications_explain"/>

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -7,27 +7,6 @@
                             android:title="@string/pref_notifications"
                             android:defaultValue="true" />
 
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:dependency="pref_key_enable_notifications"
-            android:defaultValue="false"
-            android:key="pref_push_optimizations"
-            android:title="@string/pref_push_notifications"
-            android:summary="@string/pref_push_notifications_explain"/>
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:dependency="pref_key_enable_notifications"
-            android:defaultValue="false"
-            android:key="pref_ignore_battery_optimizations"
-            android:title="@string/pref_background_notifications"
-            android:summary="@string/pref_background_notifications_explain"/>
-
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:dependency="pref_key_enable_notifications"
-            android:defaultValue="false"
-            android:key="pref_reliable_service"
-            android:title="@string/pref_reliable_service"
-            android:summary="@string/pref_reliable_service_explain"/>
-
         <Preference
                 android:dependency="pref_key_enable_notifications"
                 android:key="pref_key_ringtone"
@@ -70,5 +49,28 @@
             android:dependency="pref_key_enable_notifications"
             android:title="@string/pref_in_chat_sounds"
             android:defaultValue="true" />
+
+        <PreferenceCategory android:title="@string/pref_instant_delivery">
+                <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                    android:key="pref_push_optimizations"
+                    android:dependency="pref_key_enable_notifications"
+                    android:defaultValue="false"
+                    android:title="@string/pref_push_notifications"
+                    android:summary="@string/pref_push_notifications_explain"/>
+
+                <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                    android:key="pref_ignore_battery_optimizations"
+                    android:dependency="pref_key_enable_notifications"
+                    android:defaultValue="false"
+                    android:title="@string/pref_background_notifications"
+                    android:summary="@string/pref_background_notifications_explain"/>
+
+                <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                    android:key="pref_reliable_service"
+                    android:dependency="pref_key_enable_notifications"
+                    android:defaultValue="false"
+                    android:title="@string/pref_reliable_service"
+                    android:summary="@string/pref_reliable_service_explain"/>
+        </PreferenceCategory>
 
 </PreferenceScreen>

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -226,7 +226,12 @@ public class ApplicationContext extends MultiDexApplication {
             ExistingPeriodicWorkPolicy.KEEP,
             fetchWorkRequest);
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
-    FcmReceiveService.register(this);
+
+    if(Prefs.isPushEnabled(this)) {
+      FcmReceiveService.register(this);
+    } else {
+      Log.i(TAG, "FCM disabled in user settings");
+    }
   }
 
   public JobManager getJobManager() {

--- a/src/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/org/thoughtcrime/securesms/LogViewFragment.java
@@ -258,6 +258,7 @@ public class LogViewFragment extends Fragment {
       }
 
       final String token = FcmReceiveService.getToken();
+      builder.append("push-enabled=").append(Prefs.isPushEnabled(context)).append("\n");
       builder.append("push-token=").append(token == null ? "<empty>" : token).append("\n");
     } catch (Exception e) {
       builder.append("Unknown\n");

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -28,11 +28,6 @@ public class FcmReceiveService extends FirebaseMessagingService {
   private static volatile String prefixedToken;
 
   public static void register(Context context) {
-    if(!Prefs.isPushEnabled(context)) {
-      Log.w(TAG, "FCM disabled in user settings");
-      return;
-    }
-
     if (Build.VERSION.SDK_INT < 19) {
       Log.w(TAG, "FCM not available on SDK < 19");
       triedRegistering = true;

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -17,6 +17,7 @@ import com.google.firebase.messaging.RemoteMessage;
 
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.BuildConfig;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 public class FcmReceiveService extends FirebaseMessagingService {
@@ -27,6 +28,11 @@ public class FcmReceiveService extends FirebaseMessagingService {
   private static volatile String prefixedToken;
 
   public static void register(Context context) {
+    if(!Prefs.isPushEnabled(context)) {
+      Log.w(TAG, "FCM disabled in user settings");
+      return;
+    }
+
     if (Build.VERSION.SDK_INT < 19) {
       Log.w(TAG, "FCM not available on SDK < 19");
       triedRegistering = true;

--- a/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -92,6 +92,23 @@ public class FcmReceiveService extends FirebaseMessagingService {
     return prefixedToken;
   }
 
+  public static void deleteToken() {
+    if (prefixedToken == null) {
+      Log.i(TAG, "FCM not registered yet, no token to delete");
+      return;
+    }
+
+    Util.runOnAnyBackgroundThread(() -> {
+      try {
+        Tasks.await(FirebaseMessaging.getInstance().deleteToken());
+        prefixedToken = null;
+        Log.i(TAG, "FCM token deleted for " + BuildConfig.APPLICATION_ID);
+      } catch (Exception e) {
+        Log.e(TAG, "cannot delete FCM token for " + BuildConfig.APPLICATION_ID + ": " + e);
+      }
+    });
+  }
+
   @Override
   public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
     Log.i(TAG, "FCM push notification received");

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -22,6 +22,7 @@ import android.text.TextUtils;
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.KeepAliveService;
+import org.thoughtcrime.securesms.notifications.FcmReceiveService;
 import org.thoughtcrime.securesms.util.Prefs;
 
 import static android.app.Activity.RESULT_OK;
@@ -30,7 +31,6 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
 
   private static final int REQUEST_CODE_NOTIFICATION_SELECTED = 1;
 
-  private CheckBoxPreference usePushService;
   private CheckBoxPreference ignoreBattery;
 
   @Override
@@ -69,8 +69,15 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
 
     initializeRingtoneSummary(findPreference(Prefs.RINGTONE_PREF));
 
-    usePushService = this.findPreference("pref_push_enabled");
-    usePushService.setChecked(Prefs.isPushEnabled(getActivity()));
+    CheckBoxPreference usePushService = this.findPreference("pref_push_enabled");
+    usePushService.setChecked(Prefs.isPushEnabled(getContext()));
+    usePushService.setOnPreferenceChangeListener((preference, newValue) -> {
+      boolean enabled = (Boolean) newValue; // Prefs.isPushEnabled() still has the old value
+      if (enabled) {
+        FcmReceiveService.register(getContext());
+      }
+      return true;
+    });
 
     ignoreBattery = this.findPreference("pref_ignore_battery_optimizations");
     ignoreBattery.setVisible(needsIgnoreBatteryOptimizations());

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -75,6 +75,8 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
       boolean enabled = (Boolean) newValue; // Prefs.isPushEnabled() still has the old value
       if (enabled) {
         FcmReceiveService.register(getContext());
+      } else {
+        FcmReceiveService.deleteToken();
       }
       return true;
     });

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -30,6 +30,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
 
   private static final int REQUEST_CODE_NOTIFICATION_SELECTED = 1;
 
+  private CheckBoxPreference usePushService;
   private CheckBoxPreference ignoreBattery;
 
   @Override
@@ -67,6 +68,9 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     initializeListSummary((ListPreference) findPreference(Prefs.NOTIFICATION_PRIORITY_PREF));
 
     initializeRingtoneSummary(findPreference(Prefs.RINGTONE_PREF));
+
+    usePushService = this.findPreference("pref_push_enabled");
+    usePushService.setChecked(Prefs.isPushEnabled(getActivity()));
 
     ignoreBattery = this.findPreference("pref_ignore_battery_optimizations");
     ignoreBattery.setVisible(needsIgnoreBatteryOptimizations());

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -15,6 +15,7 @@ import androidx.core.app.NotificationCompat;
 
 import com.b44t.messenger.DcContext;
 
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.preferences.widgets.NotificationPrivacyPreference;
 
@@ -172,7 +173,8 @@ public class Prefs {
   }
 
   public static boolean isPushEnabled(Context context) {
-    boolean defaultPush = true;
+    // Do not use PUSH for the the default application ID "com.b44t.messenger" which is used eg. used by F-Droid
+    boolean defaultPush = !BuildConfig.APPLICATION_ID.equals("com.b44t.messenger");
     return getBooleanPreference(context, "pref_push_enabled", defaultPush);
   }
 

--- a/src/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/org/thoughtcrime/securesms/util/Prefs.java
@@ -171,6 +171,11 @@ public class Prefs {
     return getBooleanPreference(context, NOTIFICATION_PREF, true);
   }
 
+  public static boolean isPushEnabled(Context context) {
+    boolean defaultPush = true;
+    return getBooleanPreference(context, "pref_push_enabled", defaultPush);
+  }
+
   public static boolean isHardCompressionEnabled(Context context) {
     return DcHelper.getContext(context).getConfigInt(DcHelper.CONFIG_MEDIA_QUALITY) == DcContext.DC_MEDIA_QUALITY_WORSE;
   }


### PR DESCRIPTION
- [x] add switch
- [x] disable the switch when push is unavailble, EDIT: this is not easily possible as we do not know if PUSH works without trying
- [x] implement
- [x] disable the switch by default for f-droid, closes https://github.com/deltachat/deltachat-android/issues/3030
- [x] apply changes on the switch directly

for a subsequent PR: link to the help topic `instant-delivery` from https://github.com/deltachat/deltachat-pages/pull/883 

