### PR TITLE
remove email-address unconditionally from title

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -106,7 +106,7 @@ public class ConversationTitleView extends RelativeLayout {
         DcContact dcContact = dcContext.getContact(chatContacts[0]);
         if (!profileView && dcContact.isBot()) {
           subtitleStr = context.getString(R.string.bot);
-        } else if (profileView || !dcChat.isProtected()) {
+        } else if (profileView) {
           subtitleStr = dcContact.getAddr();
         }
         isOnline = dcContact.wasSeenRecently();


### PR DESCRIPTION
_this was discussed in-person with various ppl  on the last physical gathering :)_

the email-address was removed for guaranteed-e2ee chats quite a while ago (https://github.com/deltachat/deltachat-android/pull/2916) reason was, among others, that these addresses are often chatmail and therefore random. (despite expecting otherwise, that was fine for most users).

this PR removes the email-adress unconditionally:

- having the email-address sometimes shown and sometimes not is confusing, and easily looks like a bug. this has become worse with the added vcard-support (before, there were rare non-guaranteed chats in chatmail) - resulting in more random addresses being shown

- _always_ protect against over-the-shoulder attacks

- better privacy in screenshots sent around without thinking much before (cmp. https://github.com/deltachat/deltachat-ios/pull/2329)

- wrt impersonation attacks: the pure email address in the subtitle did never protect against impersonation, one could always get sth. trustworthy looking there, it is better to check the profile with additional information (eg. other chats) if in doubt

- general cleaner, uncluttered layout

- pave the way of the upcoming multi-addresses

- @adbenitez' ArcanceChat can show "Last Seen" unconditionally now (still, i am not a fan of that precise timing information in the title, but it will improve by this PR :)

drawback is that sometimes one more tap is needed to access the email-address - however, as it is _always_ one tap away now, this can also go easily to the finger memory.

counterpart of https://github.com/deltachat/deltachat-ios/pull/2447