### PR TITLE
switch to new account when opening DCACCOUNT:// URIs

### DIFF
--- a/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -95,6 +95,11 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
     boolean fromWelcome  = getIntent().getBooleanExtra(FROM_WELCOME, false);
+    if (DcHelper.getContext(this).isConfigured() == 1) {
+      // if account is configured it means we didn't come from Welcome screen nor from QR scanner,
+      // instead, user clicked a dcaccount:// URI directly, so we need to switch to a new account:
+      AccountManager.getInstance().beginAccountCreation(this);
+    }
     getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(!fromWelcome) {
       @Override
       public void handleOnBackPressed() {


### PR DESCRIPTION
the problem is that in welcome screen we obviously switch to new account, also the case when user has selected an account and then scan dcaccount QR, it first switch to a new account before invoking InstantOnboarding screen, but the direct dcaccount:// URI handling happens by the system that directly opens the activity so we need to check that in the activity and create new account if needed
