### PR TITLE
fix: Remove long stacktrace that flooded the logcat

### DIFF
--- a/src/main/res/layout/webxdc_view.xml
+++ b/src/main/res/layout/webxdc_view.xml
@@ -20,6 +20,7 @@
                 android:layout_width="128dp"
                 android:layout_height="128dp"
                 android:scaleType="centerCrop"
+                app:strokeColor="@null"
                 app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
 
             <TextView android:id="@+id/webxdc_app_name"


### PR DESCRIPTION
Everytime I attached an image, I got a super long stacktrace in the logcat. I found it to be [this problem](https://stackoverflow.com/questions/71746801/getting-failed-to-inflate-colorstatelist-leaving-it-to-the-framework-when-usi) and applied the fix described there.