### PR TITLE
create QrShowFragment in time

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
@@ -63,6 +63,7 @@ public class QrActivity extends BaseActionBarActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_qr);
+        qrShowFragment = new QrShowFragment();
         tabLayout = ViewUtil.findById(this, R.id.tab_layout);
         viewPager = ViewUtil.findById(this, R.id.pager);
         ProfilePagerAdapter adapter = new ProfilePagerAdapter(this, getSupportFragmentManager());
@@ -229,7 +230,6 @@ public class QrActivity extends BaseActionBarActivity {
 
             switch (position) {
                 case TAB_SHOW:
-                    activity.qrShowFragment = new QrShowFragment();
                     fragment = activity.qrShowFragment;
                     break;
 


### PR DESCRIPTION
QrShowFragment is used by some menu entries
available also when the fragment is not displayed; therefore, creation on displaying is too late.

(the crash is present only on some android versions, as many android versions seem to create "neighboured tabs" anyways - so there should also not be much performance loss)

closes #3156 

nb: i could not reproduce the issue, fix just by checking log 