### PR TITLE
move 'add profile' to end of list

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
@@ -52,11 +52,11 @@ public class AccountSelectionListFragment extends DialogFragment
     int[] accountIds = accounts.getAll();
 
     int[] ids = new int[accountIds.length + 1];
-    ids[0] = DC_CONTACT_ID_ADD_ACCOUNT;
     int j = 0;
     for (int accountId : accountIds) {
-      ids[++j] = accountId;
+      ids[j++] = accountId;
     }
+    ids[j] = DC_CONTACT_ID_ADD_ACCOUNT;
     adapter.changeData(ids, accounts.getSelectedAccount().getAccountId());
   }
 


### PR DESCRIPTION
having 'add profile' at the end of the list is more natural, and more consisten with desktop/iOS -
as well as internally, eg. proxy also has 'add' at its end.

also, this paves the way to have a consistent layout when it comes to profile-switching from forward/share dialogs,
where one probably does not want to have a 'add' button (so, the first lines are not different :)

the profile list is usually not super-large,
and even if - when ppl have managed to add 10+ profiles, they'll know how to do this, even with scrolling :) also, adding is a rare function, in contrast to switching, so even then it makes sense as there is room for one more item without scrolling.

in contrast,
for 'create chat' we show 'add' at the beginning,
as these lists can contain several hundreds of entries _and_ add is often used.

![Screenshot 2024-10-10 at 17 25 10](https://github.com/user-attachments/assets/9f564c69-3d53-439a-84ac-c0cf85cd37a7)

successor of #3310
