### PR TITLE
improve logging: always log events for accId=0

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -12,7 +12,6 @@ import com.b44t.messenger.DcEvent;
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.service.FetchForegroundService;
-import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.util.ArrayList;
@@ -188,37 +187,26 @@ public class DcEventCenter {
         return 0;
     }
 
+    final String logPrefix = "[accId="+accountId + "] ";
+    switch (id) {
+      case DcContext.DC_EVENT_INFO:
+        Log.i("DeltaChat", logPrefix + event.getData2Str());
+        break;
+
+      case DcContext.DC_EVENT_WARNING:
+        Log.w("DeltaChat", logPrefix + event.getData2Str());
+        break;
+
+      case DcContext.DC_EVENT_ERROR:
+        Log.e("DeltaChat", logPrefix + event.getData2Str());
+        break;
+    }
+
     if (accountId != context.dcContext.getAccountId()) {
-      final boolean devMode = Prefs.isDeveloperModeEnabled(context);
-      if (devMode || accountId == 0) {
-        final String logPrefix = devMode? "[accId="+accountId + "] " : "";
-        switch (id) {
-          case DcContext.DC_EVENT_INFO:
-            Log.i("DeltaChat", logPrefix + event.getData2Str());
-            break;
-
-          case DcContext.DC_EVENT_WARNING:
-            Log.w("DeltaChat", logPrefix + event.getData2Str());
-            break;
-
-          case DcContext.DC_EVENT_ERROR:
-            Log.e("DeltaChat", logPrefix + event.getData2Str());
-            break;
-        }
-      }
-
       return 0;
     }
 
     switch (id) {
-      case DcContext.DC_EVENT_INFO:
-        Log.i("DeltaChat", event.getData2Str());
-        break;
-
-      case DcContext.DC_EVENT_WARNING:
-        Log.w("DeltaChat", event.getData2Str());
-        break;
-
       case DcContext.DC_EVENT_ERROR:
         handleError(id, event.getData2Str());
         break;

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -12,6 +12,7 @@ import com.b44t.messenger.DcEvent;
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.service.FetchForegroundService;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.util.ArrayList;
@@ -187,7 +188,26 @@ public class DcEventCenter {
         return 0;
     }
 
+    boolean devMode = Prefs.isDeveloperModeEnabled(context);
+    String logPrefix = devMode? "[accId="+accountId + "] " : "";
+
     if (accountId != context.dcContext.getAccountId()) {
+      if (devMode || accountId == 0) {
+        switch (id) {
+          case DcContext.DC_EVENT_INFO:
+            Log.i("DeltaChat", logPrefix + event.getData2Str());
+            break;
+
+          case DcContext.DC_EVENT_WARNING:
+            Log.w("DeltaChat", logPrefix + event.getData2Str());
+            break;
+
+          case DcContext.DC_EVENT_ERROR:
+            Log.e("DeltaChat", logPrefix + event.getData2Str());
+            break;
+        }
+      }
+
       return 0;
     }
 

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -188,11 +188,10 @@ public class DcEventCenter {
         return 0;
     }
 
-    boolean devMode = Prefs.isDeveloperModeEnabled(context);
-    String logPrefix = devMode? "[accId="+accountId + "] " : "";
-
     if (accountId != context.dcContext.getAccountId()) {
+      final boolean devMode = Prefs.isDeveloperModeEnabled(context);
       if (devMode || accountId == 0) {
+        final String logPrefix = devMode? "[accId="+accountId + "] " : "";
         switch (id) {
           case DcContext.DC_EVENT_INFO:
             Log.i("DeltaChat", logPrefix + event.getData2Str());


### PR DESCRIPTION
That "global"(accid=0) account manager events where never logged at all was a bug

This PR also log other accounts' events if the developer mode is enabled, his can be useful to debug multi-account problems like backgroundFetch()

