### PR TITLE
refine QR reset wording

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
@@ -113,9 +113,12 @@ public class QrActivity extends BaseActionBarActivity implements View.OnClickLis
       menu.clear();
       getMenuInflater().inflate(R.menu.qr_show, menu);
       menu.findItem(R.id.new_classic_contact).setVisible(!DcHelper.getContext(this).isChatmail());
+
+      Util.redMenuItem(menu, R.id.withdraw);
       if(tabLayout.getSelectedTabPosition() == TAB_SCAN) {
         menu.findItem(R.id.withdraw).setVisible(false);
       }
+
       return super.onPrepareOptionsMenu(menu);
     }
 

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -115,35 +115,25 @@ public class QrCodeHandler {
                 break;
 
             case DcContext.DC_QR_WITHDRAW_VERIFYCONTACT:
-                builder.setMessage(activity.getString(R.string.withdraw_verifycontact_explain));
-                builder.setPositiveButton(R.string.withdraw_qr_code, (dialog, which) -> {
+            case DcContext.DC_QR_WITHDRAW_VERIFYGROUP:
+                String message = qrParsed.getState() == DcContext.DC_QR_WITHDRAW_VERIFYCONTACT ? activity.getString(R.string.withdraw_verifycontact_explain)
+                                  : activity.getString(R.string.withdraw_verifygroup_explain, qrParsed.getText1());
+                builder.setTitle(R.string.qrshow_title);
+                builder.setMessage(message);
+                builder.setNeutralButton(R.string.reset, (dialog, which) -> {
                     dcContext.setConfigFromQr(rawString);
                 });
-                builder.setNegativeButton(R.string.cancel, null);
+                builder.setPositiveButton(R.string.ok, null);
                 break;
 
             case DcContext.DC_QR_REVIVE_VERIFYCONTACT:
-                builder.setMessage(activity.getString(R.string.revive_verifycontact_explain));
-                builder.setPositiveButton(R.string.revive_qr_code, (dialog, which) -> {
-                    dcContext.setConfigFromQr(rawString);
-                });
-                builder.setNegativeButton(R.string.cancel, null);
-                break;
-
-            case DcContext.DC_QR_WITHDRAW_VERIFYGROUP:
-                builder.setMessage(activity.getString(R.string.withdraw_verifygroup_explain, qrParsed.getText1()));
-                builder.setPositiveButton(R.string.withdraw_qr_code, (dialog, which) -> {
-                    dcContext.setConfigFromQr(rawString);
-                });
-                builder.setNegativeButton(R.string.cancel, null);
-                break;
-
             case DcContext.DC_QR_REVIVE_VERIFYGROUP:
-                builder.setMessage(activity.getString(R.string.revive_verifygroup_explain, qrParsed.getText1()));
-                builder.setPositiveButton(R.string.revive_qr_code, (dialog, which) -> {
+                builder.setTitle(R.string.qrshow_title);
+                builder.setMessage(activity.getString(R.string.revive_verifycontact_explain));
+                builder.setNeutralButton(R.string.revive_qr_code, (dialog, which) -> {
                     dcContext.setConfigFromQr(rawString);
                 });
-                builder.setNegativeButton(R.string.cancel, null);
+                builder.setPositiveButton(R.string.ok, null);
                 break;
 
             default:

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -124,7 +124,9 @@ public class QrCodeHandler {
                     dcContext.setConfigFromQr(rawString);
                 });
                 builder.setPositiveButton(R.string.ok, null);
-                break;
+                AlertDialog withdrawDialog = builder.show();
+                Util.redButton(withdrawDialog, AlertDialog.BUTTON_NEUTRAL);
+                return;
 
             case DcContext.DC_QR_REVIVE_VERIFYCONTACT:
             case DcContext.DC_QR_REVIVE_VERIFYGROUP:

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrShowActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrShowActivity.java
@@ -13,6 +13,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.Util;
 
 public class QrShowActivity extends AppCompatActivity {
 
@@ -68,6 +69,7 @@ public class QrShowActivity extends AppCompatActivity {
       menu.findItem(R.id.new_classic_contact).setVisible(false);
       menu.findItem(R.id.paste).setVisible(false);
       menu.findItem(R.id.load_from_image).setVisible(false);
+      Util.redMenuItem(menu, R.id.withdraw);
       return super.onCreateOptionsMenu(menu);
     }
 

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrShowFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrShowFragment.java
@@ -138,15 +138,19 @@ public class QrShowFragment extends Fragment implements DcEventCenter.DcEventDel
 
     public void withdrawQr() {
         Activity activity = getActivity();
+        String message = chatId == 0 ? activity.getString(R.string.withdraw_verifycontact_explain)
+                          : activity.getString(R.string.withdraw_verifygroup_explain, dcContext.getChat(chatId).getName());
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        builder.setMessage(activity.getString(R.string.withdraw_verifycontact_explain));
-        builder.setPositiveButton(R.string.withdraw_qr_code, (dialog, which) -> {
+        builder.setTitle(R.string.withdraw_qr_code);
+        builder.setMessage(message);
+        builder.setPositiveButton(R.string.reset, (dialog, which) -> {
                 DcContext dcContext = DcHelper.getContext(activity);
                 dcContext.setConfigFromQr(dcContext.getSecurejoinQr(chatId));
                 activity.finish();
         });
         builder.setNegativeButton(R.string.cancel, null);
-        builder.create().show();
+        AlertDialog dialog = builder.show();
+        Util.redPositiveButton(dialog);
     }
 
     public void showInviteLinkDialog() {

--- a/src/main/java/org/thoughtcrime/securesms/util/Util.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Util.java
@@ -104,8 +104,12 @@ public class Util {
   }
 
   public static void redPositiveButton(AlertDialog dialog) {
+    redButton(dialog, AlertDialog.BUTTON_POSITIVE);
+  }
+
+  public static void redButton(AlertDialog dialog, int whichButton) {
     try {
-      dialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(redDestructiveColor);
+      dialog.getButton(whichButton).setTextColor(redDestructiveColor);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -985,12 +985,11 @@
     <string name="qrscan_contains_text">Scanned QR code text:\n\n%1$s</string>
     <string name="qrscan_contains_url">Scanned QR code URL:\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">Fingerprint</string>
-    <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to contact you.\n\nYou can deactivate the QR code here and reactivate it by scanning it again.</string>
-    <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nYou can deactivate the QR code here and reactivate it by scanning it again.</string>
-    <string name="withdraw_qr_code">Deactivate QR Code</string>
-    <!-- "could" in the meaning of "possible at some point in the past, but no longer possible today" -->
-    <string name="revive_verifycontact_explain">This QR code could be scanned by others to contact you.\n\nThe QR code is not active on this device.</string>
-    <!-- "could" in the meaning of "possible at some point in the past, but no longer possible today" -->
+    <string name="withdraw_verifycontact_explain">This QR code can be scanned by others to contact you.\n\nYou can reset it, so that the existing QR code or invite link will no longer work.</string>
+    <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nYou can reset it, so that the existing QR code or invite link will no longer work.</string>
+    <string name="withdraw_qr_code">Reset QR Code</string>
+    <string name="revive_verifycontact_explain">This QR code has been reset and is no longer active.</string>
+    <!-- deprecated, use revive_verifycontact_explain -->
     <string name="revive_verifygroup_explain">This QR code could be scanned by others to join the group \"%1$s\".\n\nThe QR code is not active on this device.</string>
     <string name="revive_qr_code">Activate QR Code</string>
     <string name="qrshow_title">QR Invite Code</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -989,8 +989,7 @@
     <string name="withdraw_verifygroup_explain">This QR code can be scanned by others to join the group \"%1$s\".\n\nYou can reset it, so that the existing QR code or invite link will no longer work.</string>
     <string name="withdraw_qr_code">Reset QR Code</string>
     <string name="revive_verifycontact_explain">This QR code has been reset and is no longer active.</string>
-    <!-- deprecated, use revive_verifycontact_explain -->
-    <string name="revive_verifygroup_explain">This QR code could be scanned by others to join the group \"%1$s\".\n\nThe QR code is not active on this device.</string>
+    <string name="revive_verifygroup_explain">This QR code to join group \"%1$s\" has been reset and is no longer active.</string>
     <string name="revive_qr_code">Activate QR Code</string>
     <string name="qrshow_title">QR Invite Code</string>
     <string name="qrshow_x_joining">%1$s joins.</string>


### PR DESCRIPTION
this PR streamlines resetting QR codes, mitigating lots of confusion we encountered on testing.

- use "reset", as known from other messengers - and which is also more accurate as a new QR code will be created immediately as needed

- simpler "activate" wording, tbh, i am not sure if that is even a thing that will ppl do

- incorporate "invite link" wording, at least partly 

to make adaption easier, it does not split strings for so (eg. use different strings for scanning and button), so other OS will benefit without doing additional things.

moreover, the PR adapts the layout, uses colors and uses "reset" only as primary button when selected via menu entry. this is how it looks like.

the weird primary button was also often cause of confusion.

<img width=320 src=https://github.com/user-attachments/assets/0ac3ee2e-9b1e-498e-97b2-bfb56d4bd637>
<img width=320 src=https://github.com/user-attachments/assets/7c2b142b-d0db-4951-b6ea-c14c49b55372>
<img width=320 src=https://github.com/user-attachments/assets/53c80e69-facc-4148-8507-81dbb92cf266>
<img width=320 src=https://github.com/user-attachments/assets/f11e47f6-628e-4d20-b19b-1665e9151f57>



