### PR TITLE
hide some option in Encryption category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * add mute option "8 hours"
 * add menu option to easily save/unsave selected message
 * improve deletion confirmation for "Device Messages"
+* remove dangerous encryption options
 
 ## v1.54.4
 2025-03

--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -150,7 +150,6 @@ public class DcMsg {
     public native String  getWebxdcHref      ();
     public native boolean isForwarded        ();
     public native boolean isInfo             ();
-    public native boolean isSetupMessage     ();
     public native boolean hasHtml            ();
     public native String  getSetupCodeBegin  ();
     public native String  getVideochatUrl    ();

--- a/src/main/java/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -294,7 +294,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     else if (type==DcMsg.DC_MSG_AUDIO || type==DcMsg.DC_MSG_VOICE) {
       return dcMsg.isOutgoing()? MESSAGE_TYPE_AUDIO_OUTGOING : MESSAGE_TYPE_AUDIO_INCOMING;
     }
-    else if (type==DcMsg.DC_MSG_FILE && !dcMsg.isSetupMessage()) {
+    else if (type==DcMsg.DC_MSG_FILE) {
       return dcMsg.isOutgoing()? MESSAGE_TYPE_DOCUMENT_OUTGOING : MESSAGE_TYPE_DOCUMENT_INCOMING;
     }
     else if (type==DcMsg.DC_MSG_IMAGE || type==DcMsg.DC_MSG_GIF || type==DcMsg.DC_MSG_VIDEO) {

--- a/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
@@ -390,7 +390,7 @@ public class ConversationItem extends BaseConversationItem
   }
 
   private boolean hasDocument(DcMsg dcMsg) {
-    return dcMsg.getType()==DcMsg.DC_MSG_FILE && !dcMsg.isSetupMessage();
+    return dcMsg.getType()==DcMsg.DC_MSG_FILE;
   }
 
   private void setBodyText(DcMsg messageRecord) {
@@ -399,11 +399,7 @@ public class ConversationItem extends BaseConversationItem
 
     String text = messageRecord.getText();
 
-    if (messageRecord.isSetupMessage()) {
-      bodyText.setText(context.getString(R.string.autocrypt_asm_click_body));
-      bodyText.setVisibility(View.VISIBLE);
-    }
-    else if (text.isEmpty()) {
+    if (text.isEmpty()) {
       bodyText.setVisibility(View.GONE);
     }
     else {

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -61,7 +61,6 @@ public class DcHelper {
     public static final String CONFIG_DISPLAY_NAME = "displayname";
     public static final String CONFIG_SELF_STATUS = "selfstatus";
     public static final String CONFIG_SELF_AVATAR = "selfavatar";
-    public static final String CONFIG_E2EE_ENABLED = "e2ee_enabled";
     public static final String CONFIG_SENTBOX_WATCH = "sentbox_watch";
     public static final String CONFIG_MVBOX_MOVE = "mvbox_move";
     public static final String CONFIG_ONLY_FETCH_MVBOX = "only_fetch_mvbox";

--- a/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -269,7 +269,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     }
 
     if (dcContext.isChatmail()) {
-      preferE2eeCheckbox.setVisible(false);
+      this.findPreference("pref_category_encryption").setVisible(false);
       showSystemContacts.setVisible(false);
       sentboxWatchCheckbox.setVisible(false);
       bccSelfCheckbox.setVisible(false);

--- a/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -3,7 +3,6 @@ package org.thoughtcrime.securesms.preferences;
 import static android.app.Activity.RESULT_OK;
 import static android.text.InputType.TYPE_TEXT_VARIATION_URI;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_BCC_SELF;
-import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_E2EE_ENABLED;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_MVBOX_MOVE;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_ONLY_FETCH_MVBOX;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SENTBOX_WATCH;
@@ -11,13 +10,11 @@ import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_SHOW_EMAILS;
 import static org.thoughtcrime.securesms.connect.DcHelper.CONFIG_WEBXDC_REALTIME_ENABLED;
 import static org.thoughtcrime.securesms.connect.DcHelper.getRpc;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -32,7 +29,6 @@ import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 
-import com.b44t.messenger.DcContext;
 import com.b44t.messenger.rpc.RpcException;
 
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
@@ -42,12 +38,9 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.RegistrationActivity;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.mms.AttachmentManager;
-import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.proxy.ProxySettingsActivity;
 import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
-import org.thoughtcrime.securesms.util.StorageUtil;
 import org.thoughtcrime.securesms.util.StreamUtil;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -63,10 +56,8 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
                                         implements DcEventCenter.DcEventDelegate
 {
   private static final String TAG = AdvancedPreferenceFragment.class.getSimpleName();
-  public static final int PICK_SELF_KEYS = 29923;
 
   private ListPreference showEmails;
-  CheckBoxPreference preferE2eeCheckbox;
   CheckBoxPreference sentboxWatchCheckbox;
   CheckBoxPreference bccSelfCheckbox;
   CheckBoxPreference mvboxMoveCheckbox;
@@ -90,11 +81,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     Preference sendAsm = this.findPreference("pref_send_autocrypt_setup_message");
     if (sendAsm != null) {
       sendAsm.setOnPreferenceClickListener(new SendAsmListener());
-    }
-
-    preferE2eeCheckbox = (CheckBoxPreference) this.findPreference("pref_prefer_e2ee");
-    if (preferE2eeCheckbox != null) {
-      preferE2eeCheckbox.setOnPreferenceChangeListener(new PreferE2eeListener());
     }
 
     sentboxWatchCheckbox = (CheckBoxPreference) this.findPreference("pref_sentbox_watch");
@@ -161,11 +147,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
         dcContext.setConfigInt("ui.android.show_system_contacts", enabled? 1 : 0);
         return true;
       });
-    }
-
-    Preference manageKeys = this.findPreference("pref_manage_keys");
-    if (manageKeys != null) {
-      manageKeys.setOnPreferenceClickListener(new ManageKeysListener());
     }
 
     Preference screenSecurity = this.findPreference(Prefs.SCREEN_SECURITY_PREF);
@@ -269,7 +250,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     }
 
     if (dcContext.isChatmail()) {
-      this.findPreference("pref_category_encryption").setVisible(false);
       showSystemContacts.setVisible(false);
       sentboxWatchCheckbox.setVisible(false);
       bccSelfCheckbox.setVisible(false);
@@ -292,7 +272,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     showEmails.setValue(value);
     updateListSummary(showEmails, value);
 
-    preferE2eeCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_E2EE_ENABLED));
     sentboxWatchCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_SENTBOX_WATCH));
     bccSelfCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_BCC_SELF));
     mvboxMoveCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_MVBOX_MOVE));
@@ -304,24 +283,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
-    if (resultCode != RESULT_OK) return;
-    if (requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS) {
-        manageKeys();
-    } else if (requestCode == PICK_SELF_KEYS) {
-        Uri uri = (data != null ? data.getData() : null);
-        if (uri == null) {
-            Log.e(TAG, " Can't import null URI");
-            return;
-        }
-      try {
-        String name = AttachmentManager.getFileName(getContext(), uri);
-        if (name == null || name.isEmpty()) name = "FILE";
-        File file = copyToCacheDir(uri);
-        showImportKeysDialog(file.getAbsolutePath(), name);
-      } catch (IOException e) {
-        Log.e(TAG, "Error calling copyToCacheDir()", e);
-      }
-    } else if (requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_ACCOUNT) {
+    if (resultCode == RESULT_OK && requestCode == REQUEST_CODE_CONFIRM_CREDENTIALS_ACCOUNT) {
       openRegistrationActivity();
     }
   }
@@ -469,77 +431,5 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
         .show();
       return true;
     }
-  }
-
-  private class PreferE2eeListener implements Preference.OnPreferenceChangeListener {
-    @Override
-    public boolean onPreferenceChange(@NonNull final Preference preference, Object newValue) {
-      boolean enabled = (Boolean) newValue;
-      dcContext.setConfigInt(CONFIG_E2EE_ENABLED, enabled? 1 : 0);
-      return true;
-    }
-  }
-
-  /***********************************************************************************************
-   * Key Import/Export
-   **********************************************************************************************/
-  protected void showImportKeysDialog(String imexPath, String pathAsDisplayedToUser) {
-    new AlertDialog.Builder(requireActivity())
-      .setTitle(R.string.pref_managekeys_import_secret_keys)
-      .setMessage(requireActivity().getString(R.string.pref_managekeys_import_explain, pathAsDisplayedToUser))
-      .setNegativeButton(android.R.string.cancel, null)
-      .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImexOne(DcContext.DC_IMEX_IMPORT_SELF_KEYS, imexPath, pathAsDisplayedToUser))
-      .show();
-  }
-
-  private class ManageKeysListener implements Preference.OnPreferenceClickListener {
-    @Override
-    public boolean onPreferenceClick(@NonNull Preference preference) {
-      boolean result = ScreenLockUtil.applyScreenLock(requireActivity(), getString(R.string.pref_manage_keys), getString(R.string.enter_system_secret_to_continue), REQUEST_CODE_CONFIRM_CREDENTIALS_KEYS);
-      if (!result) {
-        manageKeys();
-      }
-      return true;
-    }
-  }
-
-  private void manageKeys() {
-    Activity activity = requireActivity();
-    Permissions.with(activity)
-        .request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
-        .alwaysGrantOnSdk30()
-        .ifNecessary()
-        .withPermanentDenialDialog(getString(R.string.perm_explain_access_to_storage_denied))
-        .onAllGranted(() -> {
-          new AlertDialog.Builder(activity)
-              .setTitle(R.string.pref_managekeys_menu_title)
-              .setItems(new CharSequence[]{
-                      activity.getString(R.string.pref_managekeys_export_secret_keys),
-                      activity.getString(R.string.pref_managekeys_import_secret_keys)
-                  },
-                  (dialogInterface, i) -> {
-                    if (i==0) {
-                      new AlertDialog.Builder(activity)
-                          .setTitle(R.string.pref_managekeys_export_secret_keys)
-                          .setMessage(activity.getString(R.string.pref_managekeys_export_explain, DcHelper.getImexDir().getAbsolutePath()))
-                          .setNegativeButton(android.R.string.cancel, null)
-                          .setPositiveButton(android.R.string.ok, (dialogInterface2, i2) -> startImexOne(DcContext.DC_IMEX_EXPORT_SELF_KEYS))
-                          .show();
-                    }
-                    else {
-                      if (Build.VERSION.SDK_INT >= 30) {
-                        AttachmentManager.selectMediaType(activity, "*/*", null, PICK_SELF_KEYS, StorageUtil.getDownloadUri());
-                      } else {
-                        String path = DcHelper.getImexDir().getAbsolutePath();
-                        showImportKeysDialog(path, path);
-                      }
-                    }
-                  }
-              )
-              .setNegativeButton(R.string.cancel, null)
-              .setNeutralButton(R.string.learn_more, (d, w) -> DcHelper.openHelp(activity, "#importkey"))
-              .show();
-        })
-        .execute();
   }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -878,8 +878,8 @@
     <string name="autocrypt_send_asm_explain_after">Your setup has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:</string>
     <string name="autocrypt_prefer_e2ee">Prefer End-To-End Encryption</string>
     <string name="autocrypt_asm_subject">Autocrypt Setup Message</string>
-    <!-- deprecated -->
     <string name="autocrypt_asm_general_body">This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\nTo decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.</string>
+    <!-- deprecated -->
     <string name="autocrypt_asm_click_body">This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\nTo decrypt and use your setup, tap or click on this message.</string>
     <string name="autocrypt_continue_transfer_title">Autocrypt Setup Message</string>
     <string name="autocrypt_continue_transfer_please_enter_code">Please enter the setup code displayed on the other device.</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -876,6 +876,7 @@
     <string name="autocrypt_send_asm_explain_after">Your setup has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:</string>
     <string name="autocrypt_prefer_e2ee">Prefer End-To-End Encryption</string>
     <string name="autocrypt_asm_subject">Autocrypt Setup Message</string>
+    <!-- deprecated -->
     <string name="autocrypt_asm_general_body">This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\nTo decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.</string>
     <string name="autocrypt_asm_click_body">This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\nTo decrypt and use your setup, tap or click on this message.</string>
     <string name="autocrypt_continue_transfer_title">Autocrypt Setup Message</string>

--- a/src/main/res/xml/preferences_advanced.xml
+++ b/src/main/res/xml/preferences_advanced.xml
@@ -70,7 +70,9 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/pref_encryption">
+    <PreferenceCategory
+        android:key="pref_category_encryption"
+        android:title="@string/pref_encryption">
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="true"

--- a/src/main/res/xml/preferences_advanced.xml
+++ b/src/main/res/xml/preferences_advanced.xml
@@ -74,15 +74,6 @@
         android:key="pref_category_encryption"
         android:title="@string/pref_encryption">
 
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="pref_prefer_e2ee"
-            android:title="@string/autocrypt_prefer_e2ee"/>
-
-
-        <Preference android:key="pref_manage_keys"
-            android:title="@string/pref_manage_keys"/>
-
         <Preference android:key="pref_send_autocrypt_setup_message"
             android:title="@string/autocrypt_send_asm_title"/>
 


### PR DESCRIPTION
close #3591, similar to https://github.com/deltachat/deltachat-ios/pull/2636

- Remove "Prefer end-to-end encryption"
- Remove option to import key by file or autocrypt setup message (ASM), targets targets https://github.com/deltachat/interface/issues/80
- Remove option to export key file, which doesn't really make sense on mobile because it was exporting the key file without any passphrase to the world-readable Downloads folder
- Remove receiving ASM
- Deprecate unused strings

Sending ASM stays for now.
