### PR TITLE
always prefix href with baseURL

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -216,7 +216,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     webView.setNetworkAvailable(internetAccess); // this does not block network but sets `window.navigator.isOnline` in js land
     webView.addJavascriptInterface(new InternalJSApi(), "InternalJSApi");
 
-    String href = b.getString(EXTRA_HREF, "");
+    String href = baseURL + "/" + b.getString(EXTRA_HREF, "index.html");
     String encodedHref = "";
     try {
       encodedHref = URLEncoder.encode(href, Charsets.UTF_8.name());

--- a/src/main/res/raw/webxdc_wrapper.html
+++ b/src/main/res/raw/webxdc_wrapper.html
@@ -145,7 +145,7 @@
 
      const params = new URLSearchParams(document.location.search);
      const internetAccess = (params.get("i") || "0") === "1";
-     let href = params.get("href") || "index.html";
+     const href = params.get("href");
 
      if (internetAccess) {  // fill500 not needed, just load the frame
          fill500 = (href) => {


### PR DESCRIPTION
always prefix href with baseURL to avoid working accidentally if developer pass full URL which will work locally but will not work in other devices / platforms