### PR TITLE
do not start foreground service in foreground

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/service/FetchForegroundService.java
+++ b/src/main/java/org/thoughtcrime/securesms/service/FetchForegroundService.java
@@ -13,6 +13,7 @@ import androidx.core.content.ContextCompat;
 
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.connect.ForegroundDetector;
 import org.thoughtcrime.securesms.notifications.FcmReceiveService;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
 import org.thoughtcrime.securesms.util.Util;
@@ -23,6 +24,11 @@ public final class FetchForegroundService extends Service {
   private static Intent service;
 
   public static void start(Context context) {
+    ForegroundDetector foregroundDetector = ForegroundDetector.getInstance();
+    if (foregroundDetector != null && foregroundDetector.isForeground()) {
+      return;
+    }
+
     GenericForegroundService.createFgNotificationChannel(context);
     synchronized (SERVICE_LOCK) {
       if (service == null) {


### PR DESCRIPTION
the foreground service was introduced unconditionally in #3312, however turns out to be annoying and flickering
if the app is actually in foreground.

the service _might_ be needed in this case only
if the app is about going to background during fetch, but in this case, we assume,
that we have some 10 seconds time still.
@Hocuri iirc, you wanted to double check that :)

in any case,
this is still an improvement to the released apps, that _never_ show a foreground service.

(for the naming, it could also be maybeStart() or so, but this was also the case before as it checks if already started, so i do not mind. moving the check outside will add code, and makes tweaking harder. also, as the service will potentially be used also from other places, eg. when it comes to huawei, so i'd be pragmatic here)