### PR TITLE
improve nickname dialog

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1778,6 +1778,15 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcContact_getName(JNIEnv *env, jobject
 }
 
 
+JNIEXPORT jstring Java_com_b44t_messenger_DcContact_getAuthName(JNIEnv *env, jobject obj)
+{
+    char* temp = dc_contact_get_auth_name(get_dc_contact(env, obj));
+        jstring ret = JSTRING_NEW(temp);
+    dc_str_unref(temp);
+    return ret;
+}
+
+
 JNIEXPORT jstring Java_com_b44t_messenger_DcContact_getDisplayName(JNIEnv *env, jobject obj)
 {
     char* temp = dc_contact_get_display_name(get_dc_contact(env, obj));

--- a/src/main/java/com/b44t/messenger/DcContact.java
+++ b/src/main/java/com/b44t/messenger/DcContact.java
@@ -47,6 +47,7 @@ public class DcContact {
 
     public native int     getId          ();
     public native String  getName        ();
+    public native String  getAuthName    ();
     public native String  getDisplayName ();
     public native String  getAddr        ();
     public native String  getNameNAddr   ();

--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -6,6 +6,7 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.text.TextUtils;
 import android.view.ContextMenu;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -550,12 +551,21 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
     }
     else {
       DcContact dcContact = dcContext.getContact(contactId);
+
+      String authName = dcContact.getAuthName();
+      if (TextUtils.isEmpty(authName)) {
+        authName = dcContact.getAddr();
+      }
+
       View gl = View.inflate(this, R.layout.single_line_input, null);
       EditText inputField = gl.findViewById(R.id.input_field);
       inputField.setText(dcContact.getName());
       inputField.setSelection(inputField.getText().length());
+      inputField.setHint(getString(R.string.edit_name_placeholder, authName));
+
       new AlertDialog.Builder(this)
           .setTitle(R.string.menu_edit_name)
+          .setMessage(getString(R.string.edit_name_explain, authName))
           .setView(gl)
           .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
             String newName = inputField.getText().toString();

--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -572,6 +572,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
             dcContext.createContact(newName, dcContact.getAddr());
           })
           .setNegativeButton(android.R.string.cancel, null)
+          .setCancelable(false)
           .show();
     }
   }

--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -161,6 +161,10 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
         menu.findItem(R.id.menu_vibrate).setVisible(false);
       }
 
+      if (isContactProfile()) {
+        menu.findItem(R.id.edit_name).setTitle(R.string.menu_edit_name);
+      }
+
       if (!isContactProfile() || chatIsDeviceTalk) {
         menu.findItem(R.id.block_contact).setVisible(false);
       }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
     <string name="select_more">Select more</string>
     <string name="menu_edit_name">Edit Name</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
-    <string name="edit_name_explain">Set a local nickname to replace \"%1$s\". Leave empty to use the contact\'s chosen name.</string>
+    <string name="edit_name_explain">Set a nickname that will be displayed for you instead of \"%1$s\". Leave empty to use the contact\'s chosen name.</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
     <string name="edit_name_placeholder">Nickname for \"%1$s\"</string>
     <string name="menu_settings">Settings</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
     <string name="select_more">Select more</string>
     <string name="menu_edit_name">Edit Name</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
-    <string name="edit_name_explain">Set a nickname that will be displayed for you instead of \"%1$s\". Leave empty to use the user\'s chosen name.</string>
+    <string name="edit_name_explain">Set a local nickname to replace \"%1$s\". Leave empty to use the user\'s chosen name.</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
     <string name="edit_name_placeholder">Nickname for \"%1$s\"</string>
     <string name="menu_settings">Settings</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -267,6 +267,10 @@
     <string name="select_chat">Select Chat</string>
     <string name="select_more">Select more</string>
     <string name="menu_edit_name">Edit Name</string>
+    <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
+    <string name="edit_name_explain">Set a nickname that will be displayed for you instead of \"%1$s\". Leave empty to use the user\'s chosen name.</string>
+    <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
+    <string name="edit_name_placeholder">Nickname for \"%1$s\"</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_advanced">Advanced</string>
     <string name="menu_view_profile">View Profile</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
     <string name="select_more">Select more</string>
     <string name="menu_edit_name">Edit Name</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
-    <string name="edit_name_explain">Set a nickname that will be displayed for you instead of \"%1$s\". Leave empty to use the contact\'s chosen name.</string>
+    <string name="edit_name_explain">Set a nickname that will be shown to you instead of \"%1$s\". Leave empty to use the contact\'s chosen name.</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
     <string name="edit_name_placeholder">Nickname for \"%1$s\"</string>
     <string name="menu_settings">Settings</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
     <string name="select_more">Select more</string>
     <string name="menu_edit_name">Edit Name</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
-    <string name="edit_name_explain">Set a local nickname to replace \"%1$s\". Leave empty to use the user\'s chosen name.</string>
+    <string name="edit_name_explain">Set a local nickname to replace \"%1$s\". Leave empty to use the contact\'s chosen name.</string>
     <!-- The placeholder will be replaced by the name the contact gave themself (if any) or by an e-mail address. -->
     <string name="edit_name_placeholder">Nickname for \"%1$s\"</string>
     <string name="menu_settings">Settings</string>


### PR DESCRIPTION
this PR improves the "Edit Name" dialog.

inspired by [this forum post](https://support.delta.chat/t/ux-for-setting-alias-name-for-contacts-is-not-obvious/3224) - indeed, there was just nothing. thanks a lot for the hints!

after some internal discussions, we went for placeholder+description. using radio buttons looks to complex for a comparable easy task, also in relation to comparable dialogs in-app and in other apps.

moreover, the PR uses the string "Edit Name" instead of "Edit" in the menu. i was thinking about renaming that even to "Nickname", however, that may be confusing on other levels,  we can always iterate.

finally, the dialog is no longer closed by one wrong tap, avoiding potential loss of typed names.

once this is merged, desktop and iOS can pick up these strings.

<img width=320 src=https://github.com/user-attachments/assets/7d416225-f9e7-46a0-97e7-10c8a210f605>
<img width=320 src=https://github.com/user-attachments/assets/0fefd4ef-7ac5-4d6a-8c4b-f12b34e0d8bc>

_before / after_