### PR TITLE
remove deprecated hint 'chat with any email'

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -113,9 +113,7 @@ public class ConversationListFragment extends BaseConversationListFragment
     if (archive) {
       fab.setVisibility(View.GONE);
       TextView emptyTitle = ViewUtil.findById(view, R.id.empty_title);
-      TextView emptySubtitle = ViewUtil.findById(view, R.id.empty_subtitle);
       emptyTitle.setText(R.string.archive_empty_hint);
-      emptySubtitle.setVisibility(View.GONE);
     } else {
       fab.setVisibility(View.VISIBLE);
     }

--- a/src/main/res/layout/conversation_list_fragment.xml
+++ b/src/main/res/layout/conversation_list_fragment.xml
@@ -34,18 +34,6 @@
                   android:lineSpacingMultiplier="1.3"
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"/>
-
-        <TextView android:id="@+id/empty_subtitle"
-                  android:text="@string/chat_no_chats_yet_hint"
-                  android:textSize="16sp"
-                  android:paddingLeft="16dp"
-                  android:paddingTop="16dp"
-                  android:paddingRight="16dp"
-                  android:paddingBottom="64dp"
-                  android:gravity="center"
-                  android:lineSpacingMultiplier="1.3"
-                  android:layout_width="match_parent"
-                  android:layout_height="wrap_content"/>
     </LinearLayout>
 
     <LinearLayout android:layout_width="match_parent"


### PR DESCRIPTION
the string is deprecated and also no longer used on desktop/iOS.

the 'empty state view' where the string could appear is anyways not shown often
(usually, there is 'saved messages' and 'device messages'), so it also does not make sense to think over a replacement.

the string as such can be removed in a subsequent PR when we cleanup unused strings.