### PR TITLE
send a videochat invitation to self chat

### DIFF
--- a/src/main/java/com/b44t/messenger/DcChat.java
+++ b/src/main/java/com/b44t/messenger/DcChat.java
@@ -64,10 +64,6 @@ public class DcChat {
       return getType() == DC_CHAT_TYPE_BROADCAST;
     }
 
-    public boolean canVideochat() {
-        return canSend() && !isSelfTalk();
-    }
-
     public boolean isHalfBlocked() {
       return isProtectionBroken() || isContactRequest();
     }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -453,7 +453,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       menu.findItem(R.id.menu_show_map).setVisible(false);
     }
 
-    if (!DcHelper.isWebrtcConfigOk(dcContext) || !dcChat.canVideochat()) {
+    if (!DcHelper.isWebrtcConfigOk(dcContext) || !dcChat.canSend()) {
       menu.findItem(R.id.menu_videochat_invite).setVisible(false);
     }
 


### PR DESCRIPTION
there are not really reasons to not allow sending videochat invitations to the self chat:
- it is useful for testing
- one may forward them from there to somewhere else
- it is allowed on desktop and ios as well

in fact, i was very confused that it is not possible when playing around with https://github.com/deltachat/deltachat-android/issues/3187 . might be a relict where we did _only_ allow videochat in normal one-to-one chats.