### PR TITLE
fix starting of webxdc

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -216,7 +216,12 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     webView.setNetworkAvailable(internetAccess); // this does not block network but sets `window.navigator.isOnline` in js land
     webView.addJavascriptInterface(new InternalJSApi(), "InternalJSApi");
 
-    String href = baseURL + "/" + b.getString(EXTRA_HREF, "index.html");
+    String extraHref = b.getString(EXTRA_HREF, "");
+    if (TextUtils.isEmpty(extraHref)) {
+      extraHref = "index.html";
+    }
+
+    String href = baseURL + "/" + extraHref;
     String encodedHref = "";
     try {
       encodedHref = URLEncoder.encode(href, Charsets.UTF_8.name());


### PR DESCRIPTION
the issue is that unset `EXTRA_HREF` is passed around as an empty string, however `Bundle.getString(href, "index.html")` returns `index.html` only when `href` is `NULL`, which is mostly never the case.

this results in webxdc never started with index.html, and then not started at all