### PR TITLE
Visual feedback when tapping the action button on messages, attempt 2

### DIFF
--- a/src/main/res/drawable-v21/touch_highlight_background_strong.xml
+++ b/src/main/res/drawable-v21/touch_highlight_background_strong.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Like touch_highlight_background, but creates a stronger (i.e. better visible)
+ visual feedback when the button is pressed. -->
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/delta_primary">
+    <item android:id="@android:id/mask" android:drawable="@android:color/white" />
+    <item>
+        <selector>
+            <item android:drawable="@color/touch_highlight" android:state_pressed="true" />
+        </selector>
+    </item>
+</ripple>

--- a/src/main/res/drawable/touch_highlight_background_strong.xml
+++ b/src/main/res/drawable/touch_highlight_background_strong.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true" android:drawable="@color/touch_highlight" />
+    <item android:state_focused="true" android:drawable="@color/delta_primary" />
+    <item android:drawable="@android:color/transparent" />
+</selector>

--- a/src/main/res/layout/conversation_item_received.xml
+++ b/src/main/res/layout/conversation_item_received.xml
@@ -191,7 +191,7 @@
                 android:paddingBottom="@dimen/message_bubble_showmore_padding"
                 android:minHeight="1dp"
                 android:minWidth="0dp"
-                android:background="@android:color/transparent"
+                android:background="@drawable/touch_highlight_background_strong"
                 android:textColor="@color/delta_accent_darker"
                 android:text="@string/show_full_message"
                 android:textAllCaps="false"/>

--- a/src/main/res/layout/conversation_item_sent.xml
+++ b/src/main/res/layout/conversation_item_sent.xml
@@ -169,7 +169,7 @@
                 android:paddingBottom="@dimen/message_bubble_showmore_padding"
                 android:minHeight="1dp"
                 android:minWidth="0dp"
-                android:background="@android:color/transparent"
+                android:background="@drawable/touch_highlight_background_strong"
                 android:textColor="@color/delta_accent_darker"
                 android:text="@string/show_full_message"
                 android:textAllCaps="false"/>

--- a/src/main/res/values-v19/colors.xml
+++ b/src/main/res/values-v19/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="touch_highlight">#22000000</color>
-</resources>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -36,7 +36,7 @@
     <color name="conversation_compose_divider">#32000000</color>
 
     <color name="action_mode_status_bar">@color/gray50</color>
-    <color name="touch_highlight">#400099cc</color>
+    <color name="touch_highlight">#5C4CB8DB</color>
 
     <color name="sticker_selected_color">#99ffffff</color>
     <color name="transparent">#00FFFFFF</color>


### PR DESCRIPTION
Follow-up for https://github.com/deltachat/deltachat-android/pull/3263.

This does still slightly change the highlight color for the whole app, since I do think it's nice to have it the same throughout the app. The previous highlight color was from the old Signal code was seemingly forgotten when changing from Signal look-and-feel to Delta look-and-feel.

Before/after: ("before" the visual feedback is barely visible except for when you pointed onto it with a mouse):

![Screenshot_20241014-194207](https://github.com/user-attachments/assets/a6ee16dd-32e0-4be8-acf3-fb9da9f7ba2b)
![Screenshot_20241014-202253](https://github.com/user-attachments/assets/191182c7-f384-40e1-ad2c-1d3698747368)

_But_, it would be simple to revert the last two commits and instead directly write `#5C4CB8DB` into `touch_highlight_background_strong.xml`, then nothing will change in the app except for the background of the action button.