### PR TITLE
handle now unsupported oauth2

### DIFF
--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -260,6 +260,15 @@ public class DcContext {
       }
     }
 
+    public boolean isGmailOauth2Addr(String addr) {
+      final String oauth2url = getOauth2Url(addr, "chat.delta:/foo");
+      return isGmailOauth2Url(oauth2url);
+    }
+
+    public boolean isGmailOauth2Url(String oauth2url) {
+      return oauth2url.startsWith("https://accounts.google.com/");
+    }
+
     /**
      * @return true if at least one chat has location streaming enabled
      */

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -18,6 +18,8 @@ package org.thoughtcrime.securesms;
 
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
 import static org.thoughtcrime.securesms.ConversationActivity.STARTING_POSITION_EXTRA;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ADDRESS;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SERVER_FLAGS;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
 import static org.thoughtcrime.securesms.util.RelayUtil.getDirectSharingChatId;
 import static org.thoughtcrime.securesms.util.RelayUtil.getSharedTitle;
@@ -140,6 +142,20 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
         Prefs.setBooleanPreference(this, "info_about_switch_profile_added", true);
       }
       // /add info
+
+
+      // remove gmail oauth2
+      final int serverFlags = dcContext.getConfigInt(CONFIG_SERVER_FLAGS);
+      if ((serverFlags & DcContext.DC_LP_AUTH_OAUTH2)!=0) {
+        Util.runOnAnyBackgroundThread(() -> {
+          if (dcContext.isGmailOauth2Addr(dcContext.getConfig(CONFIG_ADDRESS))) {
+            final DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+            msg.setText("⚠️ GMail Users: If you have problems using GMail, go to \"Settings / Advanced / Password and Account\".\n\nThere, login again using an \"App Password\".");
+            dcContext.addDeviceMsg("info_about_gmail_oauth2_removal8", msg);
+          }
+        });
+      }
+      // /remove gmail oauth2
 
     } catch(Exception e) {
       e.printStackTrace();

--- a/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -231,7 +231,16 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
 
             int serverFlags = DcHelper.getInt(this, CONFIG_SERVER_FLAGS);
             int sel = 0;
-            if((serverFlags&DcContext.DC_LP_AUTH_OAUTH2)!=0) sel = 1;
+            if((serverFlags&DcContext.DC_LP_AUTH_OAUTH2)!=0) {
+              sel = 1;
+
+              // remove gmail oauth2
+              if (DcHelper.getContext(this).isGmailOauth2Addr(email)) { // this is a blocking call, not perfect, but as rarely used and temporary, good enough
+                sel = 0;
+                updateProviderInfo(); // we refer to the hints in the device message, show them immediately
+              }
+              // /remove gmail oauth2
+            }
             authMethod.setSelection(sel);
             expandAdvanced = expandAdvanced || sel != 0;
 
@@ -424,6 +433,13 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             // and should be whitelisted by the supported oauth2 services
             String redirectUrl = "chat.delta:/"+BuildConfig.APPLICATION_ID+"/auth";
             oauth2url = dcContext.getOauth2Url(email, redirectUrl);
+
+            // remove gmail oauth2
+            if (dcContext.isGmailOauth2Url(oauth2url)) {
+              oauth2url = null;
+            }
+            // /remove gmail oauth2
+
             return null;
         }
 


### PR DESCRIPTION
this PR adds a device message for existing gmail-oauth2 users, telling them how to fix log in problems.

new gmail profiles won't be created using gmail-oauth2

<img width=320 src=https://github.com/user-attachments/assets/0fd71c2f-dd87-4bf0-ad05-9f5670c05b94>
<img width=320 src=https://github.com/user-attachments/assets/b0e18342-fea1-415c-a9bc-6b7a921595a3>

closes #3233 

~~need to update the hints in the provider-db now~~ EDIT: done: https://github.com/deltachat/provider-db/pull/299