### PR TITLE
upgrade to api 34

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ android {
         multiDexEnabled true
 
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
 
         vectorDrawables.useSupportLibrary = true
 

--- a/src/gplay/AndroidManifest.xml
+++ b/src/gplay/AndroidManifest.xml
@@ -12,6 +12,7 @@
   <application>
     <service
         android:name=".notifications.FcmReceiveService"
+        android:foregroundServiceType="dataSync"
         android:exported="true">
       <intent-filter>
         <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
-    <!-- normal permissions - adding them here is enough -->
+    <!-- normal/instant permissions - adding them here is enough -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -39,6 +39,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <!-- force compiling emojipicker on sdk<21; runtime checks are required then -->
     <uses-sdk tools:overrideLibrary="androidx.emoji2.emojipicker"/>
@@ -361,14 +362,15 @@
         android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
     </activity>
 
-    <service android:name=".connect.KeepAliveService" android:enabled="true" />
+    <service android:name=".connect.KeepAliveService" android:foregroundServiceType="dataSync" android:enabled="true" />
 
-    <service android:name=".geolocation.LocationBackgroundService"  />
+    <service android:name=".geolocation.LocationBackgroundService" android:foregroundServiceType="location" />
 
-    <service android:name=".service.GenericForegroundService" />
+    <service android:name=".service.GenericForegroundService" android:foregroundServiceType="dataSync" />
 
     <service
         android:name=".service.IPCAddAccountsService"
+        android:foregroundServiceType="dataSync"
         android:enabled="true"
         android:exported="true"
         >

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -362,11 +362,18 @@
         android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
     </activity>
 
-    <service android:name=".connect.KeepAliveService" android:foregroundServiceType="dataSync" android:enabled="true" />
+    <service
+        android:name=".connect.KeepAliveService"
+        android:foregroundServiceType="dataSync"
+        android:enabled="true" />
 
-    <service android:name=".geolocation.LocationBackgroundService" android:foregroundServiceType="location" />
+    <service
+        android:name=".geolocation.LocationBackgroundService"
+        android:foregroundServiceType="location" />
 
-    <service android:name=".service.GenericForegroundService" android:foregroundServiceType="dataSync" />
+    <service
+        android:name=".service.GenericForegroundService"
+        android:foregroundServiceType="dataSync" />
 
     <service
         android:name=".service.IPCAddAccountsService"


### PR DESCRIPTION
this PR increases sdk to 34 and adds foreground services as needed.

to be done:

- check our usage of intents (maybe someone else is in the mindset of explicit/implicit intents more than me :)

<details>

![Screenshot 2024-07-15 at 12 21 36](https://github.com/user-attachments/assets/ed5a1450-4f0c-4cc7-93d6-4476d3c2eda8)

</details>

- there are also some warnings about forground-service-type declarations needed somewhere deep in androidx dependencies - not sure, if they are used during runtime. **upgrading androidx seem to require us to bump minSdkVersion from 16 to 21** or to add quite some exceptions as for emojipicker

<details>

![Screenshot 2024-07-15 at 12 26 43](https://github.com/user-attachments/assets/3897bb38-af1c-4507-ab33-d608cca470bf)

</details>

- in general, someone else should read and check "Tools / Android SDK Upgrade Assistent" additionally, i do not get all the points, just started with some :) feel free to push to this PR directly

in general, we have 6 weeks left, so compared to other issues, this is not the most pressing :)

closes #3151