### PR TITLE
add 'Cancel' button to location steaming dialog

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ShareLocationDialog.java
+++ b/src/main/java/org/thoughtcrime/securesms/ShareLocationDialog.java
@@ -23,6 +23,7 @@ public class ShareLocationDialog {
 
       listener.onSelected(shareLocationUnit);
     });
+    builder.setNegativeButton(R.string.cancel, null);
 
     builder.show();
   }


### PR DESCRIPTION
that was just missing
(though cancellation was implicitly always possible using 'back' or by tapping outside)

![Screenshot 2024-08-04 at 21 56 04](https://github.com/user-attachments/assets/15c3e047-69ee-4d07-a997-8129f1b6ea61)
