### PR TITLE
fix crash on some mailto: links

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/util/MailtoUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/MailtoUtil.java
@@ -54,7 +54,7 @@ public class MailtoUtil {
                 String[] queryEntryArray = queryEntry.split(KEY_VALUE_SEPARATOR);
                 try {
                     mailtoQueryMap.put(queryEntryArray[0], URLDecoder.decode(queryEntryArray[1], "UTF-8"));
-                } catch (UnsupportedEncodingException e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }


### PR DESCRIPTION
if the value part is missing,
it otherwise crashes when calling MailtoUtil.getText() and the exception is not handled there (it is not in at least one case).

therefore, just catch the exception in this cornercase (same for bad encoding) and return an empty string.

nb: i could not reproduce, however, the reported crash is pretty obvious

closes #3157