### PR TITLE
use name `deviceMsgLabel` as it is a label and no id

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -104,8 +104,8 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     // it is not needed to keep all past update messages, however, when deleted, also the strings should be deleted.
     try {
       DcContext dcContext = DcHelper.getContext(this);
-      final String deviceMsgId = "update_1_46_0l_android";
-      if (!dcContext.wasDeviceMsgEverAdded(deviceMsgId)) {
+      final String deviceMsgLabel = "update_1_46_0l_android";
+      if (!dcContext.wasDeviceMsgEverAdded(deviceMsgLabel)) {
         DcMsg msg = null;
         if (!getIntent().getBooleanExtra(FROM_WELCOME, false)) {
           msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
@@ -117,15 +117,15 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
 
           msg.setText(getString(R.string.update_1_46_android, "https://get.delta.chat/#changelogs"));
         }
-        dcContext.addDeviceMsg(deviceMsgId, msg);
+        dcContext.addDeviceMsg(deviceMsgLabel, msg);
 
-        if (Prefs.getStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, "").equals(deviceMsgId)) {
+        if (Prefs.getStringPreference(this, Prefs.LAST_DEVICE_MSG_LABEL, "").equals(deviceMsgLabel)) {
           int deviceChatId = dcContext.getChatIdByContactId(DcContact.DC_CONTACT_ID_DEVICE);
           if (deviceChatId != 0) {
             dcContext.marknoticedChat(deviceChatId);
           }
         }
-        Prefs.setStringPreference(this, Prefs.LAST_DEVICE_MSG_ID, deviceMsgId);
+        Prefs.setStringPreference(this, Prefs.LAST_DEVICE_MSG_LABEL, deviceMsgLabel);
       }
     } catch(Exception e) {
       e.printStackTrace();

--- a/src/main/java/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Prefs.java
@@ -65,7 +65,7 @@ public class Prefs {
   public  static final String  ALWAYS_LOAD_REMOTE_CONTENT = "pref_always_load_remote_content";
   public  static final boolean ALWAYS_LOAD_REMOTE_CONTENT_DEFAULT = false;
 
-  public  static final String LAST_DEVICE_MSG_ID               = "pref_last_device_msg_id";
+  public  static final String LAST_DEVICE_MSG_LABEL            = "pref_last_device_msg_id";
 
   public enum VibrateState {
     DEFAULT(0), ENABLED(1), DISABLED(2);


### PR DESCRIPTION
came over that while targeting https://github.com/deltachat/deltachat-ios/pull/2204 and was shortly confused about what is going on there :)

(the name saved to database is not changed, however, to avoid popping up the message again in case we do an update without a new device messase)