### PR TITLE
fix: hide 'clone chat' if there is no chat

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -153,6 +153,7 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
           menu.findItem(R.id.share).setVisible(false);
         }
       } else {
+        menu.findItem(R.id.menu_clone).setVisible(false);
         canReceive = false;
       }
 


### PR DESCRIPTION
before, 'clone chat' was hidden for contacts having a one-to-one-chats, but not for contacts _without_ a one-to-one-chat

opening a contact's profile for contacts without a chat, is not so unusual when eg. tapping the avatar of unknown members in a group

good news is that there was no crash or so, only an empty group was created :)