### PR TITLE
[do not merge] test a three letter language

### DIFF
--- a/src/main/res/values-b+haw/strings.xml
+++ b/src/main/res/values-b+haw/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="app_name">Delta Hawaii</string>
+    <string name="invite_friends">Freunde Hawaii</string>
+</resources>


### PR DESCRIPTION
targets https://github.com/deltachat/deltachat-android/issues/3318

i tried to get a three [letter-BCP47-language-code](https://github.com/deltachat/deltachat-android/issues/3318#issuecomment-2394451433) of a language that is easier to recognize for me runnin, i chosed "Hawaii" for that.

and: the language is available in the system settings of the Delta Chat language selector, and is working as expected:

<img width=250 src=https://github.com/user-attachments/assets/ebc937b9-cc74-4881-9b8d-2eda5799e6eb>
<img width=250 src=https://github.com/user-attachments/assets/5d666e5e-bc4d-4d2e-8a71-c4b373b8ce72>
<img width=250 src=https://github.com/user-attachments/assets/c9b28e0e-2d1d-4f6d-a6d3-da09ec4fe2f7>

so, _in general_ this is the way to use letter-BCP47-language-code.

so, to close #3318, we should follow the same naming convention for `cbk` and `bqi`

might still be, the language is not supported by OS, but that is out of our control then, and one should better advocate on the OS developers then. 
