### PR TITLE
allow to open deep-link to webxdc

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1565,6 +1565,15 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcMsg_getWebxdcInfoJson(JNIEnv *env, j
 }
 
 
+JNIEXPORT jstring Java_com_b44t_messenger_DcMsg_getWebxdcHref(JNIEnv *env, jobject obj)
+{
+    char* temp = dc_msg_get_webxdc_href(get_dc_msg(env, obj));
+        jstring ret = JSTRING_NEW(temp);
+    dc_str_unref(temp);
+    return ret;
+}
+
+
 JNIEXPORT jboolean Java_com_b44t_messenger_DcMsg_isForwarded(JNIEnv *env, jobject obj)
 {
     return dc_msg_is_forwarded(get_dc_msg(env, obj))!=0;

--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -147,6 +147,7 @@ public class DcMsg {
         return new JSONObject();
       }
     }
+    public native String  getWebxdcHref      ();
     public native boolean isForwarded        ();
     public native boolean isInfo             ();
     public native boolean isSetupMessage     ();
@@ -250,5 +251,4 @@ public class DcMsg {
     private native long getQuotedMsgCPtr ();
     private native long getParentCPtr   ();
     private native String getWebxdcInfoJson ();
-    private native String getWebxdcHref ();
 };

--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -250,4 +250,5 @@ public class DcMsg {
     private native long getQuotedMsgCPtr ();
     private native long getParentCPtr   ();
     private native String getWebxdcInfoJson ();
+    private native String getWebxdcHref ();
 };

--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -795,7 +795,7 @@ public class ConversationFragment extends MessageSelectorFragment
                 DozeReminder.dozeReminderTapped(getContext());
             }
             else if(messageRecord.getInfoType() == DcMsg.DC_INFO_WEBXDC_INFO_MESSAGE) {
-                scrollMaybeSmoothToMsgId(messageRecord.getParent().getId());
+                WebxdcActivity.openWebxdcActivity(getContext(), messageRecord.getParent(), messageRecord.getWebxdcHref());
             }
             else {
                 String self_mail = dcContext.getConfig("configured_mail_user");

--- a/src/main/res/raw/webxdc_wrapper.html
+++ b/src/main/res/raw/webxdc_wrapper.html
@@ -42,11 +42,12 @@
       style="display: none"
     ></iframe>
     <script>
-      const thisUnchangable = (async () => {
+      const loadingDiv = document.getElementById("loading");
+      const iframe = document.getElementById("frame");
+
+      let fill500 = async (href) => {
         const connections = [];
         const loadingProgress = document.getElementById("progress");
-        const loadingDiv = document.getElementById("loading");
-        const iframe = document.getElementById("frame");
         const isolatedContextTest = document.getElementById(
           "test-isolated-sandbox-context"
         );
@@ -131,7 +132,7 @@
           } else {
             loadingDiv.innerHTML = "";
             iframe.style.display = 'block';
-            iframe.src = "index.html";
+            iframe.src = href;
           }
         }
 
@@ -140,7 +141,24 @@
             return connections.length;
           },
         });
-      })();
+      };
+
+     const params = new URLSearchParams(document.location.search);
+     const internetAccess = (params.get("i") || "0") === "1";
+     let href = params.get("href") || "";
+     if (!href || href.startsWith("#")) {
+         href = "index.html" + href;
+     }
+
+     if (internetAccess) {  // fill500 not needed, just load the frame
+         fill500 = (href) => {
+             loadingDiv.innerHTML = "";
+             iframe.style.display = 'block';
+             iframe.src = href;
+         }
+     }
+
+     const thisUnchangable = fill500(href)
     </script>
   </body>
 </html>


### PR DESCRIPTION
- [x] extend WebxdcActivity to allow passing deep-link when calling `WebxdcActivity.openWebxdcActivity()`
- [x] add DcMsg.getWebxdcHref()
- [x] use new core API to get deep-link from info-message when user click it and directly open webxdc?