### PR TITLE
avoid NullPointerException when using result of Rpc.getMsgReactions

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/reactions/AddReactionView.java
+++ b/src/main/java/org/thoughtcrime/securesms/reactions/AddReactionView.java
@@ -16,6 +16,7 @@ import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcMsg;
 import com.b44t.messenger.rpc.Reactions;
 import com.b44t.messenger.rpc.Rpc;
+import com.b44t.messenger.rpc.RpcException;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcHelper;
@@ -124,12 +125,14 @@ public class AddReactionView extends LinearLayout {
         String result = null;
         try {
             final Reactions reactions = rpc.getMsgReactions(dcContext.getAccountId(), msgToReactTo.getId());
-            final Map<Integer, String[]> reactionsByContact = reactions.getReactionsByContact();
-            final String [] selfReactions = reactionsByContact.get(DcContact.DC_CONTACT_ID_SELF);
-            if (selfReactions != null && selfReactions.length > 0) {
-                result = selfReactions[0];
+            if (reactions != null) {
+                final Map<Integer, String[]> reactionsByContact = reactions.getReactionsByContact();
+                final String [] selfReactions = reactionsByContact.get(DcContact.DC_CONTACT_ID_SELF);
+                if (selfReactions != null && selfReactions.length > 0) {
+                    result = selfReactions[0];
+                }
             }
-        } catch(Exception e) {
+        } catch(RpcException e) {
            e.printStackTrace();
         }
         return result;

--- a/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsDetailsFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsDetailsFragment.java
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEvent;
+import com.b44t.messenger.rpc.Reactions;
 import com.b44t.messenger.rpc.RpcException;
 
 import org.thoughtcrime.securesms.ProfileActivity;
@@ -85,17 +86,20 @@ public class ReactionsDetailsFragment extends DialogFragment implements DcEventC
 
     int accId = DcHelper.getContext(requireActivity()).getAccountId();
     try {
-      Map<Integer, String[]> reactionsByContact = DcHelper.getRpc(requireActivity()).getMsgReactions(accId, msgId).getReactionsByContact();
+      final Reactions reactions = DcHelper.getRpc(requireActivity()).getMsgReactions(accId, msgId);
       ArrayList<Pair<Integer, String>> contactsReactions = new ArrayList<>();
-      String[] selfReactions = reactionsByContact.remove(DcContact.DC_CONTACT_ID_SELF);
-      for (Integer contact: reactionsByContact.keySet()) {
-        for (String reaction: reactionsByContact.get(contact)) {
-          contactsReactions.add(new Pair<>(contact, reaction));
+      if (reactions != null) {
+        Map<Integer, String[]> reactionsByContact = reactions.getReactionsByContact();
+        String[] selfReactions = reactionsByContact.remove(DcContact.DC_CONTACT_ID_SELF);
+        for (Integer contact: reactionsByContact.keySet()) {
+          for (String reaction: reactionsByContact.get(contact)) {
+            contactsReactions.add(new Pair<>(contact, reaction));
+          }
         }
-      }
-      if (selfReactions != null) {
-        for (String reaction: selfReactions) {
-          contactsReactions.add(new Pair<>(DcContact.DC_CONTACT_ID_SELF, reaction));
+        if (selfReactions != null) {
+          for (String reaction: selfReactions) {
+            contactsReactions.add(new Pair<>(DcContact.DC_CONTACT_ID_SELF, reaction));
+          }
         }
       }
       adapter.changeData(contactsReactions);


### PR DESCRIPTION
when there is no reactions yet for a message `Rpc.getMsgReactions` returns `null`, checking for this explicitly instead of putting noise in the logs with stack traces