### PR TITLE
marked chat replied to as being noticed

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -58,6 +58,7 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
     if (responseText != null) {
       Util.runOnAnyBackgroundThread(() -> {
         DcContext dcContext = DcHelper.getAccounts(context).getAccount(accountId);
+        dcContext.marknoticedChat(chatId);
         if (dcContext.getChat(chatId).isContactRequest()) {
           dcContext.acceptChat(chatId);
         }


### PR DESCRIPTION
when replying from within a notification,
the corresponding chat should be marked as being noticed as well.

otherwise, it looks wrong that one has replied to a chat, but still the chat is shown as being "unread".

the 'reply' from a notification should leave the chat in the same state as 'dismiss' resp. 'mark read' - plus the added message.