### PR TITLE
check that getSlideUri() is not null before passing it to ScribbleActivity

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -639,13 +639,11 @@ public class AttachmentManager {
   private class EditButtonListener implements View.OnClickListener {
     @Override
     public void onClick(View v) {
-      if (Build.VERSION.SDK_INT >= 19) {
+      Uri imgUri = getSlideUri();
+      if (imgUri != null) {
         Intent intent = new Intent(context, ScribbleActivity.class);
-        intent.setData(getSlideUri());
+        intent.setData(imgUri);
         ((Activity) context).startActivityForResult(intent, ScribbleActivity.SCRIBBLE_REQUEST_CODE);
-      }
-      else {
-        Toast.makeText(context, "Image editing requires Android 4.4 KitKat or newer.", Toast.LENGTH_LONG).show();
       }
     }
   }


### PR DESCRIPTION
close #3288 

not sure this will solve the problem completely, there are other places where ScribbleActivity is launched: to crop an avatar, however, if for some reason the URI is null there, then there is another bigger problem there, I tried both ways and couldn't reproduce the problem