### PR TITLE
build: update NDK to r27

### DIFF
--- a/.github/workflows/preview-apk.yml
+++ b/.github/workflows/preview-apk.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r23c
+          ndk-version: r27
 
       - name: Compile core
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/bin
 # Install NDK manually. Other SDK parts are installed automatically by gradle.
 #
 # If you change the NDK version here, also change it in `flake.nix`.
-# NDK version r23c LTS aka 23.2.8568313
-RUN sdkmanager --sdk_root=${ANDROID_SDK_ROOT} 'ndk;23.2.8568313'
+# NDK version r27 LTS aka 27.0.11902837
+RUN sdkmanager --sdk_root=${ANDROID_SDK_ROOT} 'ndk;27.0.11902837'
 
-ENV ANDROID_NDK_ROOT ${ANDROID_SDK_ROOT}/ndk/23.2.8568313
+ENV ANDROID_NDK_ROOT ${ANDROID_SDK_ROOT}/ndk/27.0.11902837
 ENV PATH ${PATH}:${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ android {
     //   > Task :stripFatDebugDebugSymbols
     //   Unable to strip the following libraries, packaging them as they are: libanimation-decoder-gif.so, libnative-utils.so.
     // See <https://issuetracker.google.com/issues/237187538> for details.
-    ndkVersion "23.2.8568313"
+    ndkVersion "27.0.12077973"
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1710633978,
-        "narHash": "sha256-yemnwSvW7cdWtXGpivFA5jDO35rGPs6fqxlQ4l6ODXs=",
+        "lastModified": 1720988215,
+        "narHash": "sha256-nQ0Zx0vAWJo0IOGNFjCOdIkDSgOpMa//GalR8tbTl3A=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "e91fb3d8517538e5ad9b422c9a4f604b56008a9e",
+        "rev": "5a052c62cdb51b210bc0717177d5bd014cba3df1",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708939976,
-        "narHash": "sha256-O5+nFozxz2Vubpdl1YZtPrilcIXPcRAjqNdNE8oCRoA=",
+        "lastModified": 1717408969,
+        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "5ddecd67edbd568ebe0a55905273e56cc82aabe3",
+        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -96,31 +96,13 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709237383,
-        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "lastModified": 1720768451,
+        "narHash": "sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "rev": "7e7c39ea35c5cdd002cd4588b03a3fb9ece6fad9",
         "type": "github"
       },
       "original": {
@@ -132,11 +114,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1710889954,
-        "narHash": "sha256-Pr6F5Pmd7JnNEMHHmspZ0qVqIBVxyZ13ik1pJtm2QXk=",
+        "lastModified": 1723221148,
+        "narHash": "sha256-7pjpeQlZUNQ4eeVntytU3jkw9dFK3k1Htgk2iuXjaD8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7872526e9c5332274ea5932a0c3270d6e4724f3b",
+        "rev": "154bcb95ad51bc257c2ce4043a725de6ca700ef6",
         "type": "github"
       },
       "original": {
@@ -148,11 +130,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
         "type": "github"
       },
       "original": {
@@ -172,15 +154,14 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1711073443,
-        "narHash": "sha256-PpNb4xq7U5Q/DdX40qe7CijUsqhVVM3VZrhN0+c6Lcw=",
+        "lastModified": 1723429325,
+        "narHash": "sha256-4x/32xTCd+xCwFoI/kKSiCr5LQA2ZlyTRYXKEni5HR8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "eec55ba9fcde6be4c63942827247e42afef7fafe",
+        "rev": "65e3dc0fe079fe8df087cd38f1fe6836a0373aad",
         "type": "github"
       },
       "original": {
@@ -220,21 +201,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
             ndk-bundle
             platform-tools
             platforms-android-34
-            ndk-23-2-8568313
+            ndk-27-0-11902837
           ]);
         rust-version = pkgs.lib.removeSuffix "\n"
           (builtins.readFile ./scripts/rust-toolchain);
@@ -28,7 +28,7 @@
         devShells.default = pkgs.mkShell {
           ANDROID_SDK_ROOT = "${android-sdk}/share/android-sdk";
           ANDROID_NDK_ROOT =
-            "${android-sdk}/share/android-sdk/ndk/23.2.8568313";
+            "${android-sdk}/share/android-sdk/ndk/27.0.11902837";
           buildInputs = [
             android-sdk
             pkgs.openjdk17

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -7,57 +7,6 @@
 #include "deltachat-core-rust/deltachat-ffi/deltachat.h"
 
 
-#if __ANDROID_API__ == 16
-unsigned long getauxval(unsigned long type) {
-    return 0;
-}
-
-#include <sys/socket.h>
-#include <unistd.h>
-
-int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
-             int flags)
-{
-    if (flags != 0) {
-        // Not supported by the fallback.
-        return -1;
-    }
-
-    if (vlen == 0) {
-        return 0;
-    }
-
-    ssize_t n = sendmsg(sockfd, &msgvec->msg_hdr, flags);
-    if (n == -1) {
-        return -1;
-    }
-
-    (*msgvec).msg_len = n;
-    return 1;
-}
-
-int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
-             int flags, struct timespec *timeout)
-{
-    if (flags != 0) {
-        // Not supported by the fallback.
-        return -1;
-    }
-
-    if (vlen == 0) {
-        return 0;
-    }
-
-    int n = recvmsg(sockfd, &msgvec->msg_hdr, flags);
-    if (n == -1) {
-        return -1;
-    }
-    (*msgvec).msg_len = n;
-    return 1;
-}
-#endif
-
-
 static dc_msg_t* get_dc_msg(JNIEnv *env, jobject obj);
 
 

--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -68,9 +68,9 @@ fi
 unset RUSTFLAGS
 
 TOOLCHAIN="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$NDK_HOST_TAG"
-export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$TOOLCHAIN/bin/armv7a-linux-androideabi16-clang"
+export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$TOOLCHAIN/bin/armv7a-linux-androideabi21-clang"
 export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/aarch64-linux-android21-clang"
-export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/i686-linux-android16-clang"
+export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/i686-linux-android21-clang"
 export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$TOOLCHAIN/bin/x86_64-linux-android21-clang"
 
 export RUSTUP_TOOLCHAIN=$(cat "$(dirname "$0")/rust-toolchain")
@@ -116,7 +116,7 @@ unset CPATH
 
 if test -z $1 || test $1 = armeabi-v7a; then
     echo "-- cross compiling to armv7-linux-androideabi (arm) --"
-    TARGET_CC="$TOOLCHAIN/bin/armv7a-linux-androideabi16-clang" \
+    TARGET_CC="$TOOLCHAIN/bin/armv7a-linux-androideabi21-clang" \
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target armv7-linux-androideabi -p deltachat_ffi --features jsonrpc
@@ -134,7 +134,7 @@ fi
 
 if test -z $1 || test $1 = x86; then
     echo "-- cross compiling to i686-linux-android (x86) --"
-    TARGET_CC="$TOOLCHAIN/bin/i686-linux-android16-clang" \
+    TARGET_CC="$TOOLCHAIN/bin/i686-linux-android21-clang" \
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target i686-linux-android -p deltachat_ffi --features jsonrpc


### PR DESCRIPTION
If we are dropping Android 4 support anyway,
can as well upgrade to the current LTS NDK
which requires API level 21 (Android 5.0).