### PR TITLE
fix: Accept the deprecated 3 as an alias for 2

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -31,7 +31,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -225,9 +224,12 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             authMethod.setSelection(sel);
             expandAdvanced = expandAdvanced || sel != 0;
 
-            int certCheckFlags = DcHelper.getInt(this, "imap_certificate_checks");
-            certCheck.setSelection(certCheckFlags);
-            expandAdvanced = expandAdvanced || certCheckFlags != 0;
+            int imapCertificateChecks = DcHelper.getInt(this, "imap_certificate_checks");
+            if (imapCertificateChecks == 3) {
+              imapCertificateChecks = 2; // 3 is a deprecated alias for 2
+            }
+            certCheck.setSelection(imapCertificateChecks);
+            expandAdvanced = expandAdvanced || imapCertificateChecks != 0;
         } else if (getIntent() != null && getIntent().getBundleExtra(ACCOUNT_DATA) != null) {
           // Companion app might have sent account data
           Bundle b = getIntent().getBundleExtra(ACCOUNT_DATA);

--- a/src/main/res/layout/registration_activity.xml
+++ b/src/main/res/layout/registration_activity.xml
@@ -384,7 +384,6 @@
             android:layout_width="0dp"
             android:layout_height="48dp"
             android:entries="@array/pref_dc_certck_entries"
-            android:entryValues="@array/pref_dc_certck_values"
             app:layout_constraintEnd_toEndOf="@id/guideline_root_end"
             app:layout_constraintStart_toStartOf="@id/guideline_root_start"
             app:layout_constraintTop_toBottomOf="@id/cert_check_label" />

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -158,12 +158,6 @@
         <item>@string/accept_invalid_certificates</item>
     </string-array>
 
-    <string-array name="pref_dc_certck_values">
-        <item>0</item>
-        <item>1</item>
-        <item>3</item>
-    </string-array>
-
   <!-- discrete MIME type (the part before the "/") -->
 
 


### PR DESCRIPTION
fix #3408 by automatically changing a 3 to 2.

3 is a [deprecated alias for 2](https://github.com/deltachat/deltachat-core-rust/blob/37ca9d7319dabcf1cd3cf0bb75c2b4c062aa3bf0/src/login_param.rs#L18-L41), so all UIs now need to handle both values. I think it wasn't a good idea to deprecate 3 in the first place, but it's not worth it going back now.

I tested this PR like this:
- Without this PR:
  - Set certificate checks to "Accept invalid Certificates" in the settings -> `imap_certificate_checks` is 2
  - Import a backup from Desktop with "Accept invalid Certificates"
  - Open "Password and Account" in the settings -> the app crashes
- With this PR:
  - Open "Password and Account" in the settings -> the app doesn't crash anymore
  - -> `imap_certificate_checks` is 3
  - Save the settings
  -  -> `imap_certificate_checks` is 2