### PR TITLE
hint user that rollout may take time

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,7 +72,8 @@ on <https://play.google.com/apps/publish/>:
 
 9. a) open "Delta Chat/Release/Production"
       then "Create new release" and upload APK from above  
-   b) fill out "Release details/Release notes" (500 characters, summary can be reused for F-Droid),
+   b) fill out "Release details/Release notes" (500 chars), add the line
+      "These features will roll out over the coming days. Thanks for using Delta Chat!";
       release name should be default ("123 (1.2.3)")  
    c) click "Next", set "Rollout Percentage" to 1% (later 2%, 5%, 10%, 20%, 50%, 100%),
       click "Start rollout to Production"


### PR DESCRIPTION
seen a similar hint for other apps,
it is useful to give interested users a clue
why they have a feature but others may not.

counterpart of https://github.com/deltachat/deltachat-ios/pull/2194