### PR TITLE
avoid IllegalArgumentException dismissing dialog

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1084,7 +1084,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
                 );
               });
               doSend = VideoRecoder.prepareVideo(ConversationActivity.this, dcChat.getId(), msg);
-              Util.runOnMain(() -> progressDialog.dismiss());
+              Util.runOnMain(() -> {
+                try {
+                  progressDialog.dismiss();
+                } catch (final IllegalArgumentException e) {
+                  // The activity is finishing/destroyed, do nothing.
+                }
+              });
             }
 
             if (doSend) {


### PR DESCRIPTION
The activity may be  finishing/destroyed by the time the async task finishes and tries to dismiss the progress dialog, so just avoid calling `progressDialog.dismiss()` if activity is finishing/destroyed

close #3498 