### PR TITLE
prepare 1.46.11 (testrun)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Delta Chat Android Changelog
 
+## v1.46.11 Testrun
+2024-08
+
+* when SOCKS5 is enabled, route autoconfig and oauth2 config there
+* fix moving outgoing auto-generated messages to the "DeltaChat" folder
+* fix: try to create "INBOX.DeltaChat" if "DeltaChat" is not possible for some provider
+* fix receiving messages with "DeltaChat" folder cannot be selected
+* update provider database
+* update to core 1.142.6
+
+
 ## v1.46.10
 2024-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## v1.46.11 Testrun
 2024-08
 
+* add direct support for android14, required to be able to continue shipping to Google Play
+* drop support for android4, as this is no longer supported by various dependencies
+* drop support for gmail oauth2, gmail can still be used using "App Passwords", you'll get hints as needed
+  (reason for dropping was unmaintainable bureaucracy and costs added by google)
+* update various dependencies for added security and stability
+* jcenter (a dependency origin) is closing, move dependencies to other origins
 * when SOCKS5 is enabled, route autoconfig and oauth2 config there
 * fix moving outgoing auto-generated messages to the "DeltaChat" folder
 * fix: try to create "INBOX.DeltaChat" if "DeltaChat" is not possible for some provider

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        versionCode 692
-        versionName "1.46.10"
+        versionCode 693
+        versionName "1.46.11"
 
         applicationId "com.b44t.messenger"
         multiDexEnabled true


### PR DESCRIPTION
this release contains required dependency and api updates, affecting potentially all aspects of the apps, resulting in everythings needs to be tested to avoid regressions :)

(this testrun is still in the 1.46 series as we may continue the series when this version is tested some time)