### PR TITLE
add info string that is shown by iOS system when asking for accessing…

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1170,6 +1170,7 @@
     <string name="InfoPlist_NSMicrophoneUsageDescription">Delta Chat uses your microphone to record and send voice messages and videos with sound.</string>
     <string name="InfoPlist_NSPhotoLibraryUsageDescription">Delta Chat will let you choose which photos from your library to send.</string>
     <string name="InfoPlist_NSPhotoLibraryAddUsageDescription">Delta Chat wants to save images to your photo library.</string>
+    <string name="InfoPlist_NSFaceIDUsageDescription">Delta Chat can use Face ID to protect your local profile, backup creation and second device setup.</string>
 
 
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->


### PR DESCRIPTION
the string is shown by the system in case "Delta Chat iOS" ask the user to grant access to Face ID. it is totally fine if the user does not give that grant

closes https://github.com/deltachat/deltachat-ios/issues/2380 