### PR TITLE
Make the attachment background the same as the input bar background

### DIFF
--- a/src/main/res/layout/conversation_activity_attachment_editor_stub.xml
+++ b/src/main/res/layout/conversation_activity_attachment_editor_stub.xml
@@ -4,6 +4,7 @@
              android:id="@+id/attachment_editor"
              android:layout_width="match_parent"
              android:layout_height="wrap_content"
+             android:background="?attr/input_panel_bg_color"
              android:gravity="center_horizontal"
              android:visibility="gone">
 


### PR DESCRIPTION
Two different users recently complained that they find drafting images confusing. One of them thought that they had already sent it, the other one didn't know how to send it (both of them figured it out after ~10s, but still, it's nicer to avoid such confusion). In both cases, the problem was that the background of the attached file is the same as the chat background, not the same as the input bar, even though the attached file belongs to the input bar and not to the chat.

We don't have to merge this now, but it's a super small tweak (just 1 line) and I think it can reduce confusion for new users. Also, it makes things look a little more similar to Deltachat-iOS (there, the attachment is on the left, not in the middle, which might look a bit nicer - should also be easy to change if we want to).

What do you think?

Before:



![image_2024-12-06_14-41-16](https://github.com/user-attachments/assets/f916e64a-6b41-4cc5-b3b4-ce0b59bbfd90) | ![image_2024-12-06_14-41-13](https://github.com/user-attachments/assets/5078162d-3f5b-40ec-ae35-7d864ec9bd81) | ![image_2024-12-06_14-41-14](https://github.com/user-attachments/assets/78831d19-a623-497e-b438-ed47e0a0e8cf) | ![image_2024-12-06_14-41-12](https://github.com/user-attachments/assets/f7d6b1c3-49df-4109-b9fd-e7222e93585c)
-|-|-|-

After:
![image_2024-12-06_14-39-49](https://github.com/user-attachments/assets/fe7f4eea-a56b-44d2-a5a5-d36a765f6d8b) | ![image_2024-12-06_14-39-46](https://github.com/user-attachments/assets/e51e436c-8157-4bba-a5d1-c486b032262b) | ![image_2024-12-06_14-39-48](https://github.com/user-attachments/assets/bdcf177f-eadc-4edb-ba45-856e06cf33cc) | ![image_2024-12-06_14-39-47](https://github.com/user-attachments/assets/be267c30-b705-49ac-968c-134c401d0bb4) 
-|-|-|-