### PR TITLE
tune down copying email address

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms;
 
+import android.app.Activity;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -145,23 +146,17 @@ public class ConversationTitleView extends RelativeLayout {
     avatar.setSeenRecently(seenRecently);
   }
 
-  public void hideAvatar() {
-    avatar.setVisibility(View.GONE);
-  }
-
   @Override
   public void setOnClickListener(@Nullable OnClickListener listener) {
     this.content.setOnClickListener(listener);
     this.avatar.setAvatarClickListener(listener);
   }
 
-  @Override
-  public void setOnLongClickListener(@Nullable OnLongClickListener listener) {
-    this.content.setOnLongClickListener(listener);
-    this.avatar.setAvatarLongClickListener(listener);
-  }
-
   public void setOnBackClickedListener(@Nullable OnClickListener listener) {
     this.back.setOnClickListener(listener);
+  }
+
+  public void registerForContextMenu(Activity activity) {
+    activity.registerForContextMenu(content);
   }
 }

--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -1,13 +1,12 @@
 package org.thoughtcrime.securesms;
 
-import static org.thoughtcrime.securesms.util.RelayUtil.setForwardingMessageIds;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.view.ContextMenu;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -29,7 +28,6 @@ import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
-import com.b44t.messenger.DcMsg;
 import com.google.android.material.tabs.TabLayout;
 
 import org.thoughtcrime.securesms.connect.DcEventCenter;
@@ -108,6 +106,9 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       titleView = (ConversationTitleView) supportActionBar.getCustomView();
       titleView.setOnBackClickedListener(view -> onBackPressed());
       titleView.setOnClickListener(view -> onEnlargeAvatar());
+      if (isContactProfile() && !isSelfProfile() && !chatIsDeviceTalk) {
+        titleView.registerForContextMenu(this);
+      }
     }
 
     updateToolbar();
@@ -138,7 +139,6 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
         if (chatIsDeviceTalk) {
           menu.findItem(R.id.edit_name).setVisible(false);
           menu.findItem(R.id.show_encr_info).setVisible(false);
-          menu.findItem(R.id.copy_addr_to_clipboard).setVisible(false);
           menu.findItem(R.id.share).setVisible(false);
         } else if (chatIsMultiUser) {
           if (chatIsBroadcast) {
@@ -149,7 +149,6 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
               menu.findItem(R.id.edit_name).setVisible(false);
             }
           }
-          menu.findItem(R.id.copy_addr_to_clipboard).setVisible(false);
           menu.findItem(R.id.share).setVisible(false);
         }
       } else {
@@ -185,6 +184,12 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
 
     super.onPrepareOptionsMenu(menu);
     return true;
+  }
+
+  @Override
+  public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
+    super.onCreateContextMenu(menu, v, menuInfo);
+    getMenuInflater().inflate(R.menu.profile_title_context, menu);
   }
 
   boolean backPressed = false;
@@ -425,9 +430,6 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       case R.id.share:
         onShare();
         break;
-      case R.id.copy_addr_to_clipboard:
-        onCopyAddrToClipboard();
-        break;
       case R.id.show_encr_info:
         onEncrInfo();
         break;
@@ -439,6 +441,17 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
         break;
     }
 
+    return false;
+  }
+
+  @Override
+  public boolean onContextItemSelected(MenuItem item) {
+    super.onContextItemSelected(item);
+    switch (item.getItemId()) {
+      case R.id.copy_addr_to_clipboard:
+        onCopyAddrToClipboard();
+        break;
+    }
     return false;
   }
 

--- a/src/main/res/menu/profile_common.xml
+++ b/src/main/res/menu/profile_common.xml
@@ -10,10 +10,6 @@
           android:id="@+id/edit_name"
           app:showAsAction="never"/>
 
-    <item android:title="@string/menu_copy_to_clipboard"
-        android:id="@+id/copy_addr_to_clipboard"
-        app:showAsAction="never"/>
-
     <item android:title="@string/menu_mute"
         android:id="@+id/menu_mute_notifications"
         app:showAsAction="never"/>

--- a/src/main/res/menu/profile_title_context.xml
+++ b/src/main/res/menu/profile_title_context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:title="@string/menu_copy_to_clipboard"
+        android:id="@+id/copy_addr_to_clipboard"/>
+
+</menu>


### PR DESCRIPTION
copying email addresses to the clipboard
is not proper way to get in contact in the light of chatmail - even if the account is non-chatmail, the receiver may use chatmail. or the copied contact.

it is better to point ppl to use 'Share' or 'Attach Contact' therfore and not offer failing/corner-case things in the primary menu.

therefore, we do basically the same what desktop is doing all the years: no special function, however, if you select text (desktop) or long tap it (android now), you can copy it.

nb: for whatever reason, we're not using context menu before, so it makes sense to double check if things are working as expected

<img width=320 src=https://github.com/user-attachments/assets/3763bbcb-2b29-42fe-8db3-d0e6ed90dd57> <img width=320 src=https://github.com/user-attachments/assets/69861d01-9368-4fc7-9a7c-ff3203cca9a9> 

_left: long-tap the address text, right: the cleaned up "main options"_

(i was also considering [removing copying the address alltogether](https://github.com/deltachat/deltachat-android/pull/3170), however, it may be of some use here and there. if problems stay we can reconsider)