### PR TITLE
check spinner bounds

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -58,6 +58,7 @@ import org.thoughtcrime.securesms.proxy.ProxySettingsActivity;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.views.ProgressDialog;
 
 import java.lang.ref.WeakReference;
@@ -184,7 +185,7 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
 
             intVal = DcHelper.getInt(this, CONFIG_MAIL_SECURITY);
-            imapSecurity.setSelection(intVal);
+            imapSecurity.setSelection(ViewUtil.checkBounds(intVal, imapSecurity));
             expandAdvanced = expandAdvanced || intVal != 0;
 
             TextInputEditText smtpLoginInput = findViewById(R.id.smtp_login_text);
@@ -206,7 +207,7 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
             expandAdvanced = expandAdvanced || !TextUtils.isEmpty(strVal);
 
             intVal = DcHelper.getInt(this, CONFIG_SEND_SECURITY);
-            smtpSecurity.setSelection(intVal);
+            smtpSecurity.setSelection(ViewUtil.checkBounds(intVal, smtpSecurity));
             expandAdvanced = expandAdvanced || intVal != 0;
 
             int serverFlags = DcHelper.getInt(this, CONFIG_SERVER_FLAGS);
@@ -221,14 +222,14 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
               }
               // /remove gmail oauth2
             }
-            authMethod.setSelection(sel);
+            authMethod.setSelection(ViewUtil.checkBounds(sel, authMethod));
             expandAdvanced = expandAdvanced || sel != 0;
 
             int imapCertificateChecks = DcHelper.getInt(this, "imap_certificate_checks");
             if (imapCertificateChecks == 3) {
               imapCertificateChecks = 2; // 3 is a deprecated alias for 2
             }
-            certCheck.setSelection(imapCertificateChecks);
+            certCheck.setSelection(ViewUtil.checkBounds(imapCertificateChecks, certCheck));
             expandAdvanced = expandAdvanced || imapCertificateChecks != 0;
         } else if (getIntent() != null && getIntent().getBundleExtra(ACCOUNT_DATA) != null) {
           // Companion app might have sent account data

--- a/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -31,6 +31,8 @@ import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator;
+
+import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -47,6 +49,8 @@ import com.b44t.messenger.util.concurrent.SettableFuture;
 import org.thoughtcrime.securesms.util.views.Stub;
 
 public class ViewUtil {
+  private final static String TAG = ViewUtil.class.getSimpleName();
+
   @SuppressWarnings("deprecation")
   public static void setBackground(final @NonNull View v, final @Nullable Drawable drawable) {
     v.setBackground(drawable);
@@ -274,6 +278,7 @@ public class ViewUtil {
   // Otherwise, to avoid ArrayIndexOutOfBoundsException, 0 is returned, assuming to refer to a good default.
   public static int checkBounds(int selection, AbsSpinner view) {
     if (selection < 0 || selection >= view.getCount()) {
+      Log.w(TAG, "index " + selection + " out of bounds of " + view.toString());
       return 0;
     }
     return selection;

--- a/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -38,6 +38,7 @@ import android.view.ViewGroup;
 import android.view.ViewStub;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
+import android.widget.AbsSpinner;
 import android.widget.TextView;
 
 import com.b44t.messenger.util.concurrent.ListenableFuture;
@@ -266,5 +267,15 @@ public class ViewUtil {
       }
       return result;
     }
+  }
+
+  // Checks if a selection is valid for a given Spinner view.
+  // Returns given selection if valid.
+  // Otherwise, to avoid ArrayIndexOutOfBoundsException, 0 is returned, assuming to refer to a good default.
+  public static int checkBounds(int selection, AbsSpinner view) {
+    if (selection < 0 || selection >= view.getCount()) {
+      return 0;
+    }
+    return selection;
   }
 }


### PR DESCRIPTION
_can be merged to #3410 or later to main_

Spinner is very picky about bad selections,
this is an accident waiting to happen -
eg. if new values are introduced
or someone thinks, the "deprecated" case can be removed.

better do not trust incoming data.

nb: first i did a "clip to bounds", so that larger values get the "maximum", however, although anything is better than _always_ crashing,  i think it is better to for for "default" in this case. however, this requires the "deprecated" check introduced by #3410 for the next time at least (iOS and desktop always write a `3`, probably also DeltaTouch) 

