### PR TITLE
save chatmail diskspace by tweaking autodelete-from-server

### DIFF
--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -236,6 +236,19 @@ public class DcContext {
       return getConfigInt("is_chatmail") == 1;
     }
 
+    // Called for new profiles on chatmail servers that are "single device" initially;
+    // to save server disk space, we make use of that delete all messages immediately after download.
+    public void assumeSingleDevice() {
+      setConfigInt("delete_server_after", 1 /*at once*/);
+    }
+
+    // Called when we get a hint that another device may be set up.
+    public void assumeMultiDevice() {
+      if (getConfigInt("delete_server_after") == 1 /*at once*/) {
+        setConfigInt("delete_server_after", 0 /*never/automatic*/);
+      }
+    }
+
     /**
      * @return true if at least one chat has location streaming enabled
      */

--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -239,12 +239,14 @@ public class DcContext {
     // Called for new profiles on chatmail servers that are "single device" initially;
     // to save server disk space, we make use of that delete all messages immediately after download.
     public void assumeSingleDevice() {
-      setConfigInt("delete_server_after", 1 /*at once*/);
+      if (isChatmail()) {
+        setConfigInt("delete_server_after", 1 /*at once*/);
+      }
     }
 
     // Called when we get a hint that another device may be set up.
     public void assumeMultiDevice() {
-      if (getConfigInt("delete_server_after") == 1 /*at once*/) {
+      if (isChatmail() && getConfigInt("delete_server_after") == 1 /*at once*/) {
         setConfigInt("delete_server_after", 0 /*never/automatic*/);
       }
     }

--- a/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -373,6 +373,7 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
         progressUpdate((int)progress);
       } else if (progress==1000/*done*/) {
         DcHelper.getAccounts(this).startIo();
+        dcContext.assumeSingleDevice();
         progressSuccess();
       }
     }
@@ -481,9 +482,6 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
         return;
       }
       DcHelper.getAccounts(this).stopIo();
-      if (!isDcLogin) {
-        dcContext.assumeSingleDevice();
-      }
       dcContext.configure();
     }).start();
   }

--- a/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -481,6 +481,9 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
         return;
       }
       DcHelper.getAccounts(this).stopIo();
+      if (!isDcLogin) {
+        dcContext.assumeSingleDevice();
+      }
       dcContext.configure();
     }).start();
   }

--- a/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -369,6 +369,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
             else if (progress==1000/*done*/) {
                 DcHelper.getAccounts(this).startIo();
                 progressSuccess();
+                dcContext.assumeMultiDevice();
                 notificationController.close();
                 cleanupTempBackupFile();
             }

--- a/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -68,10 +68,12 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
 
     autoDelServer = findPreference("autodel_server");
     autoDelServer.setOnPreferenceChangeListener(new AutodelChangeListener("delete_server_after"));
-    if (!dcContext.isChatmail()) {
-      CharSequence[] entries = autoDelServer.getEntries();
-      entries[0] = getString(R.string.never);
-      autoDelServer.setEntries(entries);
+    if (dcContext.isChatmail()) {
+      autoDelServer.setEntries(new CharSequence[]{getString(R.string.automatic), getString(R.string.autodel_at_once)});
+      autoDelServer.setEntryValues(new CharSequence[]{"0", "1"});
+      if (dcContext.getConfigInt("delete_server_after") > 1) {
+        dcContext.setConfigInt("delete_server_after", 0 /*never/automatic*/);
+      }
     }
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -156,13 +156,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     final String onRes = context.getString(R.string.on);
     final String offRes = context.getString(R.string.off);
     String readReceiptState = dcContext.getConfigInt("mdns_enabled")!=0? onRes : offRes;
-    boolean deleteOld = (dcContext.getConfigInt("delete_device_after")!=0 || dcContext.getConfigInt("delete_server_after")!=0);
-
-    String summary = context.getString(R.string.pref_read_receipts) + " " + readReceiptState;
-    if (deleteOld) {
-      summary += ", " + context.getString(R.string.delete_old_messages) + " " + onRes;
-    }
-    return summary;
+    return context.getString(R.string.pref_read_receipts) + " " + readReceiptState;
   }
 
   private class BlockedContactsClickListener implements Preference.OnPreferenceClickListener {

--- a/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -68,6 +68,11 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
 
     autoDelServer = findPreference("autodel_server");
     autoDelServer.setOnPreferenceChangeListener(new AutodelChangeListener("delete_server_after"));
+    if (!dcContext.isChatmail()) {
+      CharSequence[] entries = autoDelServer.getEntries();
+      entries[0] = getString(R.string.never);
+      autoDelServer.setEntries(entries);
+    }
   }
 
   @Override
@@ -97,7 +102,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
   private void initAutodelFromCore() {
     String value = Integer.toString(dcContext.getConfigInt("delete_server_after"));
     autoDelServer.setValue(value);
-    updateListSummary(autoDelServer, value, value.equals("0")? null : getString(R.string.autodel_server_enabled_hint));
+    updateListSummary(autoDelServer, value, (value.equals("0") || dcContext.isChatmail())? null : getString(R.string.autodel_server_enabled_hint));
 
     value = Integer.toString(dcContext.getConfigInt("delete_device_after"));
     autoDelDevice.setValue(value);
@@ -186,9 +191,9 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
       int timeout = Util.objectToInt(newValue);
-      if (timeout>0) {
-        Context context = preference.getContext();
-        boolean fromServer = coreKey.equals("delete_server_after");
+      Context context = preference.getContext();
+      boolean fromServer = coreKey.equals("delete_server_after");
+      if (timeout>0 && !(fromServer && dcContext.isChatmail())) {
         int delCount = DcHelper.getContext(context).estimateDeletionCount(fromServer, timeout);
 
         View gl = View.inflate(getActivity(), R.layout.dialog_with_checkbox, null);

--- a/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -222,6 +222,18 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
                 .setCancelable(true) // Enable the user to quickly cancel if they are intimidated by the warnings :)
                 .setOnCancelListener(dialog -> initAutodelFromCore())
                 .show();
+      } else if (fromServer && timeout>0 && timeout<=86400 /*one day, using a constant that cannot be used in .xml would weaken grep ability*/) {
+        new AlertDialog.Builder(context)
+                .setTitle(preference.getTitle())
+                .setMessage(R.string.autodel_sever_warn_multi_device)
+                .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
+                  dcContext.setConfigInt(coreKey, timeout);
+                  initAutodelFromCore();
+                })
+                .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> initAutodelFromCore())
+                .setCancelable(true)
+                .setOnCancelListener(dialog -> initAutodelFromCore())
+                .show();
       } else {
         updateListSummary(preference, newValue);
         dcContext.setConfigInt(coreKey, timeout);

--- a/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -218,9 +218,9 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
                 .setCancelable(true) // Enable the user to quickly cancel if they are intimidated by the warnings :)
                 .setOnCancelListener(dialog -> initAutodelFromCore())
                 .show();
-      } else if (fromServer && timeout>0 && timeout<=86400 /*one day, using a constant that cannot be used in .xml would weaken grep ability*/) {
+      } else if (fromServer && timeout == 1 /*at once, using a constant that cannot be used in .xml would weaken grep ability*/) {
         new AlertDialog.Builder(context)
-                .setTitle(preference.getTitle())
+                .setTitle(R.string.autodel_sever_warn_multi_device_title)
                 .setMessage(R.string.autodel_sever_warn_multi_device)
                 .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
                   dcContext.setConfigInt(coreKey, timeout);

--- a/src/main/java/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -138,6 +138,7 @@ public abstract class ListSummaryPreferenceFragment extends CorrectedPreferenceF
   protected void startImexInner(int accountId, int what, String imexPath, String pathAsDisplayedToUser)
   {
     DcContext dcContext = DcHelper.getAccounts(getActivity()).getAccount(accountId);
+    dcContext.assumeMultiDevice();
     this.pathAsDisplayedToUser = pathAsDisplayedToUser;
     progressWhat = what;
     dcContext.imex(progressWhat, imexPath);

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -64,6 +64,7 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
         progressBar.setIndeterminate(true);
 
         dcContext = DcHelper.getContext(getActivity());
+        dcContext.assumeMultiDevice();
         DcHelper.getEventCenter(getActivity()).addObserver(DcContext.DC_EVENT_IMEX_PROGRESS, this);
 
         prepareThread = new Thread(() -> {

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
@@ -94,6 +94,7 @@ public class BackupReceiverFragment extends Fragment implements DcEventCenter.Dc
             } else if (permille == 1000) {
                 getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_SUCCESS);
                 getTransferActivity().doFinish();
+                dcContext.assumeMultiDevice();
                 return;
             }
 

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -188,12 +188,12 @@
 
   <string-array name="autodel_server_durations">
       <item>@string/automatic</item>
-      <item>@string/autodel_server_at_once</item>
-      <item>@string/autodel_server_after_1_hour</item>
-      <item>@string/autodel_server_after_1_day</item>
-      <item>@string/autodel_server_after_1_week</item>
-      <item>@string/autodel_server_after_5_weeks</item>
-      <item>@string/autodel_server_after_1_year</item>
+      <item>@string/autodel_at_once</item>
+      <item>@string/autodel_after_1_hour</item>
+      <item>@string/autodel_after_1_day</item>
+      <item>@string/autodel_after_1_week</item>
+      <item>@string/after_5_weeks</item>
+      <item>@string/autodel_after_1_year</item>
   </string-array>
 
   <string-array name="autodel_server_values">

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -187,13 +187,13 @@
   </string-array>
 
   <string-array name="autodel_server_durations">
-      <item>@string/never</item>
-      <item>@string/autodel_at_once</item>
-      <item>@string/autodel_after_1_hour</item>
-      <item>@string/autodel_after_1_day</item>
-      <item>@string/autodel_after_1_week</item>
-      <item>@string/after_5_weeks</item>
-      <item>@string/autodel_after_1_year</item>
+      <item>@string/automatic</item>
+      <item>@string/autodel_server_at_once</item>
+      <item>@string/autodel_server_after_1_hour</item>
+      <item>@string/autodel_server_after_1_day</item>
+      <item>@string/autodel_server_after_1_week</item>
+      <item>@string/autodel_server_after_5_weeks</item>
+      <item>@string/autodel_server_after_1_year</item>
   </string-array>
 
   <string-array name="autodel_server_values">

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -187,7 +187,7 @@
   </string-array>
 
   <string-array name="autodel_server_durations">
-      <item>@string/automatic</item>
+      <item>@string/never</item>
       <item>@string/autodel_at_once</item>
       <item>@string/autodel_after_1_hour</item>
       <item>@string/autodel_after_1_day</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -803,7 +803,8 @@
     <string name="autodel_server_ask">Do you want to delete %1$d messages now and all newly fetched messages \"%2$s\" in the future?\n\n⚠️ This includes e-mails, media and \"Saved messages\" in all server folders\n\n⚠️ Do not use this function if you want to keep data on the server\n\n⚠️ Do not use this function if you are using other e-mail clients besides Delta Chat</string>
     <!-- shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact -->
     <string name="autodel_server_enabled_hint">This includes e-mails, media and \"Saved messages\" in all server folders. Do not use this function if you want to keep data on the server or if you are using other e-mail clients besides Delta Chat.</string>
-    <string name="autodel_sever_warn_multi_device">Use short time spans only if your are not using other devices beside this one.\n\nOtherwise, using multiple devices will not work correctly.</string>
+    <string name="autodel_sever_warn_multi_device_title">Turn on at-once deletion</string>
+    <string name="autodel_sever_warn_multi_device">If you enable at-once deletion you cannot use multiple devices on this profile anymore.</string>
     <string name="autodel_confirm">I understand, delete all these messages</string>
     <!-- "At once" in the meaning of "Immediately", without any intervening time. -->
     <string name="autodel_at_once">At once after Download</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -806,7 +806,7 @@
     <string name="autodel_sever_warn_multi_device">Use short time spans only if your are not using other devices beside this one.\n\nOtherwise, using multiple devices will not work correctly.</string>
     <string name="autodel_confirm">I understand, delete all these messages</string>
     <!-- "At once" in the meaning of "Immediately", without any intervening time. -->
-    <string name="autodel_at_once">At once</string>
+    <string name="autodel_at_once">At once after Download</string>
     <string name="after_30_seconds">After 30 seconds</string>
     <string name="after_1_minute">After 1 minute</string>
     <string name="after_5_minutes">After 5 minutes</string>
@@ -818,13 +818,6 @@
     <string name="autodel_after_4_weeks">After 4 weeks</string>
     <string name="after_5_weeks">After 5 weeks</string>
     <string name="autodel_after_1_year">After 1 year</string>
-
-    <string name="autodel_server_at_once">At once after Download</string>
-    <string name="autodel_server_after_1_hour">Latest 1 hour after Download</string>
-    <string name="autodel_server_after_1_day">Latest 1 day after Download</string>
-    <string name="autodel_server_after_1_week">Latest 1 week after Download</string>
-    <string name="autodel_server_after_5_weeks">Latest 5 weeks after Download</string>
-    <string name="autodel_server_after_1_year">Latest 1 year after Download</string>
 
     <!-- autocrypt -->
     <!-- deprecated, used "Encryption" if a headline is needed -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -803,6 +803,7 @@
     <string name="autodel_server_ask">Do you want to delete %1$d messages now and all newly fetched messages \"%2$s\" in the future?\n\n⚠️ This includes e-mails, media and \"Saved messages\" in all server folders\n\n⚠️ Do not use this function if you want to keep data on the server\n\n⚠️ Do not use this function if you are using other e-mail clients besides Delta Chat</string>
     <!-- shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact -->
     <string name="autodel_server_enabled_hint">This includes e-mails, media and \"Saved messages\" in all server folders. Do not use this function if you want to keep data on the server or if you are using other e-mail clients besides Delta Chat.</string>
+    <string name="autodel_sever_warn_multi_device">Use short time spans only if your are not using other devices beside this one.\n\nOtherwise, using multiple devices will not work correctly.</string>
     <string name="autodel_confirm">I understand, delete all these messages</string>
     <!-- "At once" in the meaning of "Immediately", without any intervening time. -->
     <string name="autodel_at_once">At once</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -813,9 +813,17 @@
     <string name="autodel_after_1_hour">After 1 hour</string>
     <string name="autodel_after_1_day">After 1 day</string>
     <string name="autodel_after_1_week">After 1 week</string>
+    <!-- deprecated -->
     <string name="autodel_after_4_weeks">After 4 weeks</string>
     <string name="after_5_weeks">After 5 weeks</string>
     <string name="autodel_after_1_year">After 1 year</string>
+
+    <string name="autodel_server_at_once">At once after Download</string>
+    <string name="autodel_server_after_1_hour">Latest 1 hour after Download</string>
+    <string name="autodel_server_after_1_day">Latest 1 day after Download</string>
+    <string name="autodel_server_after_1_week">Latest 1 week after Download</string>
+    <string name="autodel_server_after_5_weeks">Latest 5 weeks after Download</string>
+    <string name="autodel_server_after_1_year">Latest 1 year after Download</string>
 
     <!-- autocrypt -->
     <!-- deprecated, used "Encryption" if a headline is needed -->


### PR DESCRIPTION
this PR aims to help saving disk space on chatmail servers by deleting messages _at once after download_ for new profiles (new profiles are usually not multi device, and multi device is the only reason to keep messages longer).

when we later get a hint that the user _might_ set up a second device, we go back to _automatic/never_ - which was the default up to now.

we assume that we will save 90% or more space by that as many user never set up a second device.

this PR also makes the available options a bit clearer (only two are left for chatmail, normal server still have opions as week/month/year) and adds a warning when an option may break multi device:

<img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/86ec3341-971f-402c-ab76-2536af81835a> <img width =250 src=https://github.com/deltachat/deltachat-android/assets/9800740/2b4735fe-5709-4da7-b61f-c746c0ee2b4a> <img width=250 src=https://github.com/deltachat/deltachat-android/assets/9800740/b5a2ce75-5ca7-4f19-8b01-1d18f351cd45>

moreover, for chatmail the the alarming confirmation dialog is removed - there is anyways an auto-deletion and  hints as "Do not use this function if you want to keep data on the server" and "Do not use this function if you are using other e-mail clients besides Delta Chat" are not matching and not doable for chatmail.
