### PR TITLE
add "realtime is disabled" dialog

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -1,5 +1,7 @@
 package org.thoughtcrime.securesms;
 
+import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_WEBXDC_REALTIME_ENABLED;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -28,6 +30,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.TaskStackBuilder;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
@@ -72,6 +75,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   private String sourceCodeUrl = "";
   private boolean internetAccess = false;
   private boolean hideActionBar = false;
+  private boolean realtimeWarned = false;
 
   public static void openMaps(Context context, int chatId) {
     DcContext dcContext = DcHelper.getContext(context);
@@ -528,13 +532,39 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
 
     /** @noinspection unused*/
     @JavascriptInterface
+    public boolean isRealtimeSupported() {
+      return WebxdcActivity.this.dcContext.getConfigInt(CONFIG_WEBXDC_REALTIME_ENABLED) != 0;
+    }
+
+    /** @noinspection unused*/
+    @JavascriptInterface
     public void sendRealtimeAdvertisement() {
-      int accountId = WebxdcActivity.this.dcContext.getAccountId();
-      int msgId = WebxdcActivity.this.dcAppMsg.getId();
-      try {
-        WebxdcActivity.this.rpc.sendWebxdcRealtimeAdvertisement(accountId, msgId);
-      } catch (RpcException e) {
-        e.printStackTrace();
+      final WebxdcActivity activity = WebxdcActivity.this;
+      final DcContext dcContext = activity.dcContext;
+      final int accountId = activity.dcContext.getAccountId();
+      final int msgId = activity.dcAppMsg.getId();
+      if (dcContext.getConfigInt(CONFIG_WEBXDC_REALTIME_ENABLED) != 0) {
+        try {
+          activity.rpc.sendWebxdcRealtimeAdvertisement(accountId, msgId);
+        } catch (RpcException e) {
+          e.printStackTrace();
+        }
+      } else if (!activity.realtimeWarned) {
+        activity.realtimeWarned = true;
+        Util.runOnMain(() -> {
+            new AlertDialog.Builder(activity)
+            .setMessage(R.string.realtime_disabled_warning)
+            .setPositiveButton(R.string.enable, (d, b) -> {
+                dcContext.setConfigInt(CONFIG_WEBXDC_REALTIME_ENABLED, 1);
+                try {
+                  activity.rpc.sendWebxdcRealtimeAdvertisement(accountId, msgId);
+                } catch (RpcException e) {
+                  e.printStackTrace();
+                }
+            })
+            .setNegativeButton(R.string.cancel, null)
+            .show();
+        });
       }
     }
 

--- a/src/main/res/raw/webxdc.js
+++ b/src/main/res/raw/webxdc.js
@@ -46,6 +46,8 @@ window.webxdc = (() => {
 
     selfName: InternalJSApi.selfName(),
 
+    isRealtimeSupported: InternalJSApi.isRealtimeSupported,
+
     joinRealtimeChannel: () => {
       realtimeChannel = createRealtimeChannel();
       InternalJSApi.sendRealtimeAdvertisement();

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -449,7 +449,7 @@
     <string name="send_message_to">Send Message to…</string>
     <string name="enable_realtime">Real-Time Apps</string>
     <string name="enable_realtime_explain">Enable real-time connections for apps shared in chats. If enabled, chat partners may be able to discover your IP address when you start an app.</string>
-    <string name="realtime_disabled_warning">\"Real-time\" feature is disabled, this app may not work properly. Do you want to enable it? Chat partners may be able to discover your IP address</string>
+    <string name="realtime_disabled_warning">\"Real-Time Apps\" feature is disabled, this app may not work properly. Do you want to enable it? Chat partners may be able to discover your IP address.</string>
 
     <!-- map -->
     <string name="filter_map_on_time">Show locations in time frame</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="app_name">Delta Chat</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
+    <string name="enable">Enable</string>
    <!-- deprecated, the word "or" to separate blocks in the user interface that are mutually exclusive -->
     <string name="or_separator">or</string>
     <string name="clear_search">Clear Search</string>
@@ -448,6 +449,7 @@
     <string name="send_message_to">Send Message to…</string>
     <string name="enable_realtime">Real-Time Apps</string>
     <string name="enable_realtime_explain">Enable real-time connections for apps shared in chats. If enabled, chat partners may be able to discover your IP address when you start an app.</string>
+    <string name="realtime_disabled_warning">\"Real-time\" feature is disabled, this app may not work properly. Do you want to enable it? Chat partners may be able to discover your IP address</string>
 
     <!-- map -->
     <string name="filter_map_on_time">Show locations in time frame</string>


### PR DESCRIPTION
also add `window.webxdc.isRealtimeSupported()` so apps that don't require the feature to work can avoid the dialog pop up and just keep working without real-time, to mitigate annoyances when apps work without realtime and use it only to add extra features opportunistically 


`window.webxdc.isRealtimeSupported()`  makes sense in general as some webxdc implementations besides allowing to disable it, might just not support realtime channels feature, as it is more work to implement than the simple basic API, giving the client a way to communicate that the feature is missing without silently doing nothing, so apps can realize the lack of support and adapt or show a warning if they can't work without realtime

I guess this requires the Webxdc spec to be updated as well in some our repos