### PR TITLE
Use tag or display name for notifications instead address

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -396,7 +396,9 @@ public class NotificationCenter {
 
             if (privacy.isDisplayContact()) {
                 builder.setContentTitle(dcChat.getName());
-                builder.setSubText(accountTag);
+                if (!TextUtils.isEmpty(accountTag)) {
+                    builder.setSubText(accountTag);
+                }
             }
 
             // if privacy allows, for better accessibility,
@@ -540,7 +542,7 @@ public class NotificationCenter {
                     .setContentTitle("Delta Chat") // content title would only be used on SDK <24
                     .setContentText("New messages") // content text would only be used on SDK <24
                     .setContentIntent(getOpenChatlistIntent(accountId));
-                  if (privacy.isDisplayContact()) {
+                  if (privacy.isDisplayContact() && !TextUtils.isEmpty(accountTag)) {
                     summary.setSubText(accountTag);
                   }
                   notificationManager.notify(String.valueOf(accountId), ID_MSG_SUMMARY, summary.build());

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -1,5 +1,7 @@
 package org.thoughtcrime.securesms.notifications;
 
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_PRIVATE_TAG;
+
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationChannelGroup;
@@ -387,10 +389,14 @@ public class NotificationCenter {
                 builder.setGroup(GRP_MSG + "." + accountId);
             }
 
-            String accountAddr = dcContext.getConfig("addr");
+            String accountTag = dcContext.getConfig(CONFIG_PRIVATE_TAG);
+            if (accountTag.isEmpty() && context.dcAccounts.getAll().length > 1) {
+                accountTag = dcContext.getName();
+            }
+
             if (privacy.isDisplayContact()) {
                 builder.setContentTitle(dcChat.getName());
-                builder.setSubText(accountAddr);
+                builder.setSubText(accountTag);
             }
 
             // if privacy allows, for better accessibility,
@@ -535,7 +541,7 @@ public class NotificationCenter {
                     .setContentText("New messages") // content text would only be used on SDK <24
                     .setContentIntent(getOpenChatlistIntent(accountId));
                   if (privacy.isDisplayContact()) {
-                    summary.setSubText(accountAddr);
+                    summary.setSubText(accountTag);
                   }
                   notificationManager.notify(String.valueOf(accountId), ID_MSG_SUMMARY, summary.build());
                 } catch (Exception e) {


### PR DESCRIPTION
close #3378 

before - quite some noise in the notification:

![Screenshot 2024-10-24 at 11 20 29](https://github.com/user-attachments/assets/964dd1fb-fbed-4f48-b7de-0ff535a1f723)

after - on a default installation with one account we do not need to show anything:

![Screenshot 2024-10-24 at 11 34 55](https://github.com/user-attachments/assets/9083bbdb-d4a6-474c-8253-2d378190656d)

after - using multiple accounts and label set (if not label is set, the displayname is used):

![Screenshot 2024-10-24 at 11 24 06](https://github.com/user-attachments/assets/877ac3a2-9217-4fa1-b6be-a9268d00cfb6)





