### PR TITLE
Increase account switcher hitbox

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -182,7 +182,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     TooltipCompat.setTooltipText(searchAction, getText(R.string.search_explain));
 
     TooltipCompat.setTooltipText(selfAvatar, getText(R.string.switch_account));
-    toolbar.setOnClickListener(v -> {
+    findViewById(R.id.avatar_and_title).setOnClickListener(v -> {
       if (!isRelayingMessageContent(this)) {
         AccountManager.getInstance().showSwitchAccountMenu(this);
       }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -182,8 +182,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     TooltipCompat.setTooltipText(searchAction, getText(R.string.search_explain));
 
     TooltipCompat.setTooltipText(selfAvatar, getText(R.string.switch_account));
-    selfAvatar.setOnClickListener(v -> AccountManager.getInstance().showSwitchAccountMenu(this));
-    title.setOnClickListener(v -> {
+    toolbar.setOnClickListener(v -> {
       if (!isRelayingMessageContent(this)) {
         AccountManager.getInstance().showSwitchAccountMenu(this);
       }

--- a/src/main/res/layout/conversation_list_activity.xml
+++ b/src/main/res/layout/conversation_list_activity.xml
@@ -14,8 +14,8 @@
             android:layout_height="?attr/actionBarSize"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
-            app:contentInsetStart="14dp"
-            app:contentInsetLeft="14dp"
+            app:contentInsetStart="0dp"
+            app:contentInsetLeft="0dp"
             android:elevation="4dp"
             android:theme="?attr/actionBarStyle">
 
@@ -24,47 +24,57 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-          <RelativeLayout
-              android:id="@+id/self_avatar_container"
-              android:orientation="vertical"
-              android:layout_width="wrap_content"
-              android:layout_height="match_parent">
-            <org.thoughtcrime.securesms.components.AvatarImageView
-                android:id="@+id/self_avatar"
-                android:foreground="@drawable/contact_photo_background"
-                android:layout_width="35dp"
-                android:layout_height="35dp"
-                android:layout_marginRight="10dp"
-                android:layout_marginEnd="10dp"
-                android:layout_marginTop="5dp"
-                android:layout_marginBottom="5dp"
-                android:cropToPadding="true"
-                android:clickable="true"
-                app:inverted="true"
-                tools:src="@drawable/ic_contact_picture"
-                android:contentDescription="@string/pref_profile_info_headline" />
-            <ImageView android:id="@+id/unread_indicator"
-                       android:layout_width="20dp"
-                       android:layout_height="20dp"
-                       android:layout_marginLeft="20dp"
-                       android:layout_marginStart="20dp"
-                       app:layout_constraintTop_toTopOf="parent"
-                       android:layout_marginBottom="16dp"
-                       android:contentDescription="@null"
-                       android:visibility="gone"
-                       />
-          </RelativeLayout>
+          <LinearLayout
+              android:id="@+id/avatar_and_title"
+              android:orientation="horizontal"
+              android:layout_width="0dp"
+              android:layout_weight="1"
+              android:paddingStart="14dp"
+              android:layout_height="match_parent"
+              android:layout_marginEnd="10dp">
 
-            <TextView style="@style/TextSecure.TitleTextStyle"
-                      android:id="@+id/toolbar_title"
-                      android:layout_width="0dp"
-                      android:layout_height="wrap_content"
-                      android:text="@string/app_name"
-                      android:layout_weight="1"
-                      android:layout_gravity="center_vertical"
-                      android:paddingRight="10dp"
-                      android:ellipsize="end"
-                      android:maxLines="1"/>
+            <RelativeLayout
+                android:id="@+id/self_avatar_container"
+                android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent">
+              <org.thoughtcrime.securesms.components.AvatarImageView
+                  android:id="@+id/self_avatar"
+                  android:foreground="@drawable/contact_photo_background"
+                  android:layout_width="35dp"
+                  android:layout_height="35dp"
+                  android:layout_marginRight="10dp"
+                  android:layout_marginEnd="10dp"
+                  android:layout_marginTop="5dp"
+                  android:layout_marginBottom="5dp"
+                  android:cropToPadding="true"
+                  android:clickable="true"
+                  app:inverted="true"
+                  tools:src="@drawable/ic_contact_picture"
+                  android:contentDescription="@string/pref_profile_info_headline" />
+              <ImageView android:id="@+id/unread_indicator"
+                         android:layout_width="20dp"
+                         android:layout_height="20dp"
+                         android:layout_marginLeft="20dp"
+                         android:layout_marginStart="20dp"
+                         app:layout_constraintTop_toTopOf="parent"
+                         android:layout_marginBottom="16dp"
+                         android:contentDescription="@null"
+                         android:visibility="gone"
+                         />
+            </RelativeLayout>
+
+              <TextView style="@style/TextSecure.TitleTextStyle"
+                        android:id="@+id/toolbar_title"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:text="@string/app_name"
+                        android:layout_weight="1"
+                        android:layout_gravity="center_vertical"
+                        android:paddingRight="10dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"/>
+          </LinearLayout>
 
             <ImageView android:id="@+id/search_action"
                        android:layout_width="wrap_content"


### PR DESCRIPTION
The hitbox for the account switcher was only the own avatar in and the title, so when you tapped a bit too low or too high, nothing happened.

This PR changes it to be the whole title bar.

The area where you can now tap to open the account switcher but you couldn't before:

![Screenshot_20240824-184814_1_1](https://github.com/user-attachments/assets/dc097fcd-bf44-472f-8e1f-61a26a243fd3)

(the slim area above and below the menu items on the very right is a bit unnecessary, but I don't know an easy way to avoid it. Before this PR, nothing happened when you tapped there, so I think it's fine)

Anyway, I find it quite a bit easier to open the account switcher now, just try it for yourself if you want :)