### PR TITLE
allow to add any chat to the home screen

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
@@ -144,7 +144,7 @@ public class DirectShareUtil {
     return results;
   }
 
-  private static Bitmap getIconForShortcut(@NonNull Context context, @NonNull Recipient recipient) {
+  public static Bitmap getIconForShortcut(@NonNull Context context, @NonNull Recipient recipient) {
     try {
       return getShortcutInfoBitmap(context, recipient);
     } catch (ExecutionException | InterruptedException | NullPointerException e) {

--- a/src/main/res/menu/conversation_list.xml
+++ b/src/main/res/menu/conversation_list.xml
@@ -25,6 +25,10 @@
           android:id="@+id/menu_marknoticed_selected"
           app:showAsAction="never"/>
 
+    <item android:title="@string/add_to_home_screen"
+          android:id="@+id/menu_add_to_home_screen"
+          app:showAsAction="never"/>
+
     <item android:title="@string/menu_select_all"
           android:id="@+id/menu_select_all"
           app:showAsAction="never"/>


### PR DESCRIPTION
currently we already allow to add some chats to the home screen, but in a limited way, with the launchers that support some "quick actions" when long-pressing app icon and it only displays the 3 more resent chats + the "Saved Messages" chat, with this PR people can add to home screen any chat without the mentioned limitations:

 
![image_2025-02-12_16-58-03](https://github.com/user-attachments/assets/dd2e0bbe-5271-4d3b-90d7-2b2c6bda39b5)
