### PR TITLE
show '(un)block contact' in red as well

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -175,6 +175,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     MenuItem item = menu.findItem(R.id.block_contact);
     if(item!=null) {
       item.setTitle(dcContext.getContact(contactId).isBlocked()? R.string.menu_unblock_contact : R.string.menu_block_contact);
+      Util.redMenuItem(menu, R.id.block_contact);
     }
 
     item = menu.findItem(R.id.menu_mute_notifications);


### PR DESCRIPTION
one can argue that 'unblock' is more or even less dangerous than 'block', however, the reason to leave it in 'red' is that it makes it easier to find the option again if the color does not change by state

<img width=320 src=https://github.com/user-attachments/assets/7b095172-f6c8-4614-a68b-51219374846c>

successor of https://github.com/deltachat/deltachat-android/pull/3182

