### PR TITLE
profile switcher: hide email for chatmail profiles

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListAdapter.java
@@ -104,10 +104,12 @@ public class AccountSelectionListAdapter extends RecyclerView.Adapter
       name = context.getString(R.string.add_account);
     } else {
       dcContact = dcContext.getContact(DcContact.DC_CONTACT_ID_SELF);
-      addr = dcContact.getAddr();
       name = dcContext.getConfig("displayname");
       if (TextUtils.isEmpty(name)) {
-        name = addr;
+        name = dcContact.getAddr();
+      }
+      if (!dcContext.isChatmail()) {
+        addr = dcContact.getAddr();
       }
       unreadCount = dcContext.getFreshMsgs().length;
     }


### PR DESCRIPTION
as on other places,
hide chatmail email address from primary UI as well in the account switcher.

non-chatmail addresses will stay for now;
we are considering to add a "tag" or sth. like that for the user to differenciate between accounts if they're using same name+avatar.

this also makes the dialog more on-point and easier to read:

<img width="351" alt="Screenshot 2024-08-05 at 17 07 15" src="https://github.com/user-attachments/assets/069675a6-c23a-4fbb-95f5-202da52c8a99">

closes #3208