### PR TITLE
fix: do not expect special value for backup transfer progress

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -174,17 +174,8 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
             if (permille == 0) {
                 getTransferActivity().setTransferError("Sending Error");
                 hideQrCode = true;
-            } else if(permille <= 350) {
-                statusLineText = getString(R.string.preparing_account);
-            } else if(permille <= 400) {
-                statusLine.setVisibility(View.GONE);
-                progressBar.setVisibility(View.GONE);
-                statusLineText = getString(R.string.waiting_for_receiver);
-            } else if(permille <= 450) {
-                statusLineText = getString(R.string.receiver_connected);
-                hideQrCode = true;
             } else if (permille < 1000) {
-                percent = (permille-450)/5;
+                percent = permille/10;
                 percentMax = 100;
                 statusLineText = getString(R.string.transferring);
                 hideQrCode = true;

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
@@ -81,16 +81,11 @@ public class BackupReceiverFragment extends Fragment implements DcEventCenter.Dc
             Log.i(TAG,"DC_EVENT_IMEX_PROGRESS, " + permille);
             if (permille == 0) {
                 getTransferActivity().setTransferError("Receiving Error");
-            } else if (permille <= 100) {
-                statusLineText = getString(R.string.preparing_account);
-                hideSameNetworkHint = true;
-            } else if (permille <= 950 ) {
-                percent = ((permille-100)*100)/850;
+            } else if (permille < 1000) {
+                percent = permille/10;
                 percentMax = 100;
                 statusLineText = getString(R.string.transferring) + String.format(Util.getLocale(), " %d%%", percent);
                 hideSameNetworkHint = true;
-            } else if (permille < 1000) {
-                statusLineText = "Finishing..."; // range not used, should not happen
             } else if (permille == 1000) {
                 getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_SUCCESS);
                 getTransferActivity().doFinish();


### PR DESCRIPTION
Values 100, 350, 400, 450, 950 are not used in the core, so this resulted in showing incorrect progress
such as "Preparing account" when actually
database transfer was already in progress.

Desktop already does not expect any special values and simply shows the progress bar.

This goes together with core PR https://github.com/deltachat/deltachat-core-rust/pull/6027