### PR TITLE
expand advanced settings if they are modified

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -14,9 +14,9 @@ import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SEND_USER;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SERVER_FLAGS;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SOCKS5_ENABLED;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SOCKS5_HOST;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SOCKS5_PASSWORD;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SOCKS5_PORT;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SOCKS5_USER;
-import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SOCKS5_PASSWORD;
 import static org.thoughtcrime.securesms.connect.DcHelper.getContext;
 import static org.thoughtcrime.securesms.service.IPCAddAccountsService.ACCOUNT_DATA;
 
@@ -55,7 +55,6 @@ import com.b44t.messenger.DcProvider;
 import com.b44t.messenger.util.concurrent.ListenableFuture;
 import com.b44t.messenger.util.concurrent.SettableFuture;
 import com.google.android.material.textfield.TextInputEditText;
-import com.google.android.material.textfield.TextInputLayout;
 
 import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
@@ -169,28 +168,60 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
         viewLogText.setOnClickListener((view) -> showLog());
         boolean isConfigured = DcHelper.isConfigured(getApplicationContext());
         if (isConfigured) {
-            TextInputEditText imapLoginInput = findViewById(R.id.imap_login_text);
-
             String email = DcHelper.get(this, CONFIG_ADDRESS);
             emailInput.setText(email);
             if(!TextUtils.isEmpty(email)) {
                 emailInput.setSelection(email.length(), email.length());
             }
-
             passwordInput.setText(DcHelper.get(this, CONFIG_MAIL_PASSWORD));
-            imapLoginInput.setText(DcHelper.get(this, CONFIG_MAIL_USER));
-            imapServerInput.setText(DcHelper.get(this, CONFIG_MAIL_SERVER));
-            imapPortInput.setText(DcHelper.get(this, CONFIG_MAIL_PORT));
-            imapSecurity.setSelection(DcHelper.getInt(this, CONFIG_MAIL_SECURITY));
-            TextInputEditText smtpLoginInput = findViewById(R.id.smtp_login_text);
-            TextInputEditText smtpPasswordInput = findViewById(R.id.smtp_password_text);
-            smtpLoginInput.setText(DcHelper.get(this, CONFIG_SEND_USER));
-            smtpPasswordInput.setText(DcHelper.get(this, CONFIG_SEND_PASSWORD));
-            smtpServerInput.setText(DcHelper.get(this, CONFIG_SEND_SERVER));
-            smtpPortInput.setText(DcHelper.get(this, CONFIG_SEND_PORT));
-            smtpSecurity.setSelection(DcHelper.getInt(this, CONFIG_SEND_SECURITY));
 
-            proxySwitch.setChecked(DcHelper.getInt(this, CONFIG_SOCKS5_ENABLED) == 1);
+            boolean expandAdvanced = false;
+            String strVal;
+            int intVal;
+
+            TextInputEditText imapLoginInput = findViewById(R.id.imap_login_text);
+            strVal = DcHelper.get(this, CONFIG_MAIL_USER);
+            imapLoginInput.setText(strVal);
+            expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
+
+            strVal = DcHelper.get(this, CONFIG_MAIL_SERVER);
+            imapServerInput.setText(strVal);
+            expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
+
+            strVal = DcHelper.get(this, CONFIG_MAIL_PORT);
+            imapPortInput.setText(strVal);
+            expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
+
+            intVal = DcHelper.getInt(this, CONFIG_MAIL_SECURITY);
+            imapSecurity.setSelection(intVal);
+            expandAdvanced = expandAdvanced || intVal != 0;
+
+            TextInputEditText smtpLoginInput = findViewById(R.id.smtp_login_text);
+            strVal = DcHelper.get(this, CONFIG_SEND_USER);
+            smtpLoginInput.setText(strVal);
+            expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
+
+            TextInputEditText smtpPasswordInput = findViewById(R.id.smtp_password_text);
+            strVal = DcHelper.get(this, CONFIG_SEND_PASSWORD);
+            smtpPasswordInput.setText(strVal);
+            expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
+
+            strVal = DcHelper.get(this, CONFIG_SEND_SERVER);
+            smtpServerInput.setText(strVal);
+            expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
+
+            strVal = DcHelper.get(this, CONFIG_SEND_PORT);
+            smtpPortInput.setText(strVal);
+            expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
+
+            intVal = DcHelper.getInt(this, CONFIG_SEND_SECURITY);
+            smtpSecurity.setSelection(intVal);
+            expandAdvanced = expandAdvanced || intVal != 0;
+
+            intVal = DcHelper.getInt(this, CONFIG_SOCKS5_ENABLED);
+            proxySwitch.setChecked(intVal == 1);
+            expandAdvanced = expandAdvanced || intVal == 1;
+
             proxyHostInput.setText(DcHelper.get(this, CONFIG_SOCKS5_HOST));
             proxyPortInput.setText(DcHelper.get(this, CONFIG_SOCKS5_PORT));
             TextInputEditText proxyUserInput = findViewById(R.id.socks5_user_text);
@@ -202,12 +233,17 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             int sel = 0;
             if((serverFlags&DcContext.DC_LP_AUTH_OAUTH2)!=0) sel = 1;
             authMethod.setSelection(sel);
+            expandAdvanced = expandAdvanced || sel != 0;
 
             int certCheckFlags = DcHelper.getInt(this, "imap_certificate_checks");
             certCheck.setSelection(certCheckFlags);
+            expandAdvanced = expandAdvanced || certCheckFlags != 0;
+
             encryptCheckbox.setHeight(0);
             encryptCheckbox.setClickable(false);
             encryptCheckbox.setFocusable(false);
+
+            if (expandAdvanced) { onAdvancedSettings(); }
         } else if (getIntent() != null && getIntent().getBundleExtra(ACCOUNT_DATA) != null) {
           // Companion app might have sent account data
           Bundle b = getIntent().getBundleExtra(ACCOUNT_DATA);


### PR DESCRIPTION
this helps avoid issues like user changing email address and password and pressing "configure" button without realizing they have custom imap, smpt, etc. settings

this already happened to a friend when I was trying to help them to migrate to a chatmail address, it was really confusing because address was changed and configuration succeed but it took me a while realize that the client was actually connecting to a different IMAP/SMTP server without even using the new set address and password because it was using the manual configuration set in advanced