### PR TITLE
reply/mark-read actions refer to chat, not to message

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -69,7 +69,6 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
 
         DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_TEXT);
         msg.setText(responseText.toString());
-        msg.setQuote(dcContext.getMsg(msgId));
         dcContext.sendMsg(chatId, msg);
 
         DcHelper.getNotificationCenter(context).removeNotifications(accountId, chatId);


### PR DESCRIPTION
this PR lets  the actions "Reply" and "Mark Read" refer to the chat, not to the message.

this fixes reaction/webxdc notifications as well as unclear grouping of android (android shows the messages combined, so it is unclear what "Reply" would quote). 

this is also what eg. signal is doing.

in a subsequent PR, we can go for adding a "Start" button that opens the webxdc-app directly 