### PR TITLE
clean content of obj and build folders

### DIFF
--- a/scripts/clean-core.sh
+++ b/scripts/clean-core.sh
@@ -2,6 +2,12 @@ cd jni/deltachat-core-rust
 cargo clean
 cd -
 
+rm -rf build/generated
+rm -rf build/intermediates
+rm -rf build/outputs
+rm -rf build/tmp
+rm     build/gmpAppId.txt
+rm -rf obj/local
 rm -rf jni/deltachat-core-rust/target
 rm jni/armeabi-v7a/libdeltachat.a
 rm jni/x86/libdeltachat.a


### PR DESCRIPTION
explicitly list the content to be deleted,
to have some more general protection in case sth. goes wrong accidentally ...