### PR TITLE
tweak wording in empty "all apps" and "all files" views

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -121,7 +121,7 @@ public class ProfileDocumentsFragment
 
     noMedia.setVisibility(recyclerView.getAdapter().getItemCount() > 0 ? View.GONE : View.VISIBLE);
     if (chatId == DC_CHAT_NO_CHAT) {
-      noMedia.setText(R.string.tab_all_media_empty_hint);
+      noMedia.setText(showWebxdc ? R.string.all_apps_empty_hint : R.string.tab_all_media_empty_hint);
     } else if (showAudio) {
       noMedia.setText(R.string.tab_audio_empty_hint);
     } else if (showWebxdc) {

--- a/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -121,7 +121,13 @@ public class ProfileDocumentsFragment
 
     noMedia.setVisibility(recyclerView.getAdapter().getItemCount() > 0 ? View.GONE : View.VISIBLE);
     if (chatId == DC_CHAT_NO_CHAT) {
-      noMedia.setText(showWebxdc ? R.string.all_apps_empty_hint : R.string.tab_all_media_empty_hint);
+      if (showWebxdc) {
+        noMedia.setText(R.string.all_apps_empty_hint);
+      } else if (!showAudio){
+        noMedia.setText(R.string.all_files_empty_hint);
+      } else {
+        noMedia.setText(R.string.tab_all_media_empty_hint);
+      }
     } else if (showAudio) {
       noMedia.setText(R.string.tab_audio_empty_hint);
     } else if (showWebxdc) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -514,6 +514,7 @@
     <string name="tab_audio_empty_hint">Audio files and voice messages shared in this chat will appear here.</string>
     <string name="tab_webxdc_empty_hint">Apps shared in this chat will appear here.</string>
     <string name="tab_all_media_empty_hint">Media shared in any chat will appear here.</string>
+    <string name="all_files_empty_hint">Documents and other files shared in any chat will appear here.</string>
     <string name="all_apps_empty_hint">Apps received or sent in any chat will appear here.</string>
     <string name="media_preview">Media Preview</string>
     <!-- option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :) -->


### PR DESCRIPTION
before, if there were no "apps" or "files", the hint was a bit off, saying "Media shared in any chat will appear here.". now it looks like the following:

<img width="378" alt="Screenshot 2025-02-02 at 18 36 05" src="https://github.com/user-attachments/assets/aca5163a-ea55-4d35-9fef-5beb1efbada4" />
<img width="378" alt="Screenshot 2025-02-02 at 18 51 58" src="https://github.com/user-attachments/assets/9419e0d3-43fd-4cdf-94ef-c04d0f5a87bc" />

for the other tabs, "media" is fitting enough for now :)