### PR TITLE
simplify 'Proxy Settings' to just 'Proxy'

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -604,7 +604,8 @@
     <string name="login_smtp_port">SMTP Port</string>
     <string name="login_smtp_security">SMTP Security</string>
     <string name="login_auth_method">Authorization Method</string>
-    <string name="proxy_settings">Proxy Settings</string>
+    <!-- the word "Proxy" might be left untranslated unless the destination language has a well-known term for a "Proxy Server", acting intermediary between the app and the chatmail or email server -->
+    <string name="proxy_settings">Proxy</string>
     <string name="proxy_use_proxy">Use Proxy</string>
     <!-- the word "SOCKS5" here and in the following strings should not be translated in most cases -->
     <string name="login_socks5">SOCKS5</string>


### PR DESCRIPTION
- shorter, less cluttering
- we usually do not say 'Settings' inside 'Settings', also having several 'Settings' menu entries in the main menu us not so nice
- same as telegram is doing

once merged, this needs a `./scripts/tx-push-source.sh`