### PR TITLE
cancel muting should not exit select-mode

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
@@ -165,17 +165,22 @@ public abstract class BaseConversationListFragment extends Fragment implements A
           for (long chatId : selectedConversations) {
             dcContext.setChatMuteDuration((int)chatId, duration);
           }
+
+          if (actionMode != null) {
+            actionMode.finish();
+            actionMode = null;
+          }
       });
     } else {
       // unmute
       for (long chatId : selectedConversations) {
         dcContext.setChatMuteDuration((int)chatId, 0);
       }
-    }
 
-    if (actionMode != null) {
-      actionMode.finish();
-      actionMode = null;
+      if (actionMode != null) {
+        actionMode.finish();
+        actionMode = null;
+      }
     }
   }
 


### PR DESCRIPTION
exiting 'select mode' is unexpected when hitting 'cancel' - the user may still want to do other things with the selection.

this makes the 'mute' behavior consisten with other cases showing a dialog, eg. 'delete'