### PR TITLE
remove email address from primary reaction UI

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
@@ -1,12 +1,10 @@
 package org.thoughtcrime.securesms.accounts;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -20,7 +18,6 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.AvatarImageView;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.recipients.Recipient;
-import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.ThemeUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 

--- a/src/main/java/org/thoughtcrime/securesms/reactions/ReactionRecipientItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/reactions/ReactionRecipientItem.java
@@ -2,7 +2,6 @@ package org.thoughtcrime.securesms.reactions;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -20,8 +19,6 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 public class ReactionRecipientItem extends LinearLayout {
 
   private AvatarImageView contactPhotoImage;
-  private View            addrContainer;
-  private TextView        addrView;
   private TextView        nameView;
   private TextView        reactionView;
 
@@ -39,8 +36,6 @@ public class ReactionRecipientItem extends LinearLayout {
   protected void onFinishInflate() {
     super.onFinishInflate();
     this.contactPhotoImage = findViewById(R.id.contact_photo_image);
-    this.addrContainer     = findViewById(R.id.addr_container);
-    this.addrView          = findViewById(R.id.addr);
     this.nameView          = findViewById(R.id.name);
     this.reactionView      = findViewById(R.id.reaction);
 
@@ -53,22 +48,11 @@ public class ReactionRecipientItem extends LinearLayout {
     Recipient recipient = new Recipient(getContext(), dcContact);
     this.contactPhotoImage.setAvatar(glideRequests, recipient, false);
     this.reactionView.setText(reaction);
-    setText(dcContact.getDisplayName(), dcContact.getAddr());
+    this.nameView.setText(dcContact.getDisplayName());
   }
 
   public void unbind(GlideRequests glideRequests) {
     contactPhotoImage.clear(glideRequests);
-  }
-
-  private void setText(String name, String addr) {
-    this.nameView.setText(name==null? "#" : name);
-
-    if(addr != null) {
-      this.addrView.setText(addr);
-      this.addrContainer.setVisibility(View.VISIBLE);
-    } else {
-      this.addrContainer.setVisibility(View.GONE);
-    }
   }
 
   public int getContactId() {

--- a/src/main/res/layout/reaction_recipient_item.xml
+++ b/src/main/res/layout/reaction_recipient_item.xml
@@ -46,24 +46,6 @@
             android:textSize="16sp"
             tools:text="Frieeeeeeedrich Nieeeeeeeeeetzsche" />
 
-        <LinearLayout android:id="@+id/addr_container"
-                      android:orientation="horizontal"
-                      android:layout_width="wrap_content"
-                      android:layout_height="wrap_content">
-
-            <TextView android:id="@+id/addr"
-                      android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"
-                      android:textDirection="ltr"
-                      android:singleLine="true"
-                      android:ellipsize="marquee"
-                      android:textAppearance="?android:attr/textAppearanceSmall"
-                      android:textSize="14sp"
-                      android:fontFamily="sans-serif-light"
-                      tools:text="user@example.com" />
-
-        </LinearLayout>
-
     </LinearLayout>
 
     <org.thoughtcrime.securesms.components.emoji.EmojiTextView


### PR DESCRIPTION
as at other places,
we should tune down showning email addresses
also in the primary reaction UI.

ppl will recognize name and avatar,
and if in doubt, you can always tap a reaction to go to the full profile.

this also makes the dialog easier to read, brings things to the point
and adds consistency to iOS, that never showed the address.

