### PR TITLE
delete is no primary action from enlarged images

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -375,6 +375,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     menu.clear();
     MenuInflater inflater = this.getMenuInflater();
     inflater.inflate(R.menu.media_preview, menu);
+    Util.redMenuItem(menu, R.id.delete);
 
     if (!isMediaInDb()) {
       menu.findItem(R.id.media_preview__overview).setVisible(false);

--- a/src/main/res/menu/media_preview.xml
+++ b/src/main/res/menu/media_preview.xml
@@ -5,10 +5,6 @@
         android:title="@string/menu_group_name_and_image"
         android:icon="@drawable/ic_create_white_24dp"
         app:showAsAction="always"/>
-    <item android:id="@+id/delete"
-        android:title="@string/menu_delete_messages"
-        android:icon="@drawable/ic_delete_white_24dp"
-        app:showAsAction="always"/>
     <item android:id="@+id/show_in_chat"
         android:title="@string/show_in_chat"
         app:showAsAction="never"/>
@@ -22,4 +18,7 @@
     <item android:id="@+id/media_preview__overview"
           android:title="@string/tab_gallery"
           app:showAsAction="never"/>
+    <item android:id="@+id/delete"
+        android:title="@string/delete"
+        app:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
On enlarged images, delete is not a primary action many ppl want to go for, it is more intuitive in the menu.

this is also what other messengers are doing.

(this commit was extracted from https://github.com/deltachat/deltachat-android/pull/3212


