### PR TITLE
refine post-notifications-granted logging

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/LogViewFragment.java
@@ -257,9 +257,14 @@ public class LogViewFragment extends Fragment {
         builder.append("rtl=").append(isRtl).append("\n");
       }
 
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        boolean notifPermGranted = PermissionChecker.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PermissionChecker.PERMISSION_GRANTED;
+        builder.append("post-notifications-granted=").append(notifPermGranted).append("\n");
+      } else {
+        builder.append("post-notifications-granted=<not needed>").append("\n");
+      }
+
       final String token = FcmReceiveService.getToken();
-      boolean notifPermGranted = PermissionChecker.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PermissionChecker.PERMISSION_GRANTED;
-      builder.append("post-notifications-granted=").append(notifPermGranted).append("\n");
       builder.append("push-enabled=").append(Prefs.isPushEnabled(context)).append("\n");
       builder.append("push-token=").append(token == null ? "<empty>" : token).append("\n");
     } catch (Exception e) {


### PR DESCRIPTION
saying post-notifications-granted=false on API that do not need this grant is misleading as it looks as some error or if the user has rejected sth.

just stumbled upon that and was irritated when trying out things wrt https://github.com/deltachat/deltachat-android/issues/3281 on android7