### PR TITLE
attach multiple images

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -678,7 +678,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void askSendingFiles(ArrayList<Uri> uriList, Runnable onConfirm) {
-    String message = String.format(getString(R.string.ask_send_files_to_selected_chat), uriList.size());
+    String message = String.format(getString(R.string.ask_send_files_to_chat), uriList.size(), dcChat.getName());
     if (SendRelayedMessageUtil.containsVideoType(context, uriList)) {
       message += "\n\n" + getString(R.string.videos_sent_without_recoding);
     }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -363,7 +363,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
             for (int i = 0; i < uriCount; i++) {
               uriList.add(multipleUris.getItemAt(i).getUri());
             }
-            askSendingFiles(uriList, () -> SendRelayedMessageUtil.handleSharing(this, chatId, uriList, null));
+            askSendingFiles(uriList, () -> SendRelayedMessageUtil.sendMultipleMsgs(this, chatId, uriList, null));
           }
         }
       }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -665,20 +665,24 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
+  private void askSendingFiles(ArrayList<Uri> uriList, Runnable onConfirm) {
+    String message = String.format(getString(R.string.ask_send_files_to_selected_chat), uriList.size());
+    if (SendRelayedMessageUtil.containsVideoType(context, uriList)) {
+      message += "\n\n" + getString(R.string.videos_sent_without_recoding);
+    }
+    new AlertDialog.Builder(this)
+      .setMessage(message)
+      .setCancelable(false)
+      .setNegativeButton(android.R.string.cancel, null)
+      .setPositiveButton(R.string.menu_send, (dialog, which) -> onConfirm.run())
+      .show();
+  }
+
   private void handleSharing() {
     ArrayList<Uri> uriList =  RelayUtil.getSharedUris(this);
     int sharedContactId = RelayUtil.getSharedContactId(this);
     if (uriList.size() > 1) {
-      String message = String.format(getString(R.string.ask_send_files_to_selected_chat), uriList.size());
-      if (SendRelayedMessageUtil.containsVideoType(context, uriList)) {
-        message += "\n\n" + getString(R.string.videos_sent_without_recoding);
-      }
-      new AlertDialog.Builder(this)
-              .setMessage(message)
-              .setCancelable(false)
-              .setNegativeButton(android.R.string.cancel, ((dialog, which) -> finish()))
-              .setPositiveButton(R.string.menu_send, (dialog, which) -> SendRelayedMessageUtil.immediatelyRelay(this, chatId))
-              .show();
+      askSendingFiles(uriList, () -> SendRelayedMessageUtil.immediatelyRelay(this, chatId));
     } else {
       if (sharedContactId != 0) {
         addAttachmentContactInfo(sharedContactId);

--- a/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -461,7 +461,7 @@ public class AttachmentManager {
                .request(Permissions.galleryPermissions())
                .ifNecessary()
                .withPermanentDenialDialog(activity.getString(R.string.perm_explain_access_to_storage_denied))
-               .onAllGranted(() -> selectMediaType(activity, "image/*", new String[] {"image/*", "video/*"}, requestCode))
+               .onAllGranted(() -> selectMediaType(activity, "image/*", new String[] {"image/*", "video/*"}, requestCode, null, true))
                .execute();
   }
 
@@ -574,10 +574,14 @@ public class AttachmentManager {
   }
 
   public static void selectMediaType(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode) {
-    selectMediaType(activity, type, extraMimeType, requestCode, null);
+    selectMediaType(activity, type, extraMimeType, requestCode, null, false);
   }
 
   public static void selectMediaType(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode, @Nullable Uri initialUri) {
+    selectMediaType(activity, type, extraMimeType, requestCode, initialUri, false);
+  }
+
+  public static void selectMediaType(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode, @Nullable Uri initialUri, boolean allowMultiple) {
     final Intent intent = new Intent();
     intent.setType(type);
 
@@ -587,6 +591,10 @@ public class AttachmentManager {
 
     if (initialUri != null && Build.VERSION.SDK_INT >= 26) {
       intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialUri);
+    }
+
+    if (allowMultiple) {
+      intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/src/main/java/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
+++ b/src/main/java/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
@@ -35,7 +35,7 @@ public class PersistentBlobProvider {
   public  static final String     EXPECTED_PATH_NEW     = "capture-new/*/*/*/*/#";
 
   private static final int        MIMETYPE_PATH_SEGMENT = 1;
-  private static final int        FILENAME_PATH_SEGMENT = 2;
+  public static final int         FILENAME_PATH_SEGMENT = 2;
   private static final int        FILESIZE_PATH_SEGMENT = 3;
 
   private static final String     BLOB_EXTENSION        = "blob";

--- a/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -10,6 +10,7 @@ import com.b44t.messenger.DcMsg;
 import org.thoughtcrime.securesms.ConversationListRelayingActivity;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.PartAuthority;
+import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 
 import java.io.FileOutputStream;
 import java.io.InputStream;
@@ -112,7 +113,7 @@ public class SendRelayedMessageUtil {
   private static String getRealPathFromUri(Context context, Uri uri) throws NullPointerException {
     DcContext dcContext = DcHelper.getContext(context);
     try {
-      String filename = uri.getPathSegments().get(2); // Get real file name from Uri
+      String filename = uri.getPathSegments().get(PersistentBlobProvider.FILENAME_PATH_SEGMENT);
       String ext = "";
       int i = filename.lastIndexOf(".");
       if (i >= 0) {

--- a/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -117,7 +117,7 @@ public class SendRelayedMessageUtil {
     DcContext dcContext = DcHelper.getContext(context);
     try {
 
-      String filename = "cannot-resolve.jpg";
+      String filename = "cannot-resolve.jpg"; // best guess, this still leads to most images being workable if OS does weird things
       if (PartAuthority.isLocalUri(uri)) {
         filename = uri.getPathSegments().get(PersistentBlobProvider.FILENAME_PATH_SEGMENT);
       } else if (uri.getScheme().equals("content")) {

--- a/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -57,7 +57,7 @@ public class SendRelayedMessageUtil {
     dcContext.forwardMsgs(forwardedMessageIDs, chatId);
   }
 
-  private static void handleSharing(Context context, int chatId, ArrayList<Uri> sharedUris, String sharedText) {
+  public static void handleSharing(Context context, int chatId, ArrayList<Uri> sharedUris, String sharedText) {
     DcContext dcContext = DcHelper.getContext(context);
     ArrayList<Uri> uris = sharedUris;
     String text = sharedText;

--- a/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -50,7 +50,7 @@ public class SendRelayedMessageUtil {
       resetRelayingMessageContent(activity);
       Util.runOnAnyBackgroundThread(() -> {
         for (long chatId : chatIds) {
-          handleSharing(activity, (int) chatId, sharedUris, sharedText);
+          sendMultipleMsgs(activity, (int) chatId, sharedUris, sharedText);
         }
       });
     }
@@ -61,7 +61,7 @@ public class SendRelayedMessageUtil {
     dcContext.forwardMsgs(forwardedMessageIDs, chatId);
   }
 
-  public static void handleSharing(Context context, int chatId, ArrayList<Uri> sharedUris, String sharedText) {
+  public static void sendMultipleMsgs(Context context, int chatId, ArrayList<Uri> sharedUris, String sharedText) {
     DcContext dcContext = DcHelper.getContext(context);
     ArrayList<Uri> uris = sharedUris;
     String text = sharedText;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -656,7 +656,8 @@
     <!-- share and forward messages -->
     <!-- Translators: shown above a chat/contact list when selecting recipients to forward messages -->
     <string name="forward_to">Forward to…</string>
-    <string name="ask_send_files_to_selected_chat">Send %1$d files to the selected chat?</string>
+    <!-- first placeholder is replaced by the number of files (always 2 or more); second placeholder is replaced by a chat name -->
+    <string name="ask_send_files_to_chat">Send %1$d files to \"%2$s\"?</string>
     <string name="ask_send_files_to_selected_chats">Send %1$d file(s) to %2$d chats?</string>
     <string name="videos_sent_without_recoding">(Videos are sent as original, big files. To send videos as smaller files, attach them separately)</string>
     <string name="share_text_multiple_chats">Send this text to %1$d chats?\n\n\"%2$s\"</string>


### PR DESCRIPTION
this PR allows to select and send multiple images directly from within the app's gallery.

after confirmation, the images are send as separated messages then - similar to images selected from the system gallery.

sending single images is done as usual and unchanged.

this should make the usecase of "sharing quite some holiday images" much easier - even though more advanced things as per-image comment or mini-galleries are not there, let alone sending the images in a single mail. all that would be _much_ more effort and is out of scope currently

https://github.com/user-attachments/assets/874e237e-1cdf-41ff-aec2-db0800a82cc2



