### PR TITLE
refresh title bar color 

### DIFF
--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -94,9 +94,6 @@
     <attr name="dialog_alert_icon" format="reference" />
     <attr name="dialog_background_color" format="reference|color" />
 
-    <attr name="contact_selection_label_text" format="reference|color" />
-    <attr name="contact_selection_header_text" format="reference|color" />
-
     <attr name="device_link_item_card_background" format="reference|color" />
 
     <attr name="import_export_item_background_color" format="reference|color" />
@@ -126,8 +123,6 @@
     </declare-styleable>
 
     <attr name="group_members_dialog_icon" format="reference"/>
-
-    <attr name="recipient_preference_blocked" format="color"/>
 
     <attr name="verification_background" format="color"/>
 

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
     <color name="delta_primary">#ff415e6b</color>
-    <color name="delta_primary_dark">#ff364e59</color>
     <color name="delta_primary_lite">#4c6e7d</color>
 
     <!-- delta_accent fits in light and in darkmode;

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
-    <color name="delta_primary">#ff415e6b</color>
-    <color name="delta_primary_lite">#4c6e7d</color>
+    <color name="delta_primary">#ff4b766c</color>
+    <color name="delta_primary_lite">#578379</color>
 
     <!-- delta_accent fits in light and in darkmode;
      delta_accent_darker can be used for less-covered areas as non-bold text  -->

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -11,10 +11,6 @@
         <item name="colorPrimary">@color/delta_primary</item>
         <item name="colorPrimaryDark">@color/delta_primary</item>
 
-        <item name="recipient_preference_blocked">#d00000</item>
-        <item name="contact_selection_label_text">#66000000</item>
-        <item name="contact_selection_header_text">@color/delta_primary_dark</item>
-
         <item name="profile_toolbar_background">@color/white</item>
         <item name="profile_toolbar_foreground">@color/gray70</item>
         <item name="profile_header_foreground">@color/gray50</item>
@@ -30,10 +26,6 @@
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="colorPrimary">@color/gray95</item>
         <item name="colorPrimaryDark">@color/gray95</item>
-
-        <item name="recipient_preference_blocked">#d00000</item>
-        <item name="contact_selection_label_text">#66eeeeee</item>
-        <item name="contact_selection_header_text">#66eeeeee</item>
 
         <item name="profile_toolbar_background">@color/black</item>
         <item name="profile_toolbar_foreground">@color/white</item>
@@ -172,7 +164,7 @@
         <item name="menu_forward_icon">@drawable/ic_forward_white_24dp</item>
         <item name="menu_reply_icon">@drawable/ic_reply_white_24dp</item>
 
-        <item name="pref_icon_tint">@color/delta_primary_dark</item>
+        <item name="pref_icon_tint">@color/delta_primary</item>
         <item name="icon_tint">@color/grey_700</item>
         <item name="icon_tint_dark">@color/grey_100</item>
 


### PR DESCRIPTION
after all the years, the blueish green
could need a freshup.

the new color is close enough,
that it does not break layout of other apps,
existing screenshots and so on.
that can be updated without stress as needed.

the new color was inspired by "Rinmans Green",
which has the additional safetly feature
to be [known as an antibacterial color!](https://www.monumente-online.de/de/ausgaben/2015/3/was-auf-der-hohen-kante-lag.php)

<img width=320 src=https://github.com/user-attachments/assets/f8679707-e55e-448b-83c7-ecdb9a0ac8e4> &nbsp; &nbsp; <img width=320 src=https://github.com/user-attachments/assets/98d10b7b-7679-4d2c-b3c2-86f1f9e232c9>
