### PR TITLE
Reverse order of the tiny inbox in notifications

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -504,7 +504,7 @@ public class NotificationCenter {
                         }
                         lines.add(line);
 
-                        for (int l = lines.size() - 1; l >= 0; l--) {
+                        for (int l = 0; l < lines.size(); l++) {
                             inboxStyle.addLine(lines.get(l));
                         }
                     }


### PR DESCRIPTION
When someone sends you 4 messages "1", "2", "3", "4" (in this order), this now looks like this (unexpanded/expanded):
![Screenshot_20241123-200045](https://github.com/user-attachments/assets/7b4da53d-88b5-47c4-9543-56703b869f14)
![Screenshot_20241123-200048](https://github.com/user-attachments/assets/4964ba24-8399-491d-a22e-0a048e44abfb)

Before, the unexpanded notification looked the same, the expanded notification had the other direction.

This PR here makes DC show the same behavior as Signal and WhatsApp.