### PR TITLE
fix the warning when attaching multiple files

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
@@ -93,12 +93,16 @@ public abstract class BaseConversationListFragment extends Fragment implements A
           if (isForwarding(getActivity())) {
             message = String.format(Util.getLocale(), getString(R.string.ask_forward_multiple), selectedChats.size());
           } else if (!uris.isEmpty()) {
-            message = String.format(Util.getLocale(), getString(R.string.share_multiple_attachments_multiple_chats), uris.size(), selectedChats.size());
+            message = String.format(Util.getLocale(), getString(R.string.ask_send_files_to_selected_chats), uris.size(), selectedChats.size());
           } else {
             message = String.format(Util.getLocale(), getString(R.string.share_text_multiple_chats), selectedChats.size(), getSharedText(getActivity()));
           }
+
           Context context = getContext();
           if (context != null) {
+            if (SendRelayedMessageUtil.containsVideoType(context, uris)) {
+              message += "\n\n" + getString(R.string.videos_sent_without_recoding);
+            }
             new AlertDialog.Builder(context)
                     .setMessage(message)
                     .setCancelable(false)

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -669,7 +669,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     ArrayList<Uri> uriList =  RelayUtil.getSharedUris(this);
     int sharedContactId = RelayUtil.getSharedContactId(this);
     if (uriList.size() > 1) {
-      String message = String.format(getString(R.string.share_multiple_attachments), uriList.size());
+      String message = String.format(getString(R.string.ask_send_files_to_selected_chat), uriList.size());
+      if (SendRelayedMessageUtil.containsVideoType(context, uriList)) {
+        message += "\n\n" + getString(R.string.videos_sent_without_recoding);
+      }
       new AlertDialog.Builder(this)
               .setMessage(message)
               .setCancelable(false)

--- a/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -74,6 +74,16 @@ public class SendRelayedMessageUtil {
     }
   }
 
+  public static boolean containsVideoType(Context context, ArrayList<Uri> uris) {
+    for (final Uri uri : uris) {
+      final String mimeType = MediaUtil.getMimeType(context, uri);
+      if (MediaUtil.isVideoType(mimeType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static DcMsg createMessage(Context context, Uri uri, String text) throws NullPointerException {
     DcContext dcContext = DcHelper.getContext(context);
     DcMsg message;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -656,8 +656,9 @@
     <!-- share and forward messages -->
     <!-- Translators: shown above a chat/contact list when selecting recipients to forward messages -->
     <string name="forward_to">Forward to…</string>
-    <string name="share_multiple_attachments">Send %1$d files to the selected chat?\n\nThe files are sent unmodified in their original size (eg. images and videos are not re-encoded).</string>
-    <string name="share_multiple_attachments_multiple_chats">Send %1$d file(s) to %2$d chats?\n\nThe files are sent unmodified in their original size (eg. images and videos are not re-encoded).</string>
+    <string name="ask_send_files_to_selected_chat">Send %1$d files to the selected chat?</string>
+    <string name="ask_send_files_to_selected_chats">Send %1$d file(s) to %2$d chats?</string>
+    <string name="videos_sent_without_recoding">(Videos are sent as original, big files. To send videos as smaller files, attach them separately).</string>
     <string name="share_text_multiple_chats">Send this text to %1$d chats?\n\n\"%2$s\"</string>
     <string name="share_abort">Sharing aborted due to missing permissions.</string>
 


### PR DESCRIPTION
this PR adapts the warning messages when multiple files are attached (via "Share To Delta Chat") to what actually happens.

it is on purpose, that things are recoded by default, esp. when sharing-one-image recodes, sharing-multiple-images should recode as well - and this is what happens since quite some years :)

for videos, however, recoding is not done in that flow; this is the only thing left to warn about (changing the flow is out of scope and would be a feature request)

<img width=320 src=https://github.com/user-attachments/assets/3e4eb7b4-a35e-480d-b7b7-f140d62c2cf2>
<img width=320 src=https://github.com/user-attachments/assets/24c475b0-d49f-4f5d-8e42-ca72bcdde5f2>


