### PR TITLE
fix: check draft.isOk() instead of comparing to null

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -717,7 +717,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     DcMsg draft = dcContext.getDraft(chatId);
     final String sharedText = RelayUtil.getSharedText(this);
 
-    if (draft == null) {
+    if (!draft.isOk()) {
       if (TextUtils.isEmpty(sharedText)) {
         future.set(false);
       } else {


### PR DESCRIPTION
dcContext.getDraft() never returns null.