### PR TITLE
notify webxdc events, replies and reactions to own messages even if chat is muted

### DIFF
--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -85,7 +85,7 @@ public class DcContext {
     public final static int DC_CONNECTIVITY_WORKING = 3000;
     public final static int DC_CONNECTIVITY_CONNECTED = 4000;
 
-    private static final String CONFIG_MENTION_NOTIF_ENABLED = "ui.notify_mentions";
+    private static final String CONFIG_NOTIFY_MENTIONS_IF_MUTED = "ui.notify_mentions_if_muted";
 
     // when using DcAccounts, use DcAccounts.addAccount() instead
     public DcContext(String osName, String dbfile) {
@@ -136,7 +136,8 @@ public class DcContext {
     public void                setConfigInt         (String key, int value) { setConfig(key, Integer.toString(value)); }
     public native boolean      setConfigFromQr      (String qr);
     public native String       getConfig            (String key);
-    public int                 getConfigInt         (String key) { try{return Integer.parseInt(getConfig(key));} catch(Exception e) {} return 0; }
+    public int                 getConfigInt         (String key) { return getConfigInt(key, 0); }
+    public int                 getConfigInt         (String key, int defaultValue) { try {return Integer.parseInt(getConfig(key));} catch(Exception e) {} return defaultValue; }
     public native String       getInfo              ();
     public native int          getConnectivity      ();
     public native String       getConnectivityHtml  ();
@@ -214,11 +215,11 @@ public class DcContext {
     public DcProvider          getProviderFromEmailWithDns (String email) { long cptr = getProviderFromEmailWithDnsCPtr(email); return cptr!=0 ? new DcProvider(cptr) : null; }
 
     public boolean isMentionsEnabled() {
-      return !"0".equals(getConfig(CONFIG_MENTION_NOTIF_ENABLED));
+      return getConfigInt(CONFIG_NOTIFY_MENTIONS_IF_MUTED, 1) == 1;
     }
 
     public void setMentionsEnabled(boolean enabled) {
-      setConfigInt(CONFIG_MENTION_NOTIF_ENABLED, enabled? 1 : 0);
+      setConfigInt(CONFIG_NOTIFY_MENTIONS_IF_MUTED, enabled? 1 : 0);
     }
 
     public String getName() {

--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -85,7 +85,7 @@ public class DcContext {
     public final static int DC_CONNECTIVITY_WORKING = 3000;
     public final static int DC_CONNECTIVITY_CONNECTED = 4000;
 
-    private static final String CONFIG_NOTIFY_MENTIONS_IF_MUTED = "ui.notify_mentions_if_muted";
+    private static final String CONFIG_MUTE_MENTIONS_IF_MUTED = "ui.mute_mentions_if_muted";
 
     // when using DcAccounts, use DcAccounts.addAccount() instead
     public DcContext(String osName, String dbfile) {
@@ -136,8 +136,7 @@ public class DcContext {
     public void                setConfigInt         (String key, int value) { setConfig(key, Integer.toString(value)); }
     public native boolean      setConfigFromQr      (String qr);
     public native String       getConfig            (String key);
-    public int                 getConfigInt         (String key) { return getConfigInt(key, 0); }
-    public int                 getConfigInt         (String key, int defaultValue) { try {return Integer.parseInt(getConfig(key));} catch(Exception e) {} return defaultValue; }
+    public int                 getConfigInt         (String key) { try{return Integer.parseInt(getConfig(key));} catch(Exception e) {} return 0; }
     public native String       getInfo              ();
     public native int          getConnectivity      ();
     public native String       getConnectivityHtml  ();
@@ -215,11 +214,11 @@ public class DcContext {
     public DcProvider          getProviderFromEmailWithDns (String email) { long cptr = getProviderFromEmailWithDnsCPtr(email); return cptr!=0 ? new DcProvider(cptr) : null; }
 
     public boolean isMentionsEnabled() {
-      return getConfigInt(CONFIG_NOTIFY_MENTIONS_IF_MUTED, 1) == 1;
+      return getConfigInt(CONFIG_MUTE_MENTIONS_IF_MUTED) != 1;
     }
 
     public void setMentionsEnabled(boolean enabled) {
-      setConfigInt(CONFIG_NOTIFY_MENTIONS_IF_MUTED, enabled? 1 : 0);
+      setConfigInt(CONFIG_MUTE_MENTIONS_IF_MUTED, enabled? 0 : 1);
     }
 
     public String getName() {

--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -85,6 +85,8 @@ public class DcContext {
     public final static int DC_CONNECTIVITY_WORKING = 3000;
     public final static int DC_CONNECTIVITY_CONNECTED = 4000;
 
+    private static final String CONFIG_MENTION_NOTIF_ENABLED = "ui.notify_mentions";
+
     // when using DcAccounts, use DcAccounts.addAccount() instead
     public DcContext(String osName, String dbfile) {
         contextCPtr = createContextCPtr(osName, dbfile);
@@ -210,6 +212,14 @@ public class DcContext {
     public native void         sendLocationsToChat  (int chat_id, int seconds);
     public native boolean      isSendingLocationsToChat(int chat_id);
     public DcProvider          getProviderFromEmailWithDns (String email) { long cptr = getProviderFromEmailWithDnsCPtr(email); return cptr!=0 ? new DcProvider(cptr) : null; }
+
+    public boolean isMentionsEnabled() {
+      return !"0".equals(getConfig(CONFIG_MENTION_NOTIF_ENABLED));
+    }
+
+    public void setMentionsEnabled(boolean enabled) {
+      setConfigInt(CONFIG_MENTION_NOTIF_ENABLED, enabled? 1 : 0);
+    }
 
     public String getName() {
       String displayname = getConfig("displayname");

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -418,6 +418,7 @@ public class NotificationCenter {
             DcContext dcContext = context.dcAccounts.getAccount(accountId);
             int chatId = dcChat.getId();
             ChatData chatData = new ChatData(accountId, chatId);
+            isMention = isMention && dcContext.isMentionsEnabled();
 
             if (dcContext.isMuted() || (!isMention &&  dcChat.isMuted())) {
                 return;

--- a/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -36,6 +36,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
 
   private CheckBoxPreference ignoreBattery;
   private CheckBoxPreference notificationsEnabled;
+  private CheckBoxPreference mentionNotifEnabled;
 
   @Override
   public void onCreate(Bundle paramBundle) {
@@ -99,6 +100,13 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
       dcContext.setMuted(!enabled);
       return true;
     });
+
+    mentionNotifEnabled = this.findPreference("pref_enable_mention_notifications");
+    mentionNotifEnabled.setOnPreferenceChangeListener((preference, newValue) -> {
+      boolean enabled = (Boolean) newValue;
+      dcContext.setMentionsEnabled(enabled);
+      return true;
+    });
   }
 
   @Override
@@ -114,6 +122,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     // update ignoreBattery in onResume() to reflects changes done in the system settings
     ignoreBattery.setChecked(isIgnoringBatteryOptimizations());
     notificationsEnabled.setChecked(!dcContext.isMuted());
+    mentionNotifEnabled.setChecked(dcContext.isMentionsEnabled());
   }
 
   @Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -702,8 +702,8 @@
     <string name="pref_screen_security_explain">Request to block screenshots in the recents list and inside the app</string>
     <string name="pref_screen_security_please_restart_hint">To apply the screen security setting please restart the app.</string>
     <string name="pref_notifications">Notifications</string>
-    <string name="pref_mention_notifications">Notify mentions</string>
-    <string name="pref_mention_notifications_explain">Notify messages in muted chats if they are directed to you, like replies or reactions to your messages</string>
+    <string name="pref_mention_notifications">Mentions</string>
+    <string name="pref_mention_notifications_explain">In muted groups, notify messages directed to you, like replies or reactions</string>
     <string name="pref_notifications_show">Show</string>
     <string name="pref_notifications_priority">Priority</string>
     <string name="pref_notifications_explain">Enable system notifications for new messages</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -702,6 +702,8 @@
     <string name="pref_screen_security_explain">Request to block screenshots in the recents list and inside the app</string>
     <string name="pref_screen_security_please_restart_hint">To apply the screen security setting please restart the app.</string>
     <string name="pref_notifications">Notifications</string>
+    <string name="pref_mention_notifications">Notify mentions</string>
+    <string name="pref_mention_notifications_explain">Notify messages in muted chats if they are directed to you, like replies or reactions to your messages</string>
     <string name="pref_notifications_show">Show</string>
     <string name="pref_notifications_priority">Priority</string>
     <string name="pref_notifications_explain">Enable system notifications for new messages</string>

--- a/src/main/res/xml/preferences_notifications.xml
+++ b/src/main/res/xml/preferences_notifications.xml
@@ -7,6 +7,13 @@
                             android:title="@string/pref_notifications"
                             android:defaultValue="true" />
 
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:dependency="pref_enable_notifications"
+            android:key="pref_enable_mention_notifications"
+            android:title="@string/pref_mention_notifications"
+            android:summary="@string/pref_mention_notifications_explain"
+            android:defaultValue="true" />
+
         <Preference
                 android:dependency="pref_enable_notifications"
                 android:key="pref_key_ringtone"


### PR DESCRIPTION
even if group is muted:

* notify quote-reply to own messages
* notify reactions to own messages
* notify webxdc notifications

what is still unsolved:

if webxdc sends notification while the chat is open, there is no notification, if there is no info message there is no hint that there was a notification at all, and if there is info message that doesn't warranties that the notification was the same