### PR TITLE
cleanup account switcher

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
@@ -91,7 +91,7 @@ public class AccountSelectionListItem extends LinearLayout {
       nameView.setTypeface(null, Typeface.BOLD);
     } else {
       addrView.setTypeface(null, Typeface.NORMAL);
-      nameView.setTypeface(null, accountId == DcContact.DC_CONTACT_ID_ADD_ACCOUNT? Typeface.BOLD : Typeface.NORMAL);
+      nameView.setTypeface(null, Typeface.NORMAL);
     }
 
     updateUnreadIndicator(unreadCount, isMuted);


### PR DESCRIPTION
do not show 'Add Profile' in bold.

this looks less cluttered
and makes the "bold" of the selected account more outstanding:

before, there were two types of "boldness",
the add profile button (using bold only)
and the selected profile (using bold and a background), this results in a bit cluttered, unsteady look,
esp. when there are few accounts and more bold than normal is shown.

also, this makes "bold" more outstanding,
as this attribute is given to one line only.
there is no need for the "add profile" to be that outstanding (in contrast to eg. the "add chat" dialog)
("Add Profile" is clearly less often used that an temporarily unselected profile and should stand back also from that point of view)

the "Add Profile" button with its "+" is still recognisable enough and is not really mixed with an existing profile. otherwise, we could add some more whitespace between the accounts and "add profile". btw: wondering if "Add Profile" shouln't be the last item

it is a minor, sure :)

before - a bit noisy and looking as if two things are selected. 

<img width=300 src=https://github.com/user-attachments/assets/aac0b006-bbb7-4813-881d-f511cb2eb8e9>
<img width=300 src=https://github.com/user-attachments/assets/23bf9376-d9bd-4af7-a1fe-7b1c019f74ba>

after - less agitated:

<img width=300 src=https://github.com/user-attachments/assets/f0a1e338-14d3-4558-ace9-0a1c63e48d28>
<img width=300 src=https://github.com/user-attachments/assets/5aaa41bc-91d1-445f-8e31-56cb98d7b34d>

