### PR TITLE
support BACKUP2 in chatlist-qr-code scanner, 

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -76,6 +76,7 @@ public class QrCodeHandler {
                 break;
 
             case DcContext.DC_QR_BACKUP:
+            case DcContext.DC_QR_BACKUP2:
                 builder.setTitle(R.string.multidevice_receiver_title);
                 builder.setMessage(activity.getString(R.string.multidevice_receiver_scanning_ask) + "\n\n" + activity.getString(R.string.multidevice_same_network_hint));
                 builder.setPositiveButton(R.string.perm_continue, (dialog, which) -> {


### PR DESCRIPTION
this was forgotten by the move to BACKUP2 in #3173

targets #3369, however, indeed "paste" should be added to "add second device scanner" as well