### PR TITLE
Visual feedback when tapping the action button on messages

### DIFF
--- a/src/main/res/drawable-v21/touch_highlight_background.xml
+++ b/src/main/res/drawable-v21/touch_highlight_background.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@color/touch_highlight">
-    <item
-        android:id="@android:id/mask"
-        android:drawable="@android:color/white" />
+    android:color="@color/delta_primary">
+    <item android:id="@android:id/mask" android:drawable="@android:color/white" />
+    <item>
+        <selector>
+            <item android:drawable="@color/touch_highlight" android:state_pressed="true" />
+        </selector>
+    </item>
 </ripple>

--- a/src/main/res/layout/conversation_item_received.xml
+++ b/src/main/res/layout/conversation_item_received.xml
@@ -191,7 +191,7 @@
                 android:paddingBottom="@dimen/message_bubble_showmore_padding"
                 android:minHeight="1dp"
                 android:minWidth="0dp"
-                android:background="@android:color/transparent"
+                android:background="@drawable/touch_highlight_background"
                 android:textColor="@color/delta_accent_darker"
                 android:text="@string/show_full_message"
                 android:textAllCaps="false"/>

--- a/src/main/res/layout/conversation_item_sent.xml
+++ b/src/main/res/layout/conversation_item_sent.xml
@@ -169,7 +169,7 @@
                 android:paddingBottom="@dimen/message_bubble_showmore_padding"
                 android:minHeight="1dp"
                 android:minWidth="0dp"
-                android:background="@android:color/transparent"
+                android:background="@drawable/touch_highlight_background"
                 android:textColor="@color/delta_accent_darker"
                 android:text="@string/show_full_message"
                 android:textAllCaps="false"/>

--- a/src/main/res/values-v19/colors.xml
+++ b/src/main/res/values-v19/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="touch_highlight">#22000000</color>
-</resources>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -36,7 +36,7 @@
     <color name="conversation_compose_divider">#32000000</color>
 
     <color name="action_mode_status_bar">@color/gray50</color>
-    <color name="touch_highlight">#400099cc</color>
+    <color name="touch_highlight">#5C4CB8DB</color>
 
     <color name="sticker_selected_color">#99ffffff</color>
     <color name="transparent">#00FFFFFF</color>


### PR DESCRIPTION
When tapping the action button on a message (i.e. "Show  Full Message", "Start" for Webxdcs, and "Download" for big messages"), there was no immediate visual feedback so far.

Since the Full Message / Webxdc activity takes some time to open, I was always a bit unsure whether I had misclicked or whether it's loading.

So, I find it quite a bit more comfortable like this.

**Note that this also changes how the emoji and camera buttons in the message input field look when tapped.**

**I explained the reasoning for the changes in the commit messages.**

If necessary, of course it's easily possible to tweak the colors.