### PR TITLE
cleanup menu

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -440,10 +440,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public boolean onPrepareOptionsMenu(Menu menu) {
-    MenuInflater inflater = this.getMenuInflater();
     menu.clear();
 
-    inflater.inflate(R.menu.conversation, menu);
+    getMenuInflater().inflate(R.menu.conversation, menu);
 
     if (dcChat.isSelfTalk() || dcChat.isBroadcast()) {
       menu.findItem(R.id.menu_mute_notifications).setVisible(false);
@@ -465,17 +464,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (isMultiUser()) {
       if (dcChat.canSend() && !dcChat.isBroadcast() && !dcChat.isMailingList()) {
-        inflater.inflate(R.menu.conversation_push_group_options, menu);
+        menu.findItem(R.id.menu_leave).setVisible(true);
       }
     }
 
-    inflater.inflate(R.menu.conversation_archive, menu);
     if (isArchived()) {
       menu.findItem(R.id.menu_archive_chat).setTitle(R.string.menu_unarchive_chat);
     }
-
-    inflater.inflate(R.menu.conversation_clear, menu);
-    inflater.inflate(R.menu.conversation_delete, menu);
 
     try {
       MenuItem searchItem = menu.findItem(R.id.menu_search_chat);

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -45,7 +45,6 @@ import android.util.Log;
 import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -471,6 +470,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (isArchived()) {
       menu.findItem(R.id.menu_archive_chat).setTitle(R.string.menu_unarchive_chat);
     }
+
+
+    Util.redMenuItem(menu, R.id.menu_leave);
+    Util.redMenuItem(menu, R.id.menu_clear_chat);
+    Util.redMenuItem(menu, R.id.menu_delete_chat);
 
     try {
       MenuItem searchItem = menu.findItem(R.id.menu_search_chat);

--- a/src/main/java/org/thoughtcrime/securesms/util/Util.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Util.java
@@ -95,7 +95,7 @@ public class Util {
   public static void redMenuItem(Menu menu, int id) {
     MenuItem item = menu.findItem(id);
     SpannableString s = new SpannableString(item.getTitle());
-    s.setSpan(new ForegroundColorSpan(Color.RED), 0, s.length(), 0);
+    s.setSpan(new ForegroundColorSpan(0xffff0c16 /*typical "destructive red" for light/dark mode*/), 0, s.length(), 0);
     item.setTitle(s);
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/util/Util.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Util.java
@@ -32,8 +32,11 @@ import android.os.Looper;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
+import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.accessibility.AccessibilityManager;
 
 import androidx.annotation.NonNull;
@@ -87,6 +90,13 @@ public class Util {
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
     return spanned;
+  }
+
+  public static void redMenuItem(Menu menu, int id) {
+    MenuItem item = menu.findItem(id);
+    SpannableString s = new SpannableString(item.getTitle());
+    s.setSpan(new ForegroundColorSpan(Color.RED), 0, s.length(), 0);
+    item.setTitle(s);
   }
 
   public static @NonNull int[] appendInt(@Nullable int[] cur, int val) {

--- a/src/main/res/menu/conversation.xml
+++ b/src/main/res/menu/conversation.xml
@@ -42,4 +42,17 @@
     <item android:title="@string/menu_add_attachment"
           android:id="@+id/menu_add_attachment" />
 
+    <item android:id="@+id/menu_leave"
+        android:visible="false"
+        android:title="@string/menu_leave_group"/>
+
+    <item android:title="@string/menu_archive_chat"
+        android:id="@+id/menu_archive_chat"/>
+
+    <item android:title="@string/clear_chat"
+        android:id="@+id/menu_clear_chat"/>
+
+    <item android:title="@string/menu_delete_chat"
+        android:id="@+id/menu_delete_chat"/>
+
 </menu>

--- a/src/main/res/menu/conversation.xml
+++ b/src/main/res/menu/conversation.xml
@@ -39,20 +39,24 @@
         android:icon="@drawable/ic_map_white_24dp"
         app:showAsAction="ifRoom" />
 
-    <item android:title="@string/menu_add_attachment"
-          android:id="@+id/menu_add_attachment" />
-
-    <item android:id="@+id/menu_leave"
-        android:visible="false"
-        android:title="@string/menu_leave_group"/>
-
     <item android:title="@string/menu_archive_chat"
         android:id="@+id/menu_archive_chat"/>
 
-    <item android:title="@string/clear_chat"
-        android:id="@+id/menu_clear_chat"/>
+    <item android:title="@string/menu_more_options">
+        <menu>
+            <item android:title="@string/menu_add_attachment"
+                android:id="@+id/menu_add_attachment" />
 
-    <item android:title="@string/menu_delete_chat"
-        android:id="@+id/menu_delete_chat"/>
+            <item android:id="@+id/menu_leave"
+                android:visible="false"
+                android:title="@string/menu_leave_group"/>
+
+            <item android:title="@string/clear_chat"
+                android:id="@+id/menu_clear_chat"/>
+
+            <item android:title="@string/menu_delete_chat"
+                android:id="@+id/menu_delete_chat"/>
+        </menu>
+    </item>
 
 </menu>

--- a/src/main/res/menu/conversation_archive.xml
+++ b/src/main/res/menu/conversation_archive.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:title="@string/menu_archive_chat"
-          android:id="@+id/menu_archive_chat"/>
-
-</menu>

--- a/src/main/res/menu/conversation_clear.xml
+++ b/src/main/res/menu/conversation_clear.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:title="@string/clear_chat"
-          android:id="@+id/menu_clear_chat"/>
-
-</menu>

--- a/src/main/res/menu/conversation_delete.xml
+++ b/src/main/res/menu/conversation_delete.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:title="@string/menu_delete_chat"
-          android:id="@+id/menu_delete_chat"/>
-
-</menu>

--- a/src/main/res/menu/conversation_push_group_options.xml
+++ b/src/main/res/menu/conversation_push_group_options.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <item android:id="@+id/menu_leave"
-          android:title="@string/menu_leave_group"
-          app:showAsAction="collapseActionView"/>
-
-</menu>


### PR DESCRIPTION
this PR removes less often used and dangerous options of a chat to a new "more" menu - the old menu was just a little big.

- "Archive" is not considered less often used, it is often used as a common pattern to handle chats
- "Add Attachment" could also be removed completely, however, better done in another PR/discussion (it is needed only for the rare usecase where ppl write first - while Delta  Chat is praised for never forgetting attachments by forcing adding them first if one really writes first accidentally, one could fix that by copy+paste)
- ~~would be nice to have the "dangerous" items red, but that can be figured out in another PR (at least there is no obvious option)~~ EDIT: found an easy-enough solution

<img width=320 src=https://github.com/user-attachments/assets/4378bd23-976d-4edc-83d4-aca4bf21b2d6>
<img width=320 src=https://github.com/user-attachments/assets/d677eebc-7ca7-488f-b8c6-64e16ded14cd>

nb: this should also fix/mitigate the - hopefully rare - issue of accidentally chat deletion: some ppl remember by "finger memory" that "last option in menu is used to switch account" - but being in the chat and not in the chatlist deletes the chat then (seen that two times now... ppl really do not read, though there is a warning saying "do you want to delete the chat" they read "do you want to switch account" :)

