### PR TITLE
perf: Return early in getTextScale() if text is empty or starts with a letter

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/components/emoji/AutoScaledEmojiTextView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/emoji/AutoScaledEmojiTextView.java
@@ -47,7 +47,7 @@ public class AutoScaledEmojiTextView extends AppCompatTextView {
 
     
   private float getTextScale(String text) {
-    if (text.length() > 21) {
+    if (text.length() > 21 || text.isEmpty() || Character.isLetter(text.charAt(0))) {
       return 1;
     }
     int emojiCount = countGraphemes(text, 8);


### PR DESCRIPTION
Not sure why, but `setText()` seems to be called with an empty string very often - for this case it's nice if getTextScale() returns early.

If the text starts with a letter, we can also return early.