### PR TITLE
allow to mark as read selected chats

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
@@ -184,6 +184,18 @@ public abstract class BaseConversationListFragment extends Fragment implements A
     }
   }
 
+  private void handleMarknoticedSelected() {
+    final DcContext dcContext             = DcHelper.getContext(requireActivity());
+    final Set<Long> selectedConversations = new HashSet<Long>(getListAdapter().getBatchSelections());
+    for (long chatId : selectedConversations) {
+      dcContext.marknoticedChat((int)chatId);
+    }
+    if (actionMode != null) {
+      actionMode.finish();
+      actionMode = null;
+    }
+  }
+
   @SuppressLint("StaticFieldLeak")
   private void handleArchiveAllSelected() {
     final DcContext dcContext             = DcHelper.getContext(requireActivity());
@@ -353,6 +365,7 @@ public abstract class BaseConversationListFragment extends Fragment implements A
     case R.id.menu_pin_selected:     handlePinAllSelected();     return true;
     case R.id.menu_archive_selected: handleArchiveAllSelected(); return true;
     case R.id.menu_mute_selected:    handleMuteAllSelected();    return true;
+    case R.id.menu_marknoticed_selected: handleMarknoticedSelected(); return true;
     }
 
     return false;

--- a/src/main/res/menu/conversation_list.xml
+++ b/src/main/res/menu/conversation_list.xml
@@ -21,6 +21,10 @@
           android:id="@+id/menu_mute_selected"
           app:showAsAction="never"/>
 
+    <item android:title="@string/mark_all_as_read"
+          android:id="@+id/menu_marknoticed_selected"
+          app:showAsAction="never"/>
+
     <item android:title="@string/menu_select_all"
           android:id="@+id/menu_select_all"
           app:showAsAction="never"/>

--- a/src/main/res/menu/conversation_list.xml
+++ b/src/main/res/menu/conversation_list.xml
@@ -21,7 +21,7 @@
           android:id="@+id/menu_mute_selected"
           app:showAsAction="never"/>
 
-    <item android:title="@string/mark_all_as_read"
+    <item android:title="@string/mark_as_read"
           android:id="@+id/menu_marknoticed_selected"
           app:showAsAction="never"/>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="show_full_message">Show Full Message…</string>
     <!-- Stay short here, say ~16 characters. The source string could also be "All Read", maybe that hint can make translations easier :) -->
     <string name="mark_all_as_read">Mark All as Read</string>
+    <string name="mark_as_read">Mark as Read</string>
     <!-- Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen". -->
     <string name="mark_as_read_short">Read</string>
     <!-- Placeholder text when something is loading -->


### PR DESCRIPTION
close #3128 

user can select certain chats they want to mark as seen, they still can mark as sen all by using "select all" and then use "mark all as read"