### PR TITLE
fix: Don't change display name when starting to create a new account and going back

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -244,16 +244,22 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   protected void onPause() {
     super.onPause();
 
-    final String displayName = name.getText().toString();
-    DcHelper.set(this, DcHelper.CONFIG_DISPLAY_NAME, TextUtils.isEmpty(displayName)? null : displayName);
+    // Save display name and avatar in the unconfigured profile.
+    // If the currently selected profile is configured, then this means that rollbackAccountCreation()
+    // was called (see handleOnBackPressed() above), i.e. the newly created profile was removed already
+    // and we can't save the display name & avatar.
+    if (DcHelper.getContext(this).isConfigured() == 0) {
+      final String displayName = name.getText().toString();
+      DcHelper.set(this, DcHelper.CONFIG_DISPLAY_NAME, TextUtils.isEmpty(displayName) ? null : displayName);
 
-    if (avatarChanged) {
-      try {
-        AvatarHelper.setSelfAvatar(InstantOnboardingActivity.this, avatarBmp);
-        Prefs.setProfileAvatarId(InstantOnboardingActivity.this, new SecureRandom().nextInt());
-        avatarChanged = false;
-      } catch (IOException e) {
-        Log.e(TAG, "Failed to save avatar", e);
+      if (avatarChanged) {
+        try {
+          AvatarHelper.setSelfAvatar(InstantOnboardingActivity.this, avatarBmp);
+          Prefs.setProfileAvatarId(InstantOnboardingActivity.this, new SecureRandom().nextInt());
+          avatarChanged = false;
+        } catch (IOException e) {
+          Log.e(TAG, "Failed to save avatar", e);
+        }
       }
     }
   }


### PR DESCRIPTION
fix https://github.com/deltachat/deltachat-android/issues/3433

The problem was that in line 114, rollbackAccountCreation() is called so that the previously selected profile is selected again. Then, afterwards, in onPause() the display name (and avatar, if it was changed) of this profile is changed.

I tested both #3433 and #3063 are fixed after this PR.