### PR TITLE
notify reactions added

### DIFF
--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -12,6 +12,7 @@ public class DcContext {
     public final static int DC_EVENT_ERROR_SELF_NOT_IN_GROUP     = 410;
     public final static int DC_EVENT_MSGS_CHANGED                = 2000;
     public final static int DC_EVENT_REACTIONS_CHANGED           = 2001;
+    public final static int DC_EVENT_INCOMING_REACTION           = 2002;
     public final static int DC_EVENT_INCOMING_MSG                = 2005;
     public final static int DC_EVENT_MSGS_NOTICED                = 2008;
     public final static int DC_EVENT_MSG_DELIVERED               = 2010;

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -171,7 +171,11 @@ public class DcEventCenter {
 
     switch (id) {
       case DcContext.DC_EVENT_INCOMING_MSG:
-        DcHelper.getNotificationCenter(context).addNotification(accountId, event.getData1Int(), event.getData2Int());
+        DcHelper.getNotificationCenter(context).notifyMessage(accountId, event.getData1Int(), event.getData2Int());
+        break;
+
+      case DcContext.DC_EVENT_INCOMING_REACTION:
+        DcHelper.getNotificationCenter(context).notifyReaction(accountId, event.getData1Int(), event.getData2Int(), event.getData2Str());
         break;
 
       case DcContext.DC_EVENT_MSGS_NOTICED:

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -386,8 +386,8 @@ public class NotificationCenter {
                 return;
             }
 
-            if (playInChatSound && Util.equals(visibleChat, chatData)) {
-                if (Prefs.isInChatNotifications(context)) {
+            if (Util.equals(visibleChat, chatData)) {
+                if (playInChatSound && Prefs.isInChatNotifications(context)) {
                     InChatSounds.getInstance(context).playIncomingSound();
                 }
                 return;

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -350,7 +350,7 @@ public class NotificationCenter {
           tickerLine = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId()), false) + ": " + tickerLine;
         }
 
-        maybeAddNotification(accountId, chatId, msgId, shortLine, tickerLine, true);
+        maybeAddNotification(accountId, dcChat, msgId, shortLine, tickerLine, true);
       });
     }
 
@@ -366,15 +366,15 @@ public class NotificationCenter {
 
         DcContact sender = dcContext.getContact(contactId);
         String shortLine = context.getString(R.string.reaction_by_other, sender.getDisplayName(), reaction, dcMsg.getSummarytext(2000));
-        maybeAddNotification(accountId, dcMsg.getChatId(), msgId, shortLine, shortLine, false);
+        maybeAddNotification(accountId, dcContext.getChat(dcMsg.getChatId()), msgId, shortLine, shortLine, false);
       });
     }
 
     @WorkerThread
-    private void maybeAddNotification(int accountId, int chatId, int msgId, String shortLine, String tickerLine, boolean playInChatSound) {
+    private void maybeAddNotification(int accountId, DcChat dcChat, int msgId, String shortLine, String tickerLine, boolean playInChatSound) {
 
             DcContext dcContext = context.dcAccounts.getAccount(accountId);
-            DcChat dcChat = dcContext.getChat(chatId);
+            int chatId = dcChat.getId();
             ChatData chatData = new ChatData(accountId, chatId);
 
             if (dcContext.isMuted() || dcChat.isMuted()) {

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -403,11 +403,10 @@ public class NotificationCenter {
 
             // if privacy allows, for better accessibility,
             // prepend the sender in the ticker also for one-to-one chats (for group-chats, this is already done)
-            String tickerLine = line;
             if (!dcChat.isMultiUser() && privacy.isDisplayContact()) {
                 line = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId()), false) + ": " + line;
             }
-            builder.setTicker(tickerLine);
+            builder.setTicker(line);
 
             // set sound, vibrate, led for systems that do not have notification channels
             if (!notificationChannelsSupported()) {


### PR DESCRIPTION


this PR shows notifications for reactions to one's own messages.

the notifications are added unconditionally, assuming, this is also known from other messengers. also, only reaction to _own_ messages are notified  - compared to that otherwise _all_ messages of others are notified, this usually won't add much  - either one cares or not (and in the latter case, you have muted the chat). we can always iterate :)

<img width=320 src=https://github.com/user-attachments/assets/74fe82ab-92e6-458b-8847-5c2a3e1d3f0e>
<img width=320 src=https://github.com/user-attachments/assets/ec52fd65-07f0-4265-ab4d-e14e317bcaa6>



for the "mark read": there is nothing to mark as read for reactions, however, i still think, it makes sense to keep the button as it marks the chat as noticed - and it is maybe more confusion if it is sometimes not there.

counterpart of https://github.com/deltachat/deltachat-ios/pull/2331