### PR TITLE
tweak colors of the status bar

### DIFF
--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -7,6 +7,6 @@
     <color name="reaction_pill_border_selected">@color/reaction_pill_border</color>
     <color name="reaction_pill_text_color_selected">@color/reaction_pill_text_color</color>
 
-    <color name="action_mode_status_bar">@color/gray95</color>
+    <color name="action_mode_status_bar">@color/gray78</color>
     <color name="dummy_avatar_color">#808080</color>
 </resources>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -36,7 +36,7 @@
 
     <color name="conversation_compose_divider">#32000000</color>
 
-    <color name="action_mode_status_bar">@color/gray65</color>
+    <color name="action_mode_status_bar">@color/gray50</color>
     <color name="touch_highlight">#400099cc</color>
 
     <color name="device_link_item_background_light">#ffffffff</color>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -9,7 +9,7 @@
 
         <item name="theme_type">light</item>
         <item name="colorPrimary">@color/delta_primary</item>
-        <item name="colorPrimaryDark">@color/delta_primary_dark</item>
+        <item name="colorPrimaryDark">@color/delta_primary</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
         <item name="contact_selection_label_text">#66000000</item>
@@ -29,6 +29,7 @@
         <item name="theme_type">dark</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="colorPrimary">@color/gray95</item>
+        <item name="colorPrimaryDark">@color/gray95</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
         <item name="contact_selection_label_text">#66eeeeee</item>
@@ -44,9 +45,9 @@
         <item name="theme_type">light</item>
         <item name="actionBarStyle">@style/TextSecure.LightActionBar</item>
         <item name="actionBarTabBarStyle">@style/TextSecure.LightActionBar.TabBar</item>
-        <item name="actionModeBackground">@color/gray50</item>
+        <item name="actionModeBackground">@color/action_mode_status_bar</item>
         <item name="colorPrimary">@color/delta_primary</item>
-        <item name="colorPrimaryDark">@color/delta_primary_dark</item>
+        <item name="colorPrimaryDark">@color/delta_primary</item>
 
         <item name="colorAccent">@color/delta_accent</item>
         <item name="colorControlActivated">@color/delta_accent</item>
@@ -193,8 +194,10 @@
         <item name="android:navigationBarColor" tools:targetApi="21">@color/black</item>
         <item name="actionBarStyle">@style/TextSecure.DarkActionBar</item>
         <item name="actionBarTabBarStyle">@style/TextSecure.DarkActionBar.TabBar</item>
+        <item name="colorPrimary">@color/gray95</item>
+        <item name="colorPrimaryDark">@color/gray95</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
-        <item name="actionModeBackground">@color/gray78</item>
+        <item name="actionModeBackground">@color/action_mode_status_bar</item>
         <item name="android:textColor">@color/text_color_dark_theme</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark_theme</item>
 


### PR DESCRIPTION
use same color as the app bar to give a more "modern" feeling to the app, other apps like Telegram, Signal, etc. use the same color for the app bar and status bar these days


<img src="https://github.com/user-attachments/assets/0a1c7519-7eb8-444c-929d-11973f01109f" align="left" width="300" >
<img src="https://github.com/user-attachments/assets/5b019fc0-76e0-43a4-85c7-2a32ab741ea5" align="left" width="300" >
