### PR TITLE
fix: Opening files in external apps always works now

### DIFF
--- a/src/androidTest/java/com/b44t/messenger/uitests/offline/SharingTest.java
+++ b/src/androidTest/java/com/b44t/messenger/uitests/offline/SharingTest.java
@@ -93,7 +93,7 @@ public class SharingTest {
       }
     }
     Uri uri = Uri.parse("content://" + BuildConfig.APPLICATION_ID + ".attachments/" + Uri.encode(pngImage));
-    DcHelper.sharedFiles.put(pngImage, 1);
+    DcHelper.sharedFiles.put(pngImage, "image/png");
 
     Intent i = new Intent(Intent.ACTION_SEND);
     i.setType("image/png");

--- a/src/main/java/org/thoughtcrime/securesms/connect/AttachmentsContentProvider.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/AttachmentsContentProvider.java
@@ -5,8 +5,14 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
+import android.webkit.MimeTypeMap;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.b44t.messenger.DcContext;
+
+import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -34,12 +40,12 @@ public class AttachmentsContentProvider extends ContentProvider {
         // where ef39a39 is the file in the blob directory
         // and text.txt is the original name of the file, as returned by `msg.getFilename()`.
         // `uri.getPathSegments()` returns ["ef39a39", "text.txt"] in this example.
-        String path = uri.getPathSegments().get(0);
-        if (!DcHelper.sharedFiles.containsKey(path)) {
+        String file = uri.getPathSegments().get(0);
+        if (!DcHelper.sharedFiles.containsKey(file)) {
             throw new FileNotFoundException("File was not shared before.");
         }
 
-        File privateFile = new File(dcContext.getBlobdir(), path);
+        File privateFile = new File(dcContext.getBlobdir(), file);
         return ParcelFileDescriptor.open(privateFile, ParcelFileDescriptor.MODE_READ_ONLY);
     }
 
@@ -49,8 +55,17 @@ public class AttachmentsContentProvider extends ContentProvider {
     }
 
     @Override
-    public String getType(Uri arg0) {
-        return null;
+    public String getType(Uri uri) {
+        String file = uri.getPathSegments().get(0);
+        String mimeType = DcHelper.sharedFiles.get(file);
+
+        return DcHelper.checkMime(uri.toString(), mimeType);
+    }
+
+    @Override
+    public String getTypeAnonymous(Uri uri) {
+        String ext = MediaUtil.getFileExtensionFromUrl(uri.toString());
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
     }
 
     @Override

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -299,7 +299,11 @@ public class DcHelper {
         // The last part needs to be `filename`, i.e. the original, user-visible name of the file,
         // so that the external apps show the name of the file correctly.
         uri = Uri.parse("content://" + BuildConfig.APPLICATION_ID + ".attachments/" + Uri.encode(file.getName()) + "/" + Uri.encode(filename));
-        sharedFiles.put(file.getName(), mimeType); // as different Android version handle uris in putExtra differently, we also check them on our own
+
+        // As different Android version handle uris in putExtra differently,
+        // we also check on our own that the file was actually shared.
+        // The check happens in AttachmentsContentProvider.openFile().
+        sharedFiles.put(file.getName(), mimeType);
       } else {
         if (Build.VERSION.SDK_INT >= 24) {
           uri = FileProvider.getUriForFile(activity, BuildConfig.APPLICATION_ID + ".fileprovider", file);


### PR DESCRIPTION
The problem was that we returned `null` from `getType()`.

fix #3517
