### PR TITLE
Remove getNextMedia() to make compilation succeed again

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1331,12 +1331,6 @@ JNIEXPORT jintArray Java_com_b44t_messenger_DcContext_getChatMedia(JNIEnv *env, 
 }
 
 
-JNIEXPORT jint Java_com_b44t_messenger_DcContext_getNextMedia(JNIEnv *env, jobject obj, jint msg_id, jint dir, jint type1, jint type2, jint type3)
-{
-    return dc_get_next_media(get_dc_context(env, obj), msg_id, dir, type1, type2, type3);
-}
-
-
 JNIEXPORT jintArray Java_com_b44t_messenger_DcContext_getChatMsgs(JNIEnv *env, jobject obj, jint chat_id, jint flags, jint marker1before)
 {
     dc_array_t* ca = dc_get_chat_msgs(get_dc_context(env, obj), chat_id, flags, marker1before);

--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -182,7 +182,6 @@ public class DcContext {
     public native int[]        searchMsgs           (int chat_id, String query);
     public native int[]        getFreshMsgs         ();
     public native int[]        getChatMedia         (int chat_id, int type1, int type2, int type3);
-    public native int          getNextMedia         (int msg_id, int dir, int type1, int type2, int type3);
     public native int[]        getChatContacts      (int chat_id);
     public native int          getChatEphemeralTimer (int chat_id);
     public native boolean      setChatEphemeralTimer (int chat_id, int timer);


### PR DESCRIPTION
https://github.com/deltachat/deltachat-core-rust/pull/6016/ removed this function. We didn't use it, but it was still present in the bindings.