### PR TITLE
mark bots in chat title and profile as such

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1857,6 +1857,11 @@ JNIEXPORT jint Java_com_b44t_messenger_DcContact_getVerifierId(JNIEnv *env, jobj
     return dc_contact_get_verifier_id(get_dc_contact(env, obj));
 }
 
+JNIEXPORT jboolean Java_com_b44t_messenger_DcContact_isBot(JNIEnv *env, jobject obj)
+{
+    return dc_contact_is_bot(get_dc_contact(env, obj)) != 0;
+}
+
 
 /*******************************************************************************
  * DcLot

--- a/src/main/java/com/b44t/messenger/DcContact.java
+++ b/src/main/java/com/b44t/messenger/DcContact.java
@@ -58,6 +58,7 @@ public class DcContact {
     public native boolean isBlocked      ();
     public native boolean isVerified     ();
     public native int     getVerifierId  ();
+    public native boolean isBot          ();
 
     // working with raw c-data
     private long        contactCPtr;    // CAVE: the name is referenced in the JNI

--- a/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -104,7 +104,9 @@ public class ConversationTitleView extends RelativeLayout {
       }
       else {
         DcContact dcContact = dcContext.getContact(chatContacts[0]);
-        if (profileView || !dcChat.isProtected()) {
+        if (!profileView && dcContact.isBot()) {
+          subtitleStr = context.getString(R.string.bot);
+        } else if (profileView || !dcChat.isProtected()) {
           subtitleStr = dcContact.getAddr();
         }
         isOnline = dcContact.wasSeenRecently();

--- a/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -105,7 +105,7 @@ public class ConversationTitleView extends RelativeLayout {
       else {
         DcContact dcContact = dcContext.getContact(chatContacts[0]);
         if (!profileView && dcContact.isBot()) {
-          subtitleStr = context.getString(R.string.bot);
+          subtitleStr = context.getString(R.string.bot).toLowerCase();
         } else if (profileView || !dcChat.isProtected()) {
           subtitleStr = dcContact.getAddr();
         }

--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -368,7 +368,11 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
           if (chatIsDeviceTalk) {
             return getString(R.string.profile);
           } else if(isContactProfile()) {
-            return getString(R.string.tab_contact);
+            if (dcContext.getContact(contactId).isBot()) {
+              return getString(R.string.bot);
+            } else {
+              return getString(R.string.tab_contact);
+            }
           }
           else if (chatIsBroadcast) {
             return getString(R.string.broadcast_list);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -162,6 +162,7 @@
     <string name="video">Video</string>
     <string name="documents">Documents</string>
     <string name="contact">Contact</string>
+    <string name="bot">Bot</string>
     <string name="camera">Camera</string>
     <!-- As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras -->
     <string name="capture">Capture</string>


### PR DESCRIPTION
- in chat titles, show "Bot" instead of the email address of an empty line

- in profiles, show "Bot" instead of "Contact" in the corresponding tab

there are several ideas  for further iterations, but that seems to be a good start, that can also be done on other platforms very easily

<img width="379" alt="Screenshot 2024-08-09 at 16 43 49" src="https://github.com/user-attachments/assets/d30b0fc2-e0a1-4cd4-b2dc-fcf2b8c7d8d1">
<img width="379" alt="Screenshot 2024-08-09 at 16 44 23" src="https://github.com/user-attachments/assets/6828d4da-d148-4d60-9a44-7d2affe8d2ff">
