### PR TITLE
add 'learn more' button for managing keys

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -460,6 +460,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
                   }
               )
               .setNegativeButton(R.string.cancel, null)
+              .setNeutralButton(R.string.learn_more, (d, w) -> DcHelper.openHelp(getActivity(), "#importkey"))
               .show();
         })
         .execute();


### PR DESCRIPTION
this PR makes the help - that describes key format, supported keys etc. - accessible directly from the "manage keys" section.

before, these information were harder to find.

<img width="386" alt="Screenshot 2024-10-02 at 19 23 07" src="https://github.com/user-attachments/assets/df743288-1172-4acd-9efb-5ff35825ca07">

the learn more buttons links to https://delta.chat/en/help#can-i-reuse-my-existing-private-key in the offline help (which is shipped with the app, no internet required)

came over this by the desktop issue  https://github.com/deltachat/deltachat-desktop/issues/4155