### PR TITLE
'Mark Read' instead 'Dismiss' notifications

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -8,6 +8,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.b44t.messenger.DcContext;
+
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -16,6 +18,7 @@ public class MarkReadReceiver extends BroadcastReceiver {
   public static final  String CANCEL_ACTION         = "org.thoughtcrime.securesms.notifications.CANCEL";
   public static final  String ACCOUNT_ID_EXTRA      = "account_id";
   public static final  String CHAT_ID_EXTRA         = "chat_id";
+  public static final  String MSG_ID_EXTRA          = "msg_id";
 
   @Override
   public void onReceive(final Context context, Intent intent) {
@@ -26,6 +29,7 @@ public class MarkReadReceiver extends BroadcastReceiver {
 
     final int accountId = intent.getIntExtra(ACCOUNT_ID_EXTRA, 0);
     final int chatId = intent.getIntExtra(CHAT_ID_EXTRA, DC_CHAT_NO_CHAT);
+    final int msgId = intent.getIntExtra(MSG_ID_EXTRA, 0);
     if (accountId == 0 || chatId == DC_CHAT_NO_CHAT) {
       return;
     }
@@ -33,7 +37,9 @@ public class MarkReadReceiver extends BroadcastReceiver {
     Util.runOnAnyBackgroundThread(() -> {
       DcHelper.getNotificationCenter(context).removeNotifications(accountId, chatId);
       if (markNoticed) {
-        DcHelper.getAccounts(context).getAccount(accountId).marknoticedChat(chatId);
+        DcContext dcContext = DcHelper.getAccounts(context).getAccount(accountId);
+        dcContext.marknoticedChat(chatId);
+        dcContext.markseenMsgs(new int[]{msgId});
       }
     });
   }

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -128,12 +128,13 @@ public class NotificationCenter {
                 .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
 
-    private PendingIntent getRemoteReplyIntent(ChatData chatData) {
+    private PendingIntent getRemoteReplyIntent(ChatData chatData, int msgId) {
         Intent intent = new Intent(RemoteReplyReceiver.REPLY_ACTION);
         intent.setClass(context, RemoteReplyReceiver.class);
         intent.setData(Uri.parse("custom://"+chatData.accountId+"."+chatData.chatId));
         intent.putExtra(RemoteReplyReceiver.ACCOUNT_ID_EXTRA, chatData.accountId);
         intent.putExtra(RemoteReplyReceiver.CHAT_ID_EXTRA, chatData.chatId);
+        intent.putExtra(RemoteReplyReceiver.MSG_ID_EXTRA, msgId);
         intent.setPackage(context.getPackageName());
         return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
@@ -449,7 +450,7 @@ public class NotificationCenter {
             // if privacy options are enabled, the buttons are not added.
             if (privacy.isDisplayContact() && privacy.isDisplayMessage()) {
                 try {
-                    PendingIntent inNotificationReplyIntent = getRemoteReplyIntent(chatData);
+                    PendingIntent inNotificationReplyIntent = getRemoteReplyIntent(chatData, msgId);
                     PendingIntent markReadIntent = getMarkAsReadIntent(chatData, msgId, true);
 
                     NotificationCompat.Action markAsReadAction = new NotificationCompat.Action(R.drawable.check,

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -138,12 +138,13 @@ public class NotificationCenter {
         return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
 
-    private PendingIntent getMarkAsReadIntent(ChatData chatData, boolean markNoticed) {
+    private PendingIntent getMarkAsReadIntent(ChatData chatData, int msgId, boolean markNoticed) {
         Intent intent = new Intent(markNoticed? MarkReadReceiver.MARK_NOTICED_ACTION : MarkReadReceiver.CANCEL_ACTION);
         intent.setClass(context, MarkReadReceiver.class);
         intent.setData(Uri.parse("custom://"+chatData.accountId+"."+chatData.chatId));
         intent.putExtra(MarkReadReceiver.ACCOUNT_ID_EXTRA, chatData.accountId);
         intent.putExtra(MarkReadReceiver.CHAT_ID_EXTRA, chatData.chatId);
+        intent.putExtra(MarkReadReceiver.MSG_ID_EXTRA, msgId);
         intent.setPackage(context.getPackageName());
         return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | IntentUtils.FLAG_MUTABLE());
     }
@@ -377,7 +378,7 @@ public class NotificationCenter {
                     .setCategory(NotificationCompat.CATEGORY_MESSAGE)
                     .setOnlyAlertOnce(!signal)
                     .setContentText(line)
-                    .setDeleteIntent(getMarkAsReadIntent(chatData, false))
+                    .setDeleteIntent(getMarkAsReadIntent(chatData, msgId, false))
                     .setContentIntent(getOpenChatIntent(chatData));
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -449,7 +450,7 @@ public class NotificationCenter {
             if (privacy.isDisplayContact() && privacy.isDisplayMessage()) {
                 try {
                     PendingIntent inNotificationReplyIntent = getRemoteReplyIntent(chatData);
-                    PendingIntent markReadIntent = getMarkAsReadIntent(chatData, true);
+                    PendingIntent markReadIntent = getMarkAsReadIntent(chatData, msgId, true);
 
                     NotificationCompat.Action markAsReadAction = new NotificationCompat.Action(R.drawable.check,
                             context.getString(R.string.mark_as_read_short),

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -452,7 +452,7 @@ public class NotificationCenter {
                     PendingIntent markReadIntent = getMarkAsReadIntent(chatData, true);
 
                     NotificationCompat.Action markAsReadAction = new NotificationCompat.Action(R.drawable.check,
-                            context.getString(R.string.notify_dismiss),
+                            context.getString(R.string.mark_as_read_short),
                             markReadIntent);
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {

--- a/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -27,6 +27,7 @@ import android.os.Bundle;
 import androidx.core.app.RemoteInput;
 
 import com.b44t.messenger.DcContext;
+import com.b44t.messenger.DcMsg;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Util;
@@ -65,7 +66,12 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
         if (dcContext.getChat(chatId).isContactRequest()) {
           dcContext.acceptChat(chatId);
         }
-        dcContext.sendTextMsg(chatId, responseText.toString());
+
+        DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
+        msg.setText(responseText.toString());
+        msg.setQuote(dcContext.getMsg(msgId));
+        dcContext.sendMsg(chatId, msg);
+
         DcHelper.getNotificationCenter(context).removeNotifications(accountId, chatId);
       });
     }

--- a/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -41,6 +41,7 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
   public static final String REPLY_ACTION  = "org.thoughtcrime.securesms.notifications.WEAR_REPLY";
   public static final String ACCOUNT_ID_EXTRA = "account_id";
   public static final String CHAT_ID_EXTRA = "chat_id";
+  public static final String MSG_ID_EXTRA = "msg_id";
   public static final String EXTRA_REMOTE_REPLY = "extra_remote_reply";
 
   @SuppressLint("StaticFieldLeak")
@@ -50,6 +51,7 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
     Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);
     final int accountId = intent.getIntExtra(ACCOUNT_ID_EXTRA, 0);
     final int chatId = intent.getIntExtra(CHAT_ID_EXTRA, DC_CHAT_NO_CHAT);
+    final int msgId = intent.getIntExtra(MSG_ID_EXTRA, 0);
 
     if (remoteInput == null || chatId == DC_CHAT_NO_CHAT || accountId == 0) return;
 
@@ -59,6 +61,7 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
       Util.runOnAnyBackgroundThread(() -> {
         DcContext dcContext = DcHelper.getAccounts(context).getAccount(accountId);
         dcContext.marknoticedChat(chatId);
+        dcContext.markseenMsgs(new int[]{msgId});
         if (dcContext.getChat(chatId).isContactRequest()) {
           dcContext.acceptChat(chatId);
         }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
     <string name="mark_all_as_read">Mark All as Read</string>
     <string name="mark_as_read">Mark as Read</string>
     <!-- Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen". -->
-    <string name="mark_as_read_short">Read</string>
+    <string name="mark_as_read_short">Mark Read</string>
     <!-- Placeholder text when something is loading -->
     <string name="loading">Loading…</string>
     <string name="hide">Hide</string>
@@ -993,6 +993,7 @@
     <string name="mailto_link_could_not_be_decoded">mailto link could not be decoded: %1$s</string>
 
     <!-- notifications  -->
+    <!-- deprecated, use mark_as_read or mark_as_read_short -->
     <string name="notify_dismiss">Dismiss</string>
     <string name="notify_reply_button">Reply</string>
     <string name="notify_new_message">New message</string>


### PR DESCRIPTION
'Dismiss' is a bit unclear - even though introduced at #2083 to make things clearer, i do not think this has happened :) -
i also needed to dive into the source code to see what exactly 'Dismiss' is doing.

meanwhile, we're anyway using 'Mark Read' to remove unread counter from chats, and this is basically the same. good to be consistent. finally, this is also the term WhatsApp/Telegram are using.

closes https://support.delta.chat/t/what-does-dismiss-button-on-notifications-do/3261/3

<img width=350 src=https://github.com/user-attachments/assets/d937ef6c-6d3a-43bf-8b4b-89c51e03afbe>

nb: we also change the english 'short' term from 'Read' to 'Mark Read' - this is sill shorter than many translations
and removes the ambiguousness 'Mark Read' vs 'Open for Reading" - esp. in the notification without much context, this is better, but also on iOS, where the term was introduced for, it is good to be explict.

once merged, `./scripts/tx-update-changed-sources.sh` should be called