### PR TITLE
be more clear about the impact of blocked contacts

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -377,7 +377,7 @@
     <string name="ask_forward_multiple">Forward messages to %1$d chats?</string>
     <string name="ask_export_attachment">Exporting attachments will allow other apps on your device to access them.\n\nContinue?</string>
     <string name="ask_block_contact">Block this contact?\n\nDirect messages or new groups from blocked contacts will not show up.\n\nExisting groups with blocked contacts will still show their messages.</string>
-    <string name="ask_unblock_contact">Unblock this contact? You will then be able to receive messages from them.</string>
+    <string name="ask_unblock_contact">Unblock this contact?</string>
     <string name="ask_delete_contacts">Delete contacts?\n\nContacts with ongoing chats or from the system address book cannot be deleted permanently.</string>
     <string name="ask_delete_contact">Delete contact %1$s?\n\nContacts with ongoing chats or from the system address book cannot be deleted permanently.</string>
     <string name="cannot_delete_contacts_in_use">Cannot delete contacts with ongoing chats.</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -376,7 +376,7 @@
     <string name="ask_forward">Forward messages to %1$s?</string>
     <string name="ask_forward_multiple">Forward messages to %1$d chats?</string>
     <string name="ask_export_attachment">Exporting attachments will allow other apps on your device to access them.\n\nContinue?</string>
-    <string name="ask_block_contact">Block this contact?\n\nDirect messages or new groups from blocked contacts will not show up.\n\nExisting groups with blocked contacts will still show their messages.</string>
+    <string name="ask_block_contact">Block this contact?\n\nDirect messages or groups created by blocked contacts will not show up.\n\nOther groups with blocked contacts will still show their messages.</string>
     <string name="ask_unblock_contact">Unblock this contact?</string>
     <string name="ask_delete_contacts">Delete contacts?\n\nContacts with ongoing chats or from the system address book cannot be deleted permanently.</string>
     <string name="ask_delete_contact">Delete contact %1$s?\n\nContacts with ongoing chats or from the system address book cannot be deleted permanently.</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -376,7 +376,7 @@
     <string name="ask_forward">Forward messages to %1$s?</string>
     <string name="ask_forward_multiple">Forward messages to %1$d chats?</string>
     <string name="ask_export_attachment">Exporting attachments will allow other apps on your device to access them.\n\nContinue?</string>
-    <string name="ask_block_contact">Block this contact? You will no longer receive messages from them.</string>
+    <string name="ask_block_contact">Block this contact?\n\nDirect messages or new groups from blocked contacts will not show up.\n\nExisting groups with blocked contacts will still show their messages.</string>
     <string name="ask_unblock_contact">Unblock this contact? You will then be able to receive messages from them.</string>
     <string name="ask_delete_contacts">Delete contacts?\n\nContacts with ongoing chats or from the system address book cannot be deleted permanently.</string>
     <string name="ask_delete_contact">Delete contact %1$s?\n\nContacts with ongoing chats or from the system address book cannot be deleted permanently.</string>


### PR DESCRIPTION
this PR is about  to improve the wording of the dialog shown when a contact is blocked, aligning that more with the status quo

<img width="380" alt="Screenshot 2025-02-01 at 15 07 35" src="https://github.com/user-attachments/assets/0e4f9606-8cd2-4fe9-95d6-5f36acd6731b" />

ftr, as @adbenitez just reconfirmed, telegram also shows messages of blocked contacts in groups, i think, idea is to make discussions possible - otherwise there are lots of "i did not read the message" from various ppl. if the issue with a user is that serious, one should leave shared groups