### PR TITLE
Always show the "~" before the sender name if it's overridden

### DIFF
--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -165,10 +165,10 @@ public class DcMsg {
     public native String  getError           ();
     public native String  getOverrideSenderName();
 
-    public String getSenderName(DcContact dcContact, boolean markOverride) {
+    public String getSenderName(DcContact dcContact) {
         String overrideName = getOverrideSenderName();
         if (overrideName != null) {
-            return (markOverride ? "~" : "") + overrideName;
+            return "~" + overrideName;
         } else {
             return dcContact.getDisplayName();
         }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -24,7 +24,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -427,7 +426,7 @@ public class ConversationFragment extends MessageSelectorFragment
 
             if (msg.getFromId() != prevMsg.getFromId() && !singleMsg) {
                 DcContact contact = dcContext.getContact(msg.getFromId());
-                result.append(msg.getSenderName(contact, false)).append(":\n");
+                result.append(msg.getSenderName(contact)).append(":\n");
             }
             if (msg.getType() == DcMsg.DC_MSG_TEXT || (singleMsg && !msg.getText().isEmpty())) {
                 result.append(msg.getText());

--- a/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
@@ -22,12 +22,10 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
-import android.os.Build;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -791,14 +789,14 @@ public class ConversationItem extends BaseConversationItem
 
     if (messageRecord.isForwarded()) {
       if (showSender && dcContact !=null) {
-        this.groupSender.setText(context.getString(R.string.forwarded_by, messageRecord.getSenderName(dcContact, false)));
+        this.groupSender.setText(context.getString(R.string.forwarded_by, messageRecord.getSenderName(dcContact)));
       } else {
         this.groupSender.setText(context.getString(R.string.forwarded_message));
       }
       this.groupSender.setTextColor(context.getResources().getColor(R.color.unknown_sender));
     }
     else if (showSender && dcContact !=null) {
-      this.groupSender.setText(messageRecord.getSenderName(dcContact, true));
+      this.groupSender.setText(messageRecord.getSenderName(dcContact));
       this.groupSender.setTextColor(Util.rgbToArgbColor(dcContact.getColor()));
     }
   }

--- a/src/main/java/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/QuoteView.java
@@ -4,7 +4,6 @@ package org.thoughtcrime.securesms.components;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.net.Uri;
-import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -16,7 +15,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 
 import com.annimon.stream.Stream;
 import com.b44t.messenger.DcContact;
@@ -155,7 +153,7 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
       if (contact == null) {
         authorView.setText(getContext().getString(R.string.forwarded_message));
       } else {
-        authorView.setText(getContext().getString(R.string.forwarded_by, quotedMsg.getSenderName(contact, false)));
+        authorView.setText(getContext().getString(R.string.forwarded_by, quotedMsg.getSenderName(contact)));
       }
       authorView.setTextColor(getForwardedColor());
       quoteBarView.setBackgroundColor(getForwardedColor());
@@ -166,7 +164,7 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
         quoteBarView.setBackgroundColor(getForwardedColor());
       } else {
         authorView.setVisibility(VISIBLE);
-        authorView.setText(quotedMsg.getSenderName(contact, true));
+        authorView.setText(quotedMsg.getSenderName(contact));
         if (hasSticker) {
           authorView.setTextColor(getResources().getColor(R.color.core_dark_05));
           quoteBarView.setBackgroundColor(getResources().getColor(R.color.core_dark_05));

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -343,12 +343,12 @@ public class NotificationCenter {
 
         String shortLine = privacy.isDisplayMessage()? dcMsg.getSummarytext(2000) : context.getString(R.string.notify_new_message);
         if (dcChat.isMultiUser() && privacy.isDisplayContact()) {
-          shortLine = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId()), false) + ": " + shortLine;
+          shortLine = dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId())) + ": " + shortLine;
         }
         String tickerLine = shortLine;
         if (!dcChat.isMultiUser() && privacy.isDisplayContact()) {
           DcContact contact = dcContext.getContact(dcMsg.getFromId());
-          tickerLine = dcMsg.getSenderName(contact, false) + ": " + tickerLine;
+          tickerLine = dcMsg.getSenderName(contact) + ": " + tickerLine;
 
           if (!Util.equals(dcChat.getName(), contact.getDisplayName())) {
             // There is an "overridden" display name on the message, so, we need to prepend the display name to the message,


### PR DESCRIPTION
When we introduced this, I assume that we weren't sure whether we should do it and only showed it in some places. But I think it's nicer to show the same sender name everywhere, i.e. always add the "~".

Before this PR, the "~" was _not_ shown:

- in quotes
- when copying messages of multiple senders at once (when copying just one message / messages of just one sender, the sender is not included in the copied text, anyway)
- In the "Forwarded by..." text of a forwarded message
- in notifications

Context: When the sender of a message is not part of the chat (in mailing lists or because they were sending from an alias), the name is prepended with a "~".

This PR needs to be merged after #3441.