### PR TITLE
don't throw IllegalStateException

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -900,7 +900,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
     chatId = getIntent().getIntExtra(CHAT_ID_EXTRA, -1);
     if(chatId == DcChat.DC_CHAT_NO_CHAT)
-      throw new IllegalStateException("can't display a conversation for no chat.");
+      chatId = -1;
     dcChat           = dcContext.getChat(chatId);
     recipient        = new Recipient(this, dcChat);
     glideRequests    = GlideApp.with(this);


### PR DESCRIPTION
the problem is that `CHAT_ID_EXTRA` passed to `ConversationActivity` is `0` in the reported issue, I looked at several places and often it is checked that `chatId !=0` etc. so I couldn't really find a place in which it could be zero, so instead of a crash I changed it to be handle similar to other situations where the chatId is invalid or non-existing chat
 
close #3494 