### PR TITLE
streamline help menu

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
@@ -68,7 +68,7 @@ public class LocalHelpActivity extends WebViewActivity
         openOnlineUrl("https://delta.chat/gdpr");
         return true;
       case R.id.contribute:
-        openOnlineUrl("https://github.com/deltachat/deltachat-android");
+        openOnlineUrl("https://delta.chat/contribute");
         return true;
       case R.id.report_issue:
         openOnlineUrl("https://github.com/deltachat/deltachat-android/issues");

--- a/src/main/res/menu/local_help.xml
+++ b/src/main/res/menu/local_help.xml
@@ -5,7 +5,7 @@
     <item android:title="@string/menu_scroll_to_top"
         android:id="@+id/log_scroll_up" />
 
-    <item android:title="@string/global_menu_help_learn_desktop"
+    <item android:title="@string/delta_chat_homepage"
         android:id="@+id/learn_more"
         app:showAsAction="never"/>
 
@@ -13,7 +13,7 @@
         android:id="@+id/privacy_policy"
         app:showAsAction="never"/>
 
-    <item android:title="@string/global_menu_help_contribute_desktop"
+    <item android:title="@string/contribute"
         android:id="@+id/contribute"
         app:showAsAction="never"/>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1085,8 +1085,12 @@
     <string name="global_menu_view_developer_desktop">Developer</string>
     <string name="global_menu_view_developer_tools_desktop">Developer Tools</string>
     <string name="global_menu_help_desktop">Help</string>
+    <!-- deprecated, use delta_chat_homepage instead -->
     <string name="global_menu_help_learn_desktop">Learn more about Delta Chat</string>
+    <string name="delta_chat_homepage">Delta Chat Homepage</string>
+    <!-- deprecated, use contribute instead -->
     <string name="global_menu_help_contribute_desktop">Contribute on GitHub</string>
+    <string name="contribute">Contribute</string>
     <string name="global_menu_help_report_desktop">Report an Issue</string>
     <string name="global_menu_help_about_desktop">About Delta Chat</string>
     <string name="global_menu_file_open_desktop">Open Delta Chat</string>


### PR DESCRIPTION
this PR tweaks the menu atop of the offline help a bit:

- use clear "Delta Chat Homepage" for opening our homepage (instead of unclear "Learn more about Delta Chat", which is esp. weird, when used from inside the help)

- do not "promote" GitHub in our menu entry, instead of "Contribute on GitHub", just say "Contribute". destination URL is our contribute page then - that is also more useful for ppl doing eg. translations

came over that when using more modern help menu on ios as a finger exercise at https://github.com/deltachat/deltachat-ios/pull/2545/files :)

this is how it looks like with this PR:

<img width="383" alt="Screenshot 2025-01-22 at 20 43 53" src="https://github.com/user-attachments/assets/2b878be5-46fc-49d6-8a12-ef1cbdb14f6e" />


