### PR TITLE
consolidate wording for "Message Info"

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -229,7 +229,7 @@
     <string name="menu_delete_messages">Delete Messages</string>
     <string name="delete_contact">Delete Contact</string>
     <string name="menu_delete_location">Delete this Location?</string>
-    <string name="menu_message_details">Message Details</string>
+    <string name="menu_message_details">Message Info</string>
     <string name="menu_copy_to_clipboard">Copy to Clipboard</string>
     <string name="menu_copy_selection_to_clipboard">Copy Selection</string>
     <string name="menu_copy_link_to_clipboard">Copy Link</string>


### PR DESCRIPTION
before, "Info" and "Message Details" were used for the same things synonymously,

this is an issue mostly in the context menus,
where eg. iOS had "Info" but desktop did not -
and android had an "i"-icon ...

but also, tapping 'Info' and then getting a different title (not only a longer version) is not super-nice.

with this change, everything is "Info", making also the "i"-icon fit. this is also consistent with WhatsApp.
Signal has the same mess as we before, at least on iOS.

once this is merged, `./scripts/tx-update-changed-sources.sh` needs to be run