### PR TITLE
allow to open in browser http links that look like proxies

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -98,6 +98,9 @@ public class QrCodeHandler {
                     dcContext.restartIo();
                     showDoneToast(activity);
                 });
+                if (rawString.toLowerCase().startsWith("http")) {
+                    builder.setNeutralButton(R.string.open, (d, b) -> IntentUtils.showBrowserIntent(activity, rawString));
+                }
                 builder.setNegativeButton(R.string.cancel, null);
                 builder.setCancelable(false);
                 break;


### PR DESCRIPTION
see discussion at https://support.delta.chat/t/in-the-new-android-client-it-is-not-possible-to-click-to-open-urls-with-port-numbers/3327