### PR TITLE
Don't show "0%" at the beginning when exporting/importing backups

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/ListSummaryPreferenceFragment.java
@@ -199,7 +199,7 @@ public abstract class ListSummaryPreferenceFragment extends CorrectedPreferenceF
         imexProgress.put(event.getAccountId(), (int) progress);
         int totalProgress = getTotalProgress();
         int percent = totalProgress / (10 * imexAccounts.length);
-        String formattedPercent = String.format(" %d%%", percent);
+        String formattedPercent = percent > 0 ? String.format(" %d%%", percent) : "";
         progressDialog.setMessage(getResources().getString(R.string.one_moment) + formattedPercent);
         notifController.setProgress(1000L * imexAccounts.length, totalProgress, formattedPercent);
       }


### PR DESCRIPTION
With https://github.com/deltachat/deltachat-core-rust/pull/6027, when exporting a backup, the counter stays at 0% while running housekeeping and vacuuming the database, which takes 10 seconds on my device. (note that before https://github.com/deltachat/deltachat-core-rust/pull/6027, the progress stayed at 1% while exporting the database, which can take multiple minutes, so the core PR is definitely an improvement already)

Showing "One moment... 0%" for 10 seconds (or longer on slower devices / with bigger accounts) might make users think that it's not working and abort the process. So, instead, simply show "One moment..." until the progress reaches 1%.