### PR TITLE
Also start the FetchForegroundService in onDeletedMessages()

### DIFF
--- a/src/gplay/java/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/gplay/java/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -102,7 +102,7 @@ public class FcmReceiveService extends FirebaseMessagingService {
   @Override
   public void onDeletedMessages() {
     Log.i(TAG, "FCM push notifications dropped");
-    // nothing special to do as we're running now and notifications should be processed as usual.
+    FetchForegroundService.start(this);
   }
 
   @Override


### PR DESCRIPTION
See https://firebase.google.com/docs/cloud-messaging/android/receive#override-ondeletedmessages

Shouldn't happen very often, but if it does, it's good to connect, too.

Follow-up for https://github.com/deltachat/deltachat-android/issues/3281