### PR TITLE
tint destructive buttons in red

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
@@ -35,6 +35,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.connect.DirectShareUtil;
 import org.thoughtcrime.securesms.util.RelayUtil;
 import org.thoughtcrime.securesms.util.SendRelayedMessageUtil;
+import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.task.SnackbarAsyncTask;
 import org.thoughtcrime.securesms.util.views.ProgressDialog;
 
@@ -302,7 +303,8 @@ public abstract class BaseConversationListFragment extends Fragment implements A
     });
 
     alert.setNegativeButton(android.R.string.cancel, null);
-    alert.show();
+    AlertDialog dialog = alert.show();
+    Util.redPositiveButton(dialog);
   }
 
   private void handleSelectAllThreads() {

--- a/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -211,9 +211,9 @@ public class ContactSelectionListFragment extends    Fragment
   }
 
   private void handleDeleteSelected() {
-    new AlertDialog.Builder(getActivity())
+    AlertDialog dialog = new AlertDialog.Builder(getActivity())
       .setMessage(R.string.ask_delete_contacts)
-      .setPositiveButton(R.string.delete, (dialogInterface, i) -> {
+      .setPositiveButton(R.string.delete, (d, i) -> {
           ContactSelectionListAdapter adapter = getContactSelectionListAdapter();
           final SparseIntArray actionModeSelection = adapter.getActionModeSelection().clone();
           new Thread(() -> {
@@ -234,6 +234,7 @@ public class ContactSelectionListFragment extends    Fragment
           })
       .setNegativeButton(R.string.cancel, null)
       .show();
+    Util.redPositiveButton(dialog);
   }
 
   private ContactSelectionListAdapter getContactSelectionListAdapter() {

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -609,14 +609,15 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleLeaveGroup() {
-    new AlertDialog.Builder(this)
+    AlertDialog dialog = new AlertDialog.Builder(this)
       .setMessage(getString(R.string.ask_leave_group))
-      .setPositiveButton(R.string.yes, (dialog, which) -> {
+      .setPositiveButton(R.string.menu_leave_group, (d, which) -> {
         dcContext.removeContactFromChat(chatId, DcContact.DC_CONTACT_ID_SELF);
         Toast.makeText(this, getString(R.string.done), Toast.LENGTH_SHORT).show();
       })
-      .setNegativeButton(R.string.no, null)
+      .setNegativeButton(R.string.cancel, null)
       .show();
+    Util.redPositiveButton(dialog);
   }
 
   private void handleArchiveChat() {
@@ -632,16 +633,16 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleDeleteChat() {
-
-    new AlertDialog.Builder(this)
+    AlertDialog dialog = new AlertDialog.Builder(this)
         .setMessage(getResources().getString(R.string.ask_delete_named_chat, dcChat.getName()))
-        .setPositiveButton(R.string.delete, (dialog, which) -> {
+        .setPositiveButton(R.string.delete, (d, which) -> {
           dcContext.deleteChat(chatId);
           DirectShareUtil.clearShortcut(this, chatId);
           finish();
         })
         .setNegativeButton(R.string.cancel, null)
         .show();
+    Util.redPositiveButton(dialog);
   }
 
   private void handleAddAttachment() {

--- a/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -365,7 +365,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
       finish();
     });
     builder.setNegativeButton(android.R.string.cancel, null);
-    builder.show();
+    AlertDialog dialog = builder.show();
+    Util.redPositiveButton(dialog);
   }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -22,6 +22,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask;
 import org.thoughtcrime.securesms.util.StorageUtil;
+import org.thoughtcrime.securesms.util.Util;
 
 import java.util.Set;
 
@@ -66,15 +67,16 @@ public abstract class MessageSelectorFragment
       dcChat.isDeviceTalk()? R.plurals.ask_delete_messages_simple : R.plurals.ask_delete_messages,
       messageIds.length, messageIds.length);
 
-    new AlertDialog.Builder(getActivity())
+    AlertDialog dialog = new AlertDialog.Builder(getActivity())
             .setMessage(text)
             .setCancelable(true)
-            .setPositiveButton(R.string.delete, (dialog, which) -> {
+            .setPositiveButton(R.string.delete, (d, which) -> {
                 dcContext.deleteMsgs(messageIds);
                 if (actionMode != null) actionMode.finish();
             })
             .setNegativeButton(android.R.string.cancel, null)
             .show();
+    Util.redPositiveButton(dialog);
   }
 
   protected void handleSaveAttachment(final Set<DcMsg> messageRecords) {

--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -595,13 +595,14 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
           }).show();
     }
     else {
-      new AlertDialog.Builder(this)
+      AlertDialog dialog = new AlertDialog.Builder(this)
           .setMessage(R.string.ask_block_contact)
           .setCancelable(true)
           .setNegativeButton(android.R.string.cancel, null)
-          .setPositiveButton(R.string.menu_block_contact, (dialog, which) -> {
+          .setPositiveButton(R.string.menu_block_contact, (d, which) -> {
             dcContext.blockContact(contactId, 1);
           }).show();
+      Util.redPositiveButton(dialog);
     }
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -299,8 +299,8 @@ public class ProfileSettingsFragment extends Fragment
             readableToDelList.append(dcContext.getContact(toDelId).getDisplayName());
           }
           DcChat dcChat = dcContext.getChat(chatId);
-          new AlertDialog.Builder(getContext())
-              .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+          AlertDialog dialog = new AlertDialog.Builder(getContext())
+              .setPositiveButton(R.string.remove_desktop, (d, which) -> {
                 for (Integer toDelId : toDelIds) {
                   dcContext.removeContactFromChat(chatId, toDelId);
                 }
@@ -309,6 +309,7 @@ public class ProfileSettingsFragment extends Fragment
               .setNegativeButton(android.R.string.cancel, null)
               .setMessage(getString(dcChat.isBroadcast()? R.string.ask_remove_from_broadcast : R.string.ask_remove_members, readableToDelList))
               .show();
+          Util.redPositiveButton(dialog);
           return true;
       }
       return false;

--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
@@ -117,16 +117,17 @@ public class AccountSelectionListFragment extends DialogFragment
     AccountSelectionListFragment.this.dismiss();
     if (activity == null) return;
     DcAccounts accounts = DcHelper.getAccounts(activity);
-    new AlertDialog.Builder(activity)
+    AlertDialog dialog = new AlertDialog.Builder(activity)
       .setTitle(accounts.getAccount(accountId).getNameNAddr())
       .setMessage(R.string.forget_login_confirmation_desktop)
-      .setNegativeButton(R.string.cancel, (dialog, which) -> AccountManager.getInstance().showSwitchAccountMenu(activity))
-      .setPositiveButton(R.string.ok, (dialog2, which2) -> {
+      .setNegativeButton(R.string.cancel, (d, which) -> AccountManager.getInstance().showSwitchAccountMenu(activity))
+      .setPositiveButton(R.string.delete, (d2, which2) -> {
           DcHelper.getNotificationCenter(activity).removeAllNotifiations(accountId);
           accounts.removeAccount(accountId);
           AccountManager.getInstance().showSwitchAccountMenu(activity);
       })
       .show();
+    Util.redPositiveButton(dialog);
   }
 
   private void onToggleMute(int accountId) {

--- a/src/main/java/org/thoughtcrime/securesms/util/Util.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Util.java
@@ -41,6 +41,7 @@ import android.view.accessibility.AccessibilityManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.ComposeText;
@@ -92,11 +93,21 @@ public class Util {
     return spanned;
   }
 
+  private static final int redDestructiveColor = 0xffff0c16; // typical "destructive red" for light/dark mode
+
   public static void redMenuItem(Menu menu, int id) {
     MenuItem item = menu.findItem(id);
     SpannableString s = new SpannableString(item.getTitle());
-    s.setSpan(new ForegroundColorSpan(0xffff0c16 /*typical "destructive red" for light/dark mode*/), 0, s.length(), 0);
+    s.setSpan(new ForegroundColorSpan(redDestructiveColor), 0, s.length(), 0);
     item.setTitle(s);
+  }
+
+  public static void redPositiveButton(AlertDialog dialog) {
+    try {
+      dialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(redDestructiveColor);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 
   public static @NonNull int[] appendInt(@Nullable int[] cur, int val) {


### PR DESCRIPTION
this PR tints immediately destructive buttons with a red color. the idea is to make visually more clear that there is some irreversible action taking place; this is also what other apps are doing.

i was also thinking about subclassing `AlertDialog`, however, that would result in more complex code at the first glance 

the color is the same as for the menu entries, which works nicely in dark as well as light mode.

this PR is a replacement for https://github.com/deltachat/deltachat-android/pull/3212 and a successor of https://github.com/deltachat/deltachat-android/pull/3182 and https://github.com/deltachat/deltachat-android/pull/3183



<img width="379" alt="Screenshot 2024-08-09 at 12 27 18" src="https://github.com/user-attachments/assets/1909b615-e32b-4d75-bbba-397f86db6614"> <img width="379" alt="Screenshot 2024-08-09 at 12 27 40" src="https://github.com/user-attachments/assets/43845b93-5be0-48e7-9210-b3ffdf2a6772"> 
