### PR TITLE
perf: Only set text size if the scale isn't 1

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/components/emoji/AutoScaledEmojiTextView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/emoji/AutoScaledEmojiTextView.java
@@ -41,7 +41,9 @@ public class AutoScaledEmojiTextView extends AppCompatTextView {
   @Override
   public void setText(@Nullable CharSequence text, BufferType type) {
     float scale = text != null ? getTextScale(text.toString()) : 1;
-    super.setTextSize(TypedValue.COMPLEX_UNIT_PX, originalFontSize * scale);
+    if (scale != 1) {
+      super.setTextSize(TypedValue.COMPLEX_UNIT_PX, originalFontSize * scale);
+    }
     super.setText(text, type);
   }
 


### PR DESCRIPTION
According to the Android Studio profiler, this is an easy win of 1.5ms when loading the chat activity.

I tested that when one or multiple of the latest message are large, and then I scroll up to text messages, these text messages are at scale 1. (because sometimes with the RecylcerView it happens that when you change something, it isn't reset to the default value when the item is recycled).