### PR TITLE
center attachment icons

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
@@ -90,13 +90,11 @@ public class AttachmentTypeSelector extends PopupWindow {
     this.recentRail.setListener(new RecentPhotoSelectedListener());
 
     if (!Prefs.isLocationStreamingEnabled(context)) {
-      this.locationButton.setVisibility(View.GONE);
-      ViewUtil.findById(layout, R.id.location_button_label).setVisibility(View.GONE);
+      ViewUtil.findById(layout, R.id.location_linear_layout).setVisibility(View.GONE);
     }
 
     if (!DcHelper.isWebrtcConfigOk(DcHelper.getContext(context))) {
-      this.videoChatButton.setVisibility(View.GONE);
-      ViewUtil.findById(layout, R.id.invite_video_chat_label).setVisibility(View.GONE);
+      ViewUtil.findById(layout, R.id.invite_video_chat_linear_layout).setVisibility(View.GONE);
     }
 
     setLocationButtonImage(context);

--- a/src/main/res/layout/attachment_type_selector.xml
+++ b/src/main/res/layout/attachment_type_selector.xml
@@ -26,8 +26,7 @@
                       android:layout_height="wrap_content"
                       android:layout_marginLeft="16dp"
                       android:layout_marginRight="16dp"
-                      android:layout_marginTop="16dp"
-                      android:weightSum="4">
+                      android:layout_marginTop="16dp">
 
             <!-- first row -->
 
@@ -120,7 +119,6 @@
                     app:circleColor="@color/location_icon"/>
 
                 <TextView android:layout_marginTop="10dp"
-                          android:id="@+id/location_button_label"
                           android:layout_width="wrap_content"
                           android:layout_height="wrap_content"
                           android:visibility="visible"
@@ -137,8 +135,7 @@
                       android:layout_marginTop="16dp"
                       android:layout_marginLeft="16dp"
                       android:layout_marginRight="16dp"
-                      android:layout_marginBottom="16dp"
-                      android:weightSum="4">
+                      android:layout_marginBottom="16dp">
 
             <!-- second row -->
 
@@ -213,6 +210,7 @@
             </LinearLayout>
 
             <LinearLayout android:layout_width="match_parent"
+                android:id="@+id/invite_video_chat_linear_layout"
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:layout_weight="1"
@@ -228,7 +226,6 @@
                     app:circleColor="@color/audio_icon"/>
 
                 <TextView android:layout_marginTop="10dp"
-                    android:id="@+id/invite_video_chat_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     style="@style/AttachmentTypeLabel"


### PR DESCRIPTION
this PR centers the icons in the attachment selector, the right-aligned ones looks esp. odd when no experiments are enabled.

before / after:

<img width=320 src=https://github.com/user-attachments/assets/a198bcfd-b54a-42c8-ad9f-c9cdf9b86e62> &nbsp;  &nbsp;  &nbsp; <img width=320 src=https://github.com/user-attachments/assets/dd5cd283-35ee-4f6c-8d69-e3c5aa455ea7>

the default now looks good,
and when all experiments are enabled, things are perfect as well. but even if only one experiment is enabled, things are better imo (but we anyway should optimize for default and not for experimental options):

<img width=200 src=https://github.com/user-attachments/assets/2a3428bb-a7ca-4d01-b998-47f094be9d31> <img width=200 src=https://github.com/user-attachments/assets/f7fca460-0df4-4079-a569-7376db40b087>

i know there are disucssions about changing that at all, but this PR is an easy fix i could not resist :)

@adbenitez i like the new app-icon, btw 👌