### PR TITLE
prepare 1.46.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Delta Chat Android Changelog
 
+## v1.46.3
+2024-06
+
+* Disable FCM PUSH notification support for F-Droid and other non-Google-Play-builds
+* using core 1.139.5
+
+
 ## v1.46.2
 2024-06
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 685
-        versionName "1.46.2"
+        versionCode 686
+        versionName "1.46.3"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true

--- a/metadata/en-US/changelogs/6864.txt
+++ b/metadata/en-US/changelogs/6864.txt
@@ -1,0 +1,7 @@
+- new onboarding: you can create a new profile with one tap on "Create New Profile" - or use an existing login or second-device-setup as usual
+- contacts can be attached as "Cards" at "Attach / Contact"; when the receiver taps the cards, guaranteed end-to-end encrypted can be established
+- add contacts manually at "New Chat / New Contact / Add Contact Manually"
+- send any emoji as reaction
+- show reactions in summaries
+- pin/archive/etc chats directly from search result
+- bug fixed and more


### PR DESCRIPTION
only change compared to 1.46.2 is that FCM is disabled for default/fdroid buils.

this version will go to fdroid, no need to push it to gplay.

after merging, we should follow the instructions from RELEASE.md:

```
git tag v1.46.3; git push --tags
```