### PR TITLE
'message info' just shows the file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 * use stricter TLS checks for HTTPS downloads (images in HTML mails, Autoconfig)
 * improve logging for failed QR code scans, AEAP, Autocrypt, notification permissions and sending errors
 * show more context for the "Cannot establish guaranteed..." info message
-* show original file name in "Message Info"
+* show file name in "Message Info"
 * fix: Sort received outgoing message down if it's fresher than all non fresh messages
 * fix: avoid app being killed when processing a PUSH notification
 * fix crash when refreshing avatar


### PR DESCRIPTION
from the view of the user, this is just the 'file name'. calling it 'original file name' there is maybe correct internally, as we add a random number for $reasons.
however, some users were alarmed about what the heck is transferred here.