### PR TITLE
reflect status of the proxy (enable/disabled) in the proxy icon

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -19,6 +19,7 @@ package org.thoughtcrime.securesms;
 import static org.thoughtcrime.securesms.ConversationActivity.CHAT_ID_EXTRA;
 import static org.thoughtcrime.securesms.ConversationActivity.STARTING_POSITION_EXTRA;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ADDRESS;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_PROXY_ENABLED;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SERVER_FLAGS;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_PROXY_URL;
 import static org.thoughtcrime.securesms.util.RelayUtil.acquireRelayMessageContent;
@@ -353,6 +354,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   @Override
   public void onResume() {
     super.onResume();
+    invalidateOptionsMenu();
     DirectShareUtil.triggerRefreshDirectShare(this);
   }
 
@@ -364,7 +366,14 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     if (!isRelayingMessageContent(this)) {
       inflater.inflate(R.menu.text_secure_normal, menu);
       menu.findItem(R.id.menu_global_map).setVisible(Prefs.isLocationStreamingEnabled(this));
-      menu.findItem(R.id.menu_proxy_settings).setVisible(!TextUtils.isEmpty(DcHelper.get(this, CONFIG_PROXY_URL)));
+      MenuItem proxyItem = menu.findItem(R.id.menu_proxy_settings);
+      if (TextUtils.isEmpty(DcHelper.get(this, CONFIG_PROXY_URL))) {
+        proxyItem.setVisible(false);
+      } else {
+        boolean proxyEnabled = DcHelper.getInt(this, CONFIG_PROXY_ENABLED) == 1;
+        proxyItem.setIcon(proxyEnabled? R.drawable.ic_proxy_enabled_24 : R.drawable.ic_proxy_disabled_24);
+        proxyItem.setVisible(true);
+      }
     }
 
     super.onPrepareOptionsMenu(menu);

--- a/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -1,5 +1,8 @@
 package org.thoughtcrime.securesms;
 
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_PROXY_ENABLED;
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_PROXY_URL;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -138,6 +141,14 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   public boolean onPrepareOptionsMenu(Menu menu) {
     menu.clear();
     getMenuInflater().inflate(R.menu.instant_onboarding_menu, menu);
+    MenuItem proxyItem = menu.findItem(R.id.menu_proxy_settings);
+    if (TextUtils.isEmpty(DcHelper.get(this, CONFIG_PROXY_URL))) {
+      proxyItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER);
+    } else {
+      boolean proxyEnabled = DcHelper.getInt(this, CONFIG_PROXY_ENABLED) == 1;
+      proxyItem.setIcon(proxyEnabled? R.drawable.ic_proxy_enabled_24 : R.drawable.ic_proxy_disabled_24);
+      proxyItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+    }
     return super.onPrepareOptionsMenu(menu);
   }
 
@@ -239,6 +250,12 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
         Log.e(TAG, "Failed to save avatar", e);
       }
     }
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    invalidateOptionsMenu();
   }
 
   @Override

--- a/src/main/res/drawable/baseline_proxy_24.xml
+++ b/src/main/res/drawable/baseline_proxy_24.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M20,5V4c0,-0.55 -0.45,-1 -1,-1h-2c-0.55,0 -1,0.45 -1,1v1h-1v4c0,0.55 0.45,1 1,1h1v7c0,1.1 -0.9,2 -2,2s-2,-0.9 -2,-2V7c0,-2.21 -1.79,-4 -4,-4S5,4.79 5,7v7H4c-0.55,0 -1,0.45 -1,1v4h1v1c0,0.55 0.45,1 1,1h2c0.55,0 1,-0.45 1,-1v-1h1v-4c0,-0.55 -0.45,-1 -1,-1H7V7c0,-1.1 0.9,-2 2,-2s2,0.9 2,2v10c0,2.21 1.79,4 4,4s4,-1.79 4,-4v-7h1c0.55,0 1,-0.45 1,-1V5H20z"/>
-</vector>

--- a/src/main/res/drawable/ic_proxy_disabled_24.xml
+++ b/src/main/res/drawable/ic_proxy_disabled_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2L4,5v6.09c0,5.05 3.41,9.76 8,10.91c4.59,-1.15 8,-5.86 8,-10.91V5L12,2zM18,11.09c0,4 -2.55,7.7 -6,8.83c-3.45,-1.13 -6,-4.82 -6,-8.83v-4.7l6,-2.25l6,2.25V11.09z"/>
+    
+</vector>

--- a/src/main/res/drawable/ic_proxy_enabled_24.xml
+++ b/src/main/res/drawable/ic_proxy_enabled_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5l-9,-4z"/>
+    
+</vector>

--- a/src/main/res/menu/instant_onboarding_menu.xml
+++ b/src/main/res/menu/instant_onboarding_menu.xml
@@ -6,6 +6,7 @@
 
     <item android:title="@string/proxy_settings"
           android:id="@+id/menu_proxy_settings"
+          android:icon="@drawable/ic_proxy_disabled_24"
           app:showAsAction="never"/>
 
     <item android:title="@string/pref_view_log"

--- a/src/main/res/menu/text_secure_normal.xml
+++ b/src/main/res/menu/text_secure_normal.xml
@@ -23,7 +23,7 @@
 
     <item android:title="@string/proxy_settings"
         android:id="@+id/menu_proxy_settings"
-        android:icon="@drawable/baseline_proxy_24"
+        android:icon="@drawable/ic_proxy_disabled_24"
         app:showAsAction="always"
         android:visible="false"
         />


### PR DESCRIPTION
the icon is also shown in the onboarding screen to remind the user that they have the proxy enabled to help troubleshooting

I think the icons could probably be replaced at some point but this is the best I could find and it is pretty similar to the one used by Telegram, in some way you are protecting the connection against blocking etc. and if you are using shadowsocks it is even encrypted

close #3364 
