### PR TITLE
Remove prepareMsg (and OUT_PREPARING message state)

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1572,12 +1572,6 @@ JNIEXPORT jboolean Java_com_b44t_messenger_DcMsg_isForwarded(JNIEnv *env, jobjec
 }
 
 
-JNIEXPORT jboolean Java_com_b44t_messenger_DcMsg_isIncreation(JNIEnv *env, jobject obj)
-{
-    return dc_msg_is_increation(get_dc_msg(env, obj))!=0;
-}
-
-
 JNIEXPORT jboolean Java_com_b44t_messenger_DcMsg_isInfo(JNIEnv *env, jobject obj)
 {
     return dc_msg_is_info(get_dc_msg(env, obj))!=0;

--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -702,12 +702,6 @@ JNIEXPORT jboolean Java_com_b44t_messenger_DcContext_resendMsgs(JNIEnv *env, job
 }
 
 
-JNIEXPORT jint Java_com_b44t_messenger_DcContext_prepareMsg(JNIEnv *env, jobject obj, jint chat_id, jobject msg)
-{
-    return dc_prepare_msg(get_dc_context(env, obj), chat_id, get_dc_msg(env, msg));
-}
-
-
 JNIEXPORT jint Java_com_b44t_messenger_DcContext_sendMsg(JNIEnv *env, jobject obj, jint chat_id, jobject msg)
 {
     return dc_send_msg(get_dc_context(env, obj), chat_id, get_dc_msg(env, msg));

--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -192,7 +192,6 @@ public class DcContext {
     public native void         deleteMsgs           (int msg_ids[]);
     public native void         forwardMsgs          (int msg_ids[], int chat_id);
     public native boolean      resendMsgs           (int msg_ids[]);
-    public native int          prepareMsg           (int chat_id, DcMsg msg);
     public native int          sendMsg              (int chat_id, DcMsg msg);
     public native int          sendTextMsg          (int chat_id, String text);
     public native int          sendVideochatInvitation(int chat_id);

--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -155,7 +155,6 @@ public class DcMsg {
     public native String  getSetupCodeBegin  ();
     public native String  getVideochatUrl    ();
     public native int     getVideochatType   ();
-    public native boolean isIncreation       ();
     public native void    setText            (String text);
     public native void    setFile            (String file, String filemime);
     public native void    setDimension       (int width, int height);

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -117,6 +117,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.concurrent.AssertedSuccessListener;
 import org.thoughtcrime.securesms.util.guava.Optional;
+import org.thoughtcrime.securesms.util.views.ProgressDialog;
 import org.thoughtcrime.securesms.util.views.Stub;
 import org.thoughtcrime.securesms.video.recode.VideoRecoder;
 import org.thoughtcrime.securesms.videochat.VideochatUtil;
@@ -172,6 +173,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private   View                        composePanel;
   private   ScaleStableImageView        backgroundView;
   private   MessageRequestsBottomView   messageRequestBottomView;
+  private   ProgressDialog              progressDialog;
 
   private   AttachmentTypeSelector attachmentTypeSelector;
   private   AttachmentManager      attachmentManager;
@@ -1075,7 +1077,17 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           {
             boolean doSend = true;
             if (recompress==DcMsg.DC_MSG_VIDEO) {
+              Util.runOnMain(() -> {
+                progressDialog = ProgressDialog.show(
+                        ConversationActivity.this,
+                        "",
+                        getString(R.string.one_moment),
+                        true,
+                        false
+                );
+              });
               doSend = VideoRecoder.prepareVideo(ConversationActivity.this, dcChat.getId(), msg);
+              Util.runOnMain(() -> progressDialog.dismiss());
             }
 
             if (doSend) {

--- a/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
+++ b/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
@@ -552,8 +552,7 @@ public class VideoRecoder {
   }
 
   // prepareVideo() assumes the msg object is set up properly to being sent;
-  // the function fills out missing information and also recodes the video as needed;
-  // to get a responsive ui, DcChat.prepareMsg() may be called.
+  // the function fills out missing information and also recodes the video as needed.
   // return: true=video might be prepared, can be sent, false=error
   public static boolean prepareVideo(Context context, int chatId, DcMsg msg) {
     try {
@@ -623,7 +622,6 @@ public class VideoRecoder {
         msg.setDimension(vei.resultWidth, vei.resultHeight);
       }
       msg.setDuration((int) resultDurationMs);
-      //DcHelper.getContext(context).prepareMsg(chatId, msg);
 
       // calculate bytes
       vei.estimatedBytes = VideoRecoder.calculateEstimatedSize((float) resultDurationMs / vei.originalDurationMs,

--- a/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
+++ b/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
@@ -23,6 +23,7 @@ import com.googlecode.mp4parser.util.Path;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.util.views.ProgressDialog;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -555,7 +556,6 @@ public class VideoRecoder {
   // to get a responsive ui, DcChat.prepareMsg() may be called.
   // return: true=video might be prepared, can be sent, false=error
   public static boolean prepareVideo(Context context, int chatId, DcMsg msg) {
-
     try {
       String inPath = msg.getFile();
       Log.i(TAG, "Preparing video: " + inPath);
@@ -623,7 +623,7 @@ public class VideoRecoder {
         msg.setDimension(vei.resultWidth, vei.resultHeight);
       }
       msg.setDuration((int) resultDurationMs);
-      DcHelper.getContext(context).prepareMsg(chatId, msg);
+      //DcHelper.getContext(context).prepareMsg(chatId, msg);
 
       // calculate bytes
       vei.estimatedBytes = VideoRecoder.calculateEstimatedSize((float) resultDurationMs / vei.originalDurationMs,


### PR DESCRIPTION
This PR removes prepareMsg, which put messages into the OUT_PREPARING state and was used while videos were recoded:
- It was buggy because when you forwarded a message while it was InPreparation, or when the app was killed while a message is InPreparation, the message would stay InPreparation forever.
- Android is the only UI using this InPreparation (according to @r10s, I didn't check this myself), so we can simplify some things in core, which will also make it easier to deduplicate blob files.