### PR TITLE
Rename "Back up Chats to External Storage" to "Export Backup"

### DIFF
--- a/src/main/res/xml/preferences_chats.xml
+++ b/src/main/res/xml/preferences_chats.xml
@@ -48,7 +48,7 @@
 
     <PreferenceCategory android:title="@string/pref_backup">
         <Preference android:key="pref_backup"
-            android:title="@string/pref_backup_explain"/>
+            android:title="@string/export_backup_desktop"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
A backup contains more than just the chats, and it's not true that the backup will be exported to "external storage". (the backup will be exported to the Downloads folder, which may well be on the internal storage rather than the SD card).

Old/New:

![image](https://github.com/user-attachments/assets/31995b0b-3635-49b6-bd3c-d443d8bb19f0)

![image](https://github.com/user-attachments/assets/fe146bd0-9992-44b2-ac76-d5ebec3e3fcb)
