### PR TITLE
Don't show "0%" at the beginning when being added as second device

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
@@ -84,7 +84,8 @@ public class BackupReceiverFragment extends Fragment implements DcEventCenter.Dc
             } else if (permille < 1000) {
                 percent = permille/10;
                 percentMax = 100;
-                statusLineText = getString(R.string.transferring) + String.format(Util.getLocale(), " %d%%", percent);
+                String formattedPercent = percent > 0 ? String.format(Util.getLocale(), " %d%%", percent) : "";
+                statusLineText = getString(R.string.transferring) + formattedPercent;
                 hideSameNetworkHint = true;
             } else if (permille == 1000) {
                 getTransferActivity().setTransferState(BackupTransferActivity.TransferState.TRANSFER_SUCCESS);


### PR DESCRIPTION
Mitigation for https://github.com/deltachat/deltachat-android/issues/3392, follow-up for https://github.com/deltachat/deltachat-android/pull/3337.

When creating a chatmail account, when logging in to an existing email account, and when importing a backup from the Welcome Activity, we're still showing "0%" even after this PR. So, an alternative to this PR would be to make `percent > 0 ? String.format(Util.getLocale(), " %d%%", percent) : "";` into a function and call it from all these places, too, and never show "0%" anywhere ever again.