### PR TITLE
R10s/improve ask delete chat

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -632,8 +632,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleDeleteChat() {
+
     new AlertDialog.Builder(this)
-        .setMessage(getResources().getQuantityString(R.plurals.ask_delete_chat, 1, 1))
+        .setMessage(getResources().getString(R.string.ask_delete_named_chat, dcChat.getName()))
         .setPositiveButton(R.string.delete, (dialog, which) -> {
           dcContext.deleteChat(chatId);
           DirectShareUtil.clearShortcut(this, chatId);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -225,7 +225,6 @@
     <string name="menu_delete_chat">Delete Chat</string>
     <!-- Command to delete all messages in a chat. The chat itself will not be deleted but will be empty afterwards, so make sure to be different from "Delete Chat" here. "Clear" is a verb here, "Empty Chat" would also be fine (eg. in German "Chat leeren") -->
     <string name="clear_chat">Clear Chat</string>
-    <string name="ask_delete_named_chat">Are you sure you want to delete \"%1$s\"?</string>
     <string name="menu_delete_messages">Delete Messages</string>
     <string name="delete_contact">Delete Contact</string>
     <string name="menu_delete_location">Delete this Location?</string>
@@ -341,6 +340,7 @@
         <item quantity="one">Delete %d chat? It will no longer be shown in the chat list; its messages will remain on the server.</item>
         <item quantity="other">Delete %d chats? They will no longer be shown in the chat list; their messages will remain on the server.</item>
     </plurals>
+    <string name="ask_delete_named_chat">Delete chat \"%1$s\"? It will no longer be shown in the chat list; its messages will remain on the server.</string>
     <string name="ask_delete_message">Are you sure you want to delete this message?</string>
     <plurals name="ask_delete_messages">
         <item quantity="one">Delete %d message here and on the server?</item>


### PR DESCRIPTION
this PR improves the string used when a single chat is about being deleted as discussed at https://github.com/deltachat/deltachat-desktop/pull/4072

moreover, if only one chat is about being deleted, this PR makes use of the strings on android as well (as now the same warning is provided). when multiple strings are about being deleted, nothing changed and the old string is used.

once merged, we need to call `./scripts/tx-update-changed-sources.sh`

this PR is a replacement for https://github.com/deltachat/deltachat-desktop/pull/4072

<img width="379" alt="Screenshot 2024-08-09 at 13 03 00" src="https://github.com/user-attachments/assets/f16d7228-fcb3-4804-9e3b-ecf91547a625">
<img width="379" alt="Screenshot 2024-08-09 at 12 48 38" src="https://github.com/user-attachments/assets/bec439a1-f50a-4625-84b7-59bbab748ad8">

