### PR TITLE
fix WebxdcActivity.callJavaScriptFunction()

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -366,11 +366,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   }
 
   private void callJavaScriptFunction(String func) {
-    if (internetAccess) {
-      webView.evaluateJavascript("window." + func + ";", null);
-    } else {
-      webView.evaluateJavascript("document.getElementById('frame').contentWindow." + func + ";", null);
-    }
+    webView.evaluateJavascript("document.getElementById('frame').contentWindow." + func + ";", null);
   }
 
   @Override


### PR DESCRIPTION
now even if internet access is enabled, the index.html is wrapped in an iframe