### PR TITLE
start foreground-service for background-fetch only if really in background

### DIFF
--- a/src/gplay/java/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/gplay/java/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -96,13 +96,13 @@ public class FcmReceiveService extends FirebaseMessagingService {
   @Override
   public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
     Log.i(TAG, "FCM push notification received");
-    FetchForegroundService.start(this);
+    FetchForegroundService.startIfInBackground(this);
   }
 
   @Override
   public void onDeletedMessages() {
     Log.i(TAG, "FCM push notifications dropped");
-    FetchForegroundService.start(this);
+    FetchForegroundService.startIfInBackground(this);
   }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/service/FetchForegroundService.java
+++ b/src/main/java/org/thoughtcrime/securesms/service/FetchForegroundService.java
@@ -13,6 +13,8 @@ import androidx.core.content.ContextCompat;
 
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.connect.ForegroundDetector;
 import org.thoughtcrime.securesms.notifications.FcmReceiveService;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
 import org.thoughtcrime.securesms.util.Util;
@@ -22,7 +24,17 @@ public final class FetchForegroundService extends Service {
   private static final Object SERVICE_LOCK = new Object();
   private static Intent service;
 
-  public static void start(Context context) {
+  public static void startIfInBackground(Context context) {
+    ForegroundDetector foregroundDetector = ForegroundDetector.getInstance();
+    if (foregroundDetector.isBackground()) {
+      // the app is in background, start visible foreground service to not get killed
+      FetchForegroundService.start(context);
+    } else {
+      DcHelper.getAccounts(context).maybeNetwork();
+    }
+  }
+
+  private static void start(Context context) {
     GenericForegroundService.createFgNotificationChannel(context);
     synchronized (SERVICE_LOCK) {
       if (service == null) {


### PR DESCRIPTION
closes #3319 

however, closing this pr as #3319 seems not to be needed:
- the permanent notification is usually not annoying and shortly displayed only
- the "maybe network" optimisation will be done in core, at https://github.com/deltachat/deltachat-core-rust/issues/5989