### PR TITLE
add second device: warn about 3rd parties

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -532,7 +532,7 @@
     <!-- "Second Device" can also be translated as "Another Device", if that is catchier in the destination language. However, make sure to use the term consistently. -->
     <string name="multidevice_title">Add Second Device</string>
     <string name="multidevice_same_network_hint">Make sure both devices are on the same Wi-Fi or network</string>
-    <string name="multidevice_this_creates_a_qr_code">This creates a QR code that the second device can scan to copy the profile.</string>
+    <string name="multidevice_this_creates_a_qr_code">This creates a QR code that the second device can scan to copy the profile.\n\nMake sure no unwanted observer or camera can see the following screen.</string>
     <string name="multidevice_install_dc_on_other_device">Install Delta Chat on your other device (https://get.delta.chat)</string>
     <!-- "I Already Have a Profile / Add as Second Device” should be the same text as defined by the keys onboarding_alternative_logins and multidevice_receiver_title -->
     <string name="multidevice_tap_scan_on_other_device">Start Delta Chat, tap “I Already Have a Profile / Add as Second Device” and scan the code shown here</string>


### PR DESCRIPTION
this PR adds a hint about making sure no 3rd party can see the "Add Second Device" QR code. the PR is the outcome of some community discussions.

<img width=350 src=https://github.com/user-attachments/assets/4e66a905-8b4b-4ace-87be-638e328a3ec4>

the dialog and the hint are already used on all OS, so that is a low hanging fruit -
(compared to other ideas of changing flow direction etc, which we might go for at some point;
however, that would be lots of effort on all UI,
is tricky UX wise, will come with new bugs and other cornercases, and are also not bullet save against careless users, "hey, scan my QR code ... no, from 'Add Second Device, Next, Next ...'" :)

for easy adaption and not to do lots of subsequent things on all platforms, the PR is only about the wording, colors etc. are out of scope.