### PR TITLE
do not lowercase string 'Bot'

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -105,7 +105,7 @@ public class ConversationTitleView extends RelativeLayout {
       else {
         DcContact dcContact = dcContext.getContact(chatContacts[0]);
         if (!profileView && dcContact.isBot()) {
-          subtitleStr = context.getString(R.string.bot).toLowerCase();
+          subtitleStr = context.getString(R.string.bot);
         } else if (profileView || !dcChat.isProtected()) {
           subtitleStr = dcContact.getAddr();
         }


### PR DESCRIPTION
it is regarded as a bug
and esp. weird in translations.

it was regarded to be a bit 'nerdy' that time to write it lowercase, but it seems we have to get more serious now.

via https://support.delta.chat/t/two-typos-in-dc/3396 , but tbh, i was also stumbling upon that more than once. better use correct casing, don't make me think.