### PR TITLE
check if push is sufficient before adding device message

### DIFF
--- a/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -61,6 +61,10 @@ public class DozeReminder {
       e.printStackTrace();
     }
 
+    if (isPushAvailableAndSufficient()) {
+      return false;
+    }
+
     return true; // yip, asking for disabling battery optimisations makes sense
   }
 
@@ -123,7 +127,6 @@ public class DozeReminder {
   public static void maybeAskDirectly(Context context) {
     try {
       if (isPushAvailableAndSufficient()) {
-        // do not set DOZE_ASKED_DIRECTLY, this will happen once FCM is disabled or a non-chatmail is added
         return;
       }
 


### PR DESCRIPTION
the check before was too implicit and relied on DOZE_ASKED_DIRECTLY only.

but if the user was asked one time and went for chatmail again, it did not work and the user was getting the message "please enable 'ignore battery optimisations'"
even though they were using chatmail-only.