### PR TITLE
add shortcut for `is:unread`

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/components/SearchToolbar.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/SearchToolbar.java
@@ -27,6 +27,7 @@ public class SearchToolbar extends LinearLayout {
   private static final String TAG = SearchToolbar.class.getSimpleName();
   private float x, y;
   private MenuItem searchItem;
+  private EditText searchText;
   private SearchListener listener;
 
   public SearchToolbar(Context context) {
@@ -63,7 +64,7 @@ public class SearchToolbar extends LinearLayout {
 
     this.searchItem = toolbar.getMenu().findItem(R.id.action_filter_search);
     SearchView searchView = (SearchView) searchItem.getActionView();
-    EditText   searchText = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
+    searchText = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
     searchView.setImeOptions(EditorInfo.IME_ACTION_DONE);
 
     searchView.setSubmitButtonEnabled(false);
@@ -105,6 +106,17 @@ public class SearchToolbar extends LinearLayout {
         hide();
         return true;
       }
+    });
+
+    MenuItem searchUnread = toolbar.getMenu().findItem(R.id.search_unread);
+    searchUnread.setOnMenuItemClickListener(item -> {
+      String t = searchText.getText().toString();
+      if (!t.contains("is:unread")) {
+        t += (t.isEmpty() ? "" : " ") + "is:unread ";
+      }
+      searchText.setText(t);
+      searchText.setSelection(t.length(), t.length());
+      return true;
     });
 
     toolbar.setNavigationOnClickListener(v -> hide());

--- a/src/main/res/menu/conversation_list_search.xml
+++ b/src/main/res/menu/conversation_list_search.xml
@@ -8,4 +8,8 @@
             app:actionViewClass="androidx.appcompat.widget.SearchView"
             app:showAsAction="collapseActionView|always" />
 
+    <item android:title="@string/search_unread"
+        android:id="@+id/search_unread"
+        app:showAsAction="never"/>
+
 </menu>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -466,6 +466,7 @@
     <string name="search_files">Search Files</string>
     <string name="search_explain">Search for chats, contacts, and messages</string>
     <string name="search_no_result_for_x">No results found for \"%s\"</string>
+    <!-- Adjective, as in "Show Unread Messages" -->
     <string name="search_unread">Unread</string>
 
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -466,6 +466,7 @@
     <string name="search_files">Search Files</string>
     <string name="search_explain">Search for chats, contacts, and messages</string>
     <string name="search_no_result_for_x">No results found for \"%s\"</string>
+    <string name="search_unread">Unread</string>
 
 
     <!-- create/edit groups, contact/group profile -->


### PR DESCRIPTION
this PR adds a menu item beside the search field that easily allows to filter the chatlist by showing only unread chats.

https://github.com/user-attachments/assets/5b1dcd9b-f64c-4037-bb64-e38b5a9f9e42

the functionality itself was added to the core [a while ago](https://github.com/deltachat/deltachat-core-rust/pull/4824) already; the menu entry only adds the string `is:unread` to the search field, if not already present 

(this is probably good enough; the item is more a hint, for what can be entered. i was also thinking about a toggle, however, this adds complexity, and probably no one would expect to remove the string that way; the search is ended easily using "back" or "clear")

we were also thinking about adding this to the main menu, however, that would clutter UI with more advanced features. the current step is an improvement already, and it is okay, if this is not directly the first thing new user discover (before, it was completely undiscoverable :)