### PR TITLE
fix warning about non-final resource IDs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
-android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4608m

--- a/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
@@ -410,14 +410,28 @@ public abstract class BaseConversationListFragment extends Fragment implements A
 
   @Override
   public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
-    switch (item.getItemId()) {
-    case R.id.menu_select_all:       handleSelectAllThreads();   return true;
-    case R.id.menu_delete_selected:  handleDeleteAllSelected();  return true;
-    case R.id.menu_pin_selected:     handlePinAllSelected();     return true;
-    case R.id.menu_archive_selected: handleArchiveAllSelected(); return true;
-    case R.id.menu_mute_selected:    handleMuteAllSelected();    return true;
-    case R.id.menu_marknoticed_selected: handleMarknoticedSelected(); return true;
-    case R.id.menu_add_to_home_screen:  handleAddToHomeScreen(); return true;
+    int itemId = item.getItemId();
+    if (itemId == R.id.menu_select_all) {
+      handleSelectAllThreads();
+      return true;
+    } else if (itemId == R.id.menu_delete_selected) {
+      handleDeleteAllSelected();
+      return true;
+    } else if (itemId == R.id.menu_pin_selected) {
+      handlePinAllSelected();
+      return true;
+    } else if (itemId == R.id.menu_archive_selected) {
+      handleArchiveAllSelected();
+      return true;
+    } else if (itemId == R.id.menu_mute_selected) {
+      handleMuteAllSelected();
+      return true;
+    } else if (itemId == R.id.menu_marknoticed_selected) {
+      handleMarknoticedSelected();
+      return true;
+    } else if (itemId == R.id.menu_add_to_home_screen) {
+      handleAddToHomeScreen();
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/ContactMultiSelectionActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ContactMultiSelectionActivity.java
@@ -57,11 +57,10 @@ public class ContactMultiSelectionActivity extends ContactSelectionActivity {
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case R.id.menu_add_members:
-        saveSelection();
-        finish();
-        return true;
+    if (item.getItemId() == R.id.menu_add_members) {
+      saveSelection();
+      finish();
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -149,16 +149,16 @@ public class ContactSelectionListFragment extends    Fragment
 
       @Override
       public boolean onActionItemClicked(ActionMode actionMode, MenuItem menuItem) {
-        switch (menuItem.getItemId()) {
-          case R.id.menu_select_all:
-            handleSelectAll();
-            return true;
-          case R.id.menu_view_profile:
-            handleViewProfile();
-            return true;
-          case R.id.menu_delete_selected:
-            handleDeleteSelected();
-            return true;
+        int itemId = menuItem.getItemId();
+        if (itemId == R.id.menu_select_all) {
+          handleSelectAll();
+          return true;
+        } else if (itemId == R.id.menu_view_profile) {
+          handleViewProfile();
+          return true;
+        } else if (itemId == R.id.menu_delete_selected) {
+          handleDeleteSelected();
+          return true;
         }
         return false;
       }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -503,18 +503,40 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case R.id.menu_add_attachment:        handleAddAttachment();             return true;
-      case R.id.menu_leave:                 handleLeaveGroup();                return true;
-      case R.id.menu_archive_chat:          handleArchiveChat();               return true;
-      case R.id.menu_clear_chat:            fragment.handleClearChat();        return true;
-      case R.id.menu_delete_chat:           handleDeleteChat();                return true;
-      case R.id.menu_mute_notifications:    handleMuteNotifications();         return true;
-      case R.id.menu_show_map:              WebxdcActivity.openMaps(this, chatId); return true;
-      case R.id.menu_search_up:             handleMenuSearchNext(false);       return true;
-      case R.id.menu_search_down:           handleMenuSearchNext(true);        return true;
-      case android.R.id.home:               handleReturnToConversationList();  return true;
-      case R.id.menu_ephemeral_messages:    handleEphemeralMessages();         return true;
+    int itemId = item.getItemId();
+    if (itemId == R.id.menu_add_attachment) {
+      handleAddAttachment();
+      return true;
+    } else if (itemId == R.id.menu_leave) {
+      handleLeaveGroup();
+      return true;
+    } else if (itemId == R.id.menu_archive_chat) {
+      handleArchiveChat();
+      return true;
+    } else if (itemId == R.id.menu_clear_chat) {
+      fragment.handleClearChat();
+      return true;
+    } else if (itemId == R.id.menu_delete_chat) {
+      handleDeleteChat();
+      return true;
+    } else if (itemId == R.id.menu_mute_notifications) {
+      handleMuteNotifications();
+      return true;
+    } else if (itemId == R.id.menu_show_map) {
+      WebxdcActivity.openMaps(this, chatId);
+      return true;
+    } else if (itemId == R.id.menu_search_up) {
+      handleMenuSearchNext(false);
+      return true;
+    } else if (itemId == R.id.menu_search_down) {
+      handleMenuSearchNext(true);
+      return true;
+    } else if (itemId == android.R.id.home) {
+      handleReturnToConversationList();
+      return true;
+    } else if (itemId == R.id.menu_ephemeral_messages) {
+      handleEphemeralMessages();
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -928,43 +928,43 @@ public class ConversationFragment extends MessageSelectorFragment
         @Override
         public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
             hideAddReactionView();
-            switch(item.getItemId()) {
-                case R.id.menu_context_copy:
-                    handleCopyMessage(getListAdapter().getSelectedItems());
-                    actionMode.finish();
-                    return true;
-                case R.id.menu_context_delete_message:
-                    handleDeleteMessages((int) chatId, getListAdapter().getSelectedItems());
-                    return true;
-                case R.id.menu_context_share:
-                    DcHelper.openForViewOrShare(getContext(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId(), Intent.ACTION_SEND);
-                    return true;
-                case R.id.menu_context_details:
-                    handleDisplayDetails(getSelectedMessageRecord(getListAdapter().getSelectedItems()));
-                    actionMode.finish();
-                    return true;
-                case R.id.menu_context_forward:
-                    handleForwardMessage(getListAdapter().getSelectedItems());
-                    actionMode.finish();
-                    return true;
-                case R.id.menu_add_to_home_screen:
-                    WebxdcActivity.addToHomeScreen(getActivity(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId());
-                    actionMode.finish();
-                    return true;
-                case R.id.menu_context_save_attachment:
-                    handleSaveAttachment(getListAdapter().getSelectedItems());
-                    return true;
-                case R.id.menu_context_reply:
-                    handleReplyMessage(getSelectedMessageRecord(getListAdapter().getSelectedItems()));
-                    actionMode.finish();
-                    return true;
-                case R.id.menu_context_reply_privately:
-                    handleReplyMessagePrivately(getSelectedMessageRecord(getListAdapter().getSelectedItems()));
-                    return true;
-                case R.id.menu_resend:
-                    handleResendMessage(getListAdapter().getSelectedItems());
-                    return true;
-            }
+          int itemId = item.getItemId();
+          if (itemId == R.id.menu_context_copy) {
+            handleCopyMessage(getListAdapter().getSelectedItems());
+            actionMode.finish();
+            return true;
+          } else if (itemId == R.id.menu_context_delete_message) {
+            handleDeleteMessages((int) chatId, getListAdapter().getSelectedItems());
+            return true;
+          } else if (itemId == R.id.menu_context_share) {
+            DcHelper.openForViewOrShare(getContext(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId(), Intent.ACTION_SEND);
+            return true;
+          } else if (itemId == R.id.menu_context_details) {
+            handleDisplayDetails(getSelectedMessageRecord(getListAdapter().getSelectedItems()));
+            actionMode.finish();
+            return true;
+          } else if (itemId == R.id.menu_context_forward) {
+            handleForwardMessage(getListAdapter().getSelectedItems());
+            actionMode.finish();
+            return true;
+          } else if (itemId == R.id.menu_add_to_home_screen) {
+            WebxdcActivity.addToHomeScreen(getActivity(), getSelectedMessageRecord(getListAdapter().getSelectedItems()).getId());
+            actionMode.finish();
+            return true;
+          } else if (itemId == R.id.menu_context_save_attachment) {
+            handleSaveAttachment(getListAdapter().getSelectedItems());
+            return true;
+          } else if (itemId == R.id.menu_context_reply) {
+            handleReplyMessage(getSelectedMessageRecord(getListAdapter().getSelectedItems()));
+            actionMode.finish();
+            return true;
+          } else if (itemId == R.id.menu_context_reply_privately) {
+            handleReplyMessagePrivately(getSelectedMessageRecord(getListAdapter().getSelectedItems()));
+            return true;
+          } else if (itemId == R.id.menu_resend) {
+            handleResendMessage(getListAdapter().getSelectedItems());
+            return true;
+          }
 
             return false;
         }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -421,31 +421,31 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
 
-    switch (item.getItemId()) {
-      case R.id.menu_new_chat:
-        createChat();
-        return true;
-      case R.id.menu_invite_friends:
-        shareInvite();
-        return true;
-      case R.id.menu_settings:
-        startActivity(new Intent(this, ApplicationPreferencesActivity.class));
-        return true;
-      case R.id.menu_qr:
-        new IntentIntegrator(this).setCaptureActivity(QrActivity.class).initiateScan();
-        return true;
-      case R.id.menu_global_map:
-        WebxdcActivity.openMaps(this, 0);
-        return true;
-      case R.id.menu_proxy_settings:
-        startActivity(new Intent(this, ProxySettingsActivity.class));
-        return true;
-      case android.R.id.home:
-        onBackPressed();
-        return true;
-      case R.id.menu_all_media:
-        startActivity(new Intent(this, ProfileActivity.class));
-        return true;
+    int itemId = item.getItemId();
+    if (itemId == R.id.menu_new_chat) {
+      createChat();
+      return true;
+    } else if (itemId == R.id.menu_invite_friends) {
+      shareInvite();
+      return true;
+    } else if (itemId == R.id.menu_settings) {
+      startActivity(new Intent(this, ApplicationPreferencesActivity.class));
+      return true;
+    } else if (itemId == R.id.menu_qr) {
+      new IntentIntegrator(this).setCaptureActivity(QrActivity.class).initiateScan();
+      return true;
+    } else if (itemId == R.id.menu_global_map) {
+      WebxdcActivity.openMaps(this, 0);
+      return true;
+    } else if (itemId == R.id.menu_proxy_settings) {
+      startActivity(new Intent(this, ProxySettingsActivity.class));
+      return true;
+    } else if (itemId == android.R.id.home) {
+      onBackPressed();
+      return true;
+    } else if (itemId == R.id.menu_all_media) {
+      startActivity(new Intent(this, ProfileActivity.class));
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
@@ -60,14 +60,13 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
 
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        onBackPressed();
-        return true;
-
-      case R.id.mark_as_read:
-        DcHelper.getContext(this).marknoticedChat(DcChat.DC_CHAT_ID_ARCHIVED_LINK);
-        return true;
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
+      onBackPressed();
+      return true;
+    } else if (itemId == R.id.mark_as_read) {
+      DcHelper.getContext(this).marknoticedChat(DcChat.DC_CHAT_ID_ARCHIVED_LINK);
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -97,13 +97,12 @@ public class CreateProfileActivity extends BaseActionBarActivity {
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        onBackPressed();
-        return true;
-      case R.id.menu_create_profile:
-        updateProfile();
-        break;
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
+      onBackPressed();
+      return true;
+    } else if (itemId == R.id.menu_create_profile) {
+      updateProfile();
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/FullMsgActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/FullMsgActivity.java
@@ -116,40 +116,39 @@ public class FullMsgActivity extends WebViewActivity
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case R.id.load_remote_content:
-        AlertDialog.Builder builder = new AlertDialog.Builder(this)
-          .setTitle(R.string.load_remote_content)
-          .setMessage(R.string.load_remote_content_ask);
+    if (item.getItemId() == R.id.load_remote_content) {
+      AlertDialog.Builder builder = new AlertDialog.Builder(this)
+        .setTitle(R.string.load_remote_content)
+        .setMessage(R.string.load_remote_content_ask);
 
-        // we are using the buttons "[Always]  [Never][Once]" in that order.
-        // 1. Checkmarks before [Always] and [Never] show the current state.
-        // 2. [Once] is also shown in always-mode and disables always-mode if selected
-        //    (there was the idea to hide [Once] in always mode, but that looks more like a bug in the end)
-        // (maybe a usual Always-Checkbox and "[Cancel][OK]" buttons are an alternative, however, a [Once]
-        // would be required as well - probably as the leftmost button which is not that usable in
-        // not-always-mode where the dialog is used more often. Or [Ok] would mean "Once" as well as "Change checkbox setting",
-        // which is also a bit weird. Anyway, let's give the three buttons a try :)
-        final String checkmark = DynamicTheme.getCheckmarkEmoji(this) + " ";
-        String alwaysCheckmark = "";
-        String onceCheckmark = "";
-        String neverCheckmark = "";
-        if (!blockLoadingRemote && Prefs.getAlwaysLoadRemoteContent(this)) {
-          alwaysCheckmark = checkmark;
-        } else if (loadRemoteContent) {
-          onceCheckmark = checkmark;
-        } else {
-          neverCheckmark = checkmark;
-        }
+      // we are using the buttons "[Always]  [Never][Once]" in that order.
+      // 1. Checkmarks before [Always] and [Never] show the current state.
+      // 2. [Once] is also shown in always-mode and disables always-mode if selected
+      //    (there was the idea to hide [Once] in always mode, but that looks more like a bug in the end)
+      // (maybe a usual Always-Checkbox and "[Cancel][OK]" buttons are an alternative, however, a [Once]
+      // would be required as well - probably as the leftmost button which is not that usable in
+      // not-always-mode where the dialog is used more often. Or [Ok] would mean "Once" as well as "Change checkbox setting",
+      // which is also a bit weird. Anyway, let's give the three buttons a try :)
+      final String checkmark = DynamicTheme.getCheckmarkEmoji(this) + " ";
+      String alwaysCheckmark = "";
+      String onceCheckmark = "";
+      String neverCheckmark = "";
+      if (!blockLoadingRemote && Prefs.getAlwaysLoadRemoteContent(this)) {
+        alwaysCheckmark = checkmark;
+      } else if (loadRemoteContent) {
+        onceCheckmark = checkmark;
+      } else {
+        neverCheckmark = checkmark;
+      }
 
-        if (!blockLoadingRemote) {
-          builder.setNeutralButton(alwaysCheckmark + getString(R.string.always), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ALWAYS));
-        }
-        builder.setNegativeButton(neverCheckmark + getString(blockLoadingRemote ? R.string.no : R.string.never), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.NEVER));
-        builder.setPositiveButton(onceCheckmark + getString(R.string.once), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ONCE));
+      if (!blockLoadingRemote) {
+        builder.setNeutralButton(alwaysCheckmark + getString(R.string.always), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ALWAYS));
+      }
+      builder.setNegativeButton(neverCheckmark + getString(blockLoadingRemote ? R.string.no : R.string.never), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.NEVER));
+      builder.setPositiveButton(onceCheckmark + getString(R.string.once), (dialog, which) -> onChangeLoadRemoteContent(LoadRemoteContent.ONCE));
 
-        builder.show();
-        return true;
+      builder.show();
+      return true;
     }
     return false;
   }

--- a/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -207,22 +207,22 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   @Override
   public boolean onOptionsItemSelected(@NonNull MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        finish();
-        return true;
-      case R.id.menu_create_group:
-        String groupName = getGroupName();
-        if (showGroupNameEmptyToast(groupName)) return true;
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
+      finish();
+      return true;
+    } else if (itemId == R.id.menu_create_group) {
+      String groupName = getGroupName();
+      if (showGroupNameEmptyToast(groupName)) return true;
 
-        if (groupChatId!=0) {
-          updateGroup(groupName);
-        } else {
-          verified = !broadcast && allMembersVerified();
-          createGroup(groupName);
-        }
+      if (groupChatId != 0) {
+        updateGroup(groupName);
+      } else {
+        verified = !broadcast && allMembersVerified();
+        createGroup(groupName);
+      }
 
-        return true;
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -156,14 +156,14 @@ public class InstantOnboardingActivity extends BaseActionBarActivity implements 
   public boolean onOptionsItemSelected(@NonNull MenuItem item) {
     super.onOptionsItemSelected(item);
 
-    switch (item.getItemId()) {
-    case android.R.id.home:
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
       getOnBackPressedDispatcher().onBackPressed();
       return true;
-    case R.id.menu_proxy_settings:
+    } else if (itemId == R.id.menu_proxy_settings) {
       startActivity(new Intent(this, ProxySettingsActivity.class));
       return true;
-    case R.id.menu_view_log:
+    } else if (itemId == R.id.menu_view_log) {
       startActivity(new Intent(this, LogViewActivity.class));
       return true;
     }

--- a/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
@@ -57,22 +57,22 @@ public class LocalHelpActivity extends WebViewActivity
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case R.id.log_scroll_up:
-        webView.scrollTo(0, 0);
-        return true;
-      case R.id.learn_more:
-        openOnlineUrl("https://delta.chat");
-        return true;
-      case R.id.privacy_policy:
-        openOnlineUrl("https://delta.chat/gdpr");
-        return true;
-      case R.id.contribute:
-        openOnlineUrl("https://delta.chat/contribute");
-        return true;
-      case R.id.report_issue:
-        openOnlineUrl("https://github.com/deltachat/deltachat-android/issues");
-        return true;
+    int itemId = item.getItemId();
+    if (itemId == R.id.log_scroll_up) {
+      webView.scrollTo(0, 0);
+      return true;
+    } else if (itemId == R.id.learn_more) {
+      openOnlineUrl("https://delta.chat");
+      return true;
+    } else if (itemId == R.id.privacy_policy) {
+      openOnlineUrl("https://delta.chat/gdpr");
+      return true;
+    } else if (itemId == R.id.contribute) {
+      openOnlineUrl("https://delta.chat/contribute");
+      return true;
+    } else if (itemId == R.id.report_issue) {
+      openOnlineUrl("https://github.com/deltachat/deltachat-android/issues");
+      return true;
     }
     return false;
   }

--- a/src/main/java/org/thoughtcrime/securesms/LogViewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/LogViewActivity.java
@@ -54,42 +54,42 @@ public class LogViewActivity extends BaseActionBarActivity {
     super.onOptionsItemSelected(item);
     Float newSize;
 
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        finish();
-        return true;
-      case R.id.save_log:
-        Permissions.with(this)
-            .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-            .alwaysGrantOnSdk30()
-            .ifNecessary()
-            .onAllGranted(() -> {
-              File outputDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-              boolean success = logViewFragment.saveLogFile(outputDir) != null;
-              new AlertDialog.Builder(this)
-                  .setMessage(success? R.string.pref_saved_log : R.string.pref_save_log_failed)
-                  .setPositiveButton(android.R.string.ok, null)
-                  .show();
-            })
-            .execute();
-        return true;
-      case R.id.share_log:
-        shareLog();
-        return true;
-      case R.id.log_zoom_in:
-        newSize = logViewFragment.getLogTextSize() + 2.0f;
-        logViewFragment.setLogTextSize(newSize);
-        return false;
-      case R.id.log_zoom_out:
-        newSize = logViewFragment.getLogTextSize() - 2.0f;
-        logViewFragment.setLogTextSize(newSize);
-        return false;
-      case R.id.log_scroll_down:
-        logViewFragment.scrollDownLog();
-        return false;
-      case R.id.log_scroll_up:
-        logViewFragment.scrollUpLog();
-        return false;
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
+      finish();
+      return true;
+    } else if (itemId == R.id.save_log) {
+      Permissions.with(this)
+        .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        .alwaysGrantOnSdk30()
+        .ifNecessary()
+        .onAllGranted(() -> {
+          File outputDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+          boolean success = logViewFragment.saveLogFile(outputDir) != null;
+          new AlertDialog.Builder(this)
+            .setMessage(success ? R.string.pref_saved_log : R.string.pref_save_log_failed)
+            .setPositiveButton(android.R.string.ok, null)
+            .show();
+        })
+        .execute();
+      return true;
+    } else if (itemId == R.id.share_log) {
+      shareLog();
+      return true;
+    } else if (itemId == R.id.log_zoom_in) {
+      newSize = logViewFragment.getLogTextSize() + 2.0f;
+      logViewFragment.setLogTextSize(newSize);
+      return false;
+    } else if (itemId == R.id.log_zoom_out) {
+      newSize = logViewFragment.getLogTextSize() - 2.0f;
+      logViewFragment.setLogTextSize(newSize);
+      return false;
+    } else if (itemId == R.id.log_scroll_down) {
+      logViewFragment.scrollDownLog();
+      return false;
+    } else if (itemId == R.id.log_scroll_up) {
+      logViewFragment.scrollUpLog();
+      return false;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -390,14 +390,28 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
 
-    switch (item.getItemId()) {
-      case R.id.media_preview__edit:     editAvatar();   return true;
-      case R.id.media_preview__overview: showOverview(); return true;
-      case R.id.media_preview__share:    share();        return true;
-      case R.id.save:                    saveToDisk();   return true;
-      case R.id.delete:                  deleteMedia();  return true;
-      case R.id.show_in_chat:            showInChat();   return true;
-      case android.R.id.home:            finish();       return true;
+    int itemId = item.getItemId();
+    if (itemId == R.id.media_preview__edit) {
+      editAvatar();
+      return true;
+    } else if (itemId == R.id.media_preview__overview) {
+      showOverview();
+      return true;
+    } else if (itemId == R.id.media_preview__share) {
+      share();
+      return true;
+    } else if (itemId == R.id.save) {
+      saveToDisk();
+      return true;
+    } else if (itemId == R.id.delete) {
+      deleteMedia();
+      return true;
+    } else if (itemId == R.id.show_in_chat) {
+      showInChat();
+      return true;
+    } else if (itemId == android.R.id.home) {
+      finish();
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -416,35 +416,27 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
 
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        backPressed = true;
-        finish();
-        return true;
-      case R.id.menu_mute_notifications:
-        onNotifyOnOff();
-        break;
-      case R.id.menu_sound:
-        onSoundSettings();
-        break;
-      case R.id.menu_vibrate:
-        onVibrateSettings();
-        break;
-      case R.id.edit_name:
-        onEditName();
-        break;
-      case R.id.share:
-        onShare();
-        break;
-      case R.id.show_encr_info:
-        onEncrInfo();
-        break;
-      case R.id.block_contact:
-        onBlockContact();
-        break;
-      case R.id.menu_clone:
-        onClone();
-        break;
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
+      backPressed = true;
+      finish();
+      return true;
+    } else if (itemId == R.id.menu_mute_notifications) {
+      onNotifyOnOff();
+    } else if (itemId == R.id.menu_sound) {
+      onSoundSettings();
+    } else if (itemId == R.id.menu_vibrate) {
+      onVibrateSettings();
+    } else if (itemId == R.id.edit_name) {
+      onEditName();
+    } else if (itemId == R.id.share) {
+      onShare();
+    } else if (itemId == R.id.show_encr_info) {
+      onEncrInfo();
+    } else if (itemId == R.id.block_contact) {
+      onBlockContact();
+    } else if (itemId == R.id.menu_clone) {
+      onClone();
     }
 
     return false;
@@ -453,10 +445,8 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
   @Override
   public boolean onContextItemSelected(MenuItem item) {
     super.onContextItemSelected(item);
-    switch (item.getItemId()) {
-      case R.id.copy_addr_to_clipboard:
-        onCopyAddrToClipboard();
-        break;
+    if (item.getItemId() == R.id.copy_addr_to_clipboard) {
+      onCopyAddrToClipboard();
     }
     return false;
   }

--- a/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsFragment.java
@@ -248,35 +248,35 @@ public class ProfileDocumentsFragment
 
     @Override
     public boolean onActionItemClicked(ActionMode mode, MenuItem menuItem) {
-      switch (menuItem.getItemId()) {
-        case R.id.details:
-          handleDisplayDetails(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
-          mode.finish();
-          return true;
-        case R.id.delete:
-          handleDeleteMessages(chatId, getListAdapter().getSelectedMedia());
-          mode.finish();
-          return true;
-        case R.id.share:
-          handleShare(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
-          return true;
-        case R.id.menu_add_to_home_screen:
-          WebxdcActivity.addToHomeScreen(getActivity(), getSelectedMessageRecord(getListAdapter().getSelectedMedia()).getId());
-          mode.finish();
-          return true;
-        case R.id.show_in_chat:
-          handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
-          return true;
-        case R.id.save:
-          handleSaveAttachment(getListAdapter().getSelectedMedia());
-          return true;
-        case R.id.menu_resend:
-          handleResendMessage(getListAdapter().getSelectedMedia());
-          return true;
-        case R.id.menu_select_all:
-          getListAdapter().selectAll();
-          updateActionModeBar();
-          return true;
+      int itemId = menuItem.getItemId();
+      if (itemId == R.id.details) {
+        handleDisplayDetails(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+        mode.finish();
+        return true;
+      } else if (itemId == R.id.delete) {
+        handleDeleteMessages(chatId, getListAdapter().getSelectedMedia());
+        mode.finish();
+        return true;
+      } else if (itemId == R.id.share) {
+        handleShare(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+        return true;
+      } else if (itemId == R.id.menu_add_to_home_screen) {
+        WebxdcActivity.addToHomeScreen(getActivity(), getSelectedMessageRecord(getListAdapter().getSelectedMedia()).getId());
+        mode.finish();
+        return true;
+      } else if (itemId == R.id.show_in_chat) {
+        handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+        return true;
+      } else if (itemId == R.id.save) {
+        handleSaveAttachment(getListAdapter().getSelectedMedia());
+        return true;
+      } else if (itemId == R.id.menu_resend) {
+        handleResendMessage(getListAdapter().getSelectedMedia());
+        return true;
+      } else if (itemId == R.id.menu_select_all) {
+        getListAdapter().selectAll();
+        updateActionModeBar();
+        return true;
       }
       return false;
     }

--- a/src/main/java/org/thoughtcrime/securesms/ProfileGalleryFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileGalleryFragment.java
@@ -233,31 +233,31 @@ public class ProfileGalleryFragment
 
     @Override
     public boolean onActionItemClicked(ActionMode mode, MenuItem menuItem) {
-      switch (menuItem.getItemId()) {
-        case R.id.details:
-          handleDisplayDetails(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
-          mode.finish();
-          return true;
-        case R.id.delete:
-          handleDeleteMessages(chatId, getListAdapter().getSelectedMedia());
-          mode.finish();
-          return true;
-        case R.id.share:
-          handleShare(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
-          return true;
-        case R.id.show_in_chat:
-          handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
-          return true;
-        case R.id.save:
-          handleSaveAttachment(getListAdapter().getSelectedMedia());
-          return true;
-        case R.id.menu_resend:
-          handleResendMessage(getListAdapter().getSelectedMedia());
-          return true;
-        case R.id.menu_select_all:
-          getListAdapter().selectAll();
-          updateActionModeBar();
-          return true;
+      int itemId = menuItem.getItemId();
+      if (itemId == R.id.details) {
+        handleDisplayDetails(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+        mode.finish();
+        return true;
+      } else if (itemId == R.id.delete) {
+        handleDeleteMessages(chatId, getListAdapter().getSelectedMedia());
+        mode.finish();
+        return true;
+      } else if (itemId == R.id.share) {
+        handleShare(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+        return true;
+      } else if (itemId == R.id.show_in_chat) {
+        handleShowInChat(getSelectedMessageRecord(getListAdapter().getSelectedMedia()));
+        return true;
+      } else if (itemId == R.id.save) {
+        handleSaveAttachment(getListAdapter().getSelectedMedia());
+        return true;
+      } else if (itemId == R.id.menu_resend) {
+        handleResendMessage(getListAdapter().getSelectedMedia());
+        return true;
+      } else if (itemId == R.id.menu_select_all) {
+        getListAdapter().selectAll();
+        updateActionModeBar();
+        return true;
       }
       return false;
     }

--- a/src/main/java/org/thoughtcrime/securesms/ProfileSettingsFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileSettingsFragment.java
@@ -281,29 +281,28 @@ public class ProfileSettingsFragment extends Fragment
 
     @Override
     public boolean onActionItemClicked(ActionMode mode, MenuItem menuItem) {
-      switch (menuItem.getItemId()) {
-        case R.id.delete:
-          final Collection<Integer> toDelIds = adapter.getSelectedMembers();
-          StringBuilder readableToDelList = new StringBuilder();
-          for (Integer toDelId : toDelIds) {
-            if(readableToDelList.length()>0) {
-              readableToDelList.append(", ");
-            }
-            readableToDelList.append(dcContext.getContact(toDelId).getDisplayName());
+      if (menuItem.getItemId() == R.id.delete) {
+        final Collection<Integer> toDelIds = adapter.getSelectedMembers();
+        StringBuilder readableToDelList = new StringBuilder();
+        for (Integer toDelId : toDelIds) {
+          if (readableToDelList.length() > 0) {
+            readableToDelList.append(", ");
           }
-          DcChat dcChat = dcContext.getChat(chatId);
-          AlertDialog dialog = new AlertDialog.Builder(getContext())
-              .setPositiveButton(R.string.remove_desktop, (d, which) -> {
-                for (Integer toDelId : toDelIds) {
-                  dcContext.removeContactFromChat(chatId, toDelId);
-                }
-                mode.finish();
-              })
-              .setNegativeButton(android.R.string.cancel, null)
-              .setMessage(getString(dcChat.isBroadcast()? R.string.ask_remove_from_broadcast : R.string.ask_remove_members, readableToDelList))
-              .show();
-          Util.redPositiveButton(dialog);
-          return true;
+          readableToDelList.append(dcContext.getContact(toDelId).getDisplayName());
+        }
+        DcChat dcChat = dcContext.getChat(chatId);
+        AlertDialog dialog = new AlertDialog.Builder(getContext())
+          .setPositiveButton(R.string.remove_desktop, (d, which) -> {
+            for (Integer toDelId : toDelIds) {
+              dcContext.removeContactFromChat(chatId, toDelId);
+            }
+            mode.finish();
+          })
+          .setNegativeButton(android.R.string.cancel, null)
+          .setMessage(getString(dcChat.isBroadcast() ? R.string.ask_remove_from_broadcast : R.string.ask_remove_members, readableToDelList))
+          .show();
+        Util.redPositiveButton(dialog);
+        return true;
       }
       return false;
     }

--- a/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
@@ -254,24 +254,24 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        finish();
-        return true;
-      case R.id.menu_search_up:
-        if (lastQuery.isEmpty()) {
-          webView.scrollTo(0, 0);
-        } else {
-          webView.findNext(false);
-        }
-        return true;
-      case R.id.menu_search_down:
-        if (lastQuery.isEmpty()) {
-          webView.scrollTo(0, 1000000000);
-        } else {
-          webView.findNext(true);
-        }
-        return true;
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
+      finish();
+      return true;
+    } else if (itemId == R.id.menu_search_up) {
+      if (lastQuery.isEmpty()) {
+        webView.scrollTo(0, 0);
+      } else {
+        webView.findNext(false);
+      }
+      return true;
+    } else if (itemId == R.id.menu_search_down) {
+      if (lastQuery.isEmpty()) {
+        webView.scrollTo(0, 1000000000);
+      } else {
+        webView.findNext(true);
+      }
+      return true;
     }
     return false;
   }

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -285,16 +285,16 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case R.id.menu_add_to_home_screen:
-        addToHomeScreen(this, dcAppMsg.getId());
-        return true;
-      case R.id.source_code:
-        IntentUtils.showInBrowser(this, sourceCodeUrl);
-        return true;
-      case R.id.show_in_chat:
-        showInChat();
-        return true;
+    int itemId = item.getItemId();
+    if (itemId == R.id.menu_add_to_home_screen) {
+      addToHomeScreen(this, dcAppMsg.getId());
+      return true;
+    } else if (itemId == R.id.source_code) {
+      IntentUtils.showInBrowser(this, sourceCodeUrl);
+      return true;
+    } else if (itemId == R.id.show_in_chat) {
+      showInChat();
+      return true;
     }
     return false;
   }

--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
@@ -108,16 +108,13 @@ public class AccountSelectionListFragment extends DialogFragment
   }
 
   private void onContextItemSelected(MenuItem item, int accountId) {
-    switch (item.getItemId()) {
-    case R.id.delete:
+    int itemId = item.getItemId();
+    if (itemId == R.id.delete) {
       onDeleteAccount(accountId);
-      break;
-    case R.id.menu_mute_notifications:
+    } else if (itemId == R.id.menu_mute_notifications) {
       onToggleMute(accountId);
-      break;
-    case R.id.menu_set_tag:
+    } else if (itemId == R.id.menu_set_tag) {
       onSetTag(accountId);
-      break;
     }
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/contacts/NewContactActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/contacts/NewContactActivity.java
@@ -68,31 +68,31 @@ public class NewContactActivity extends PassphraseRequiredActionBarActivity
   @Override
   public boolean onOptionsItemSelected(@NonNull MenuItem item) {
     super.onOptionsItemSelected(item);
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        finish();
+    int itemId = item.getItemId();
+    if (itemId == android.R.id.home) {
+      finish();
+      return true;
+    } else if (itemId == R.id.menu_create_contact) {
+      String addr = addrInput.getText() == null ? "" : addrInput.getText().toString();
+      String name = nameInput.getText() == null ? "" : nameInput.getText().toString();
+      if (name.isEmpty()) name = null;
+      int contactId = dcContext.mayBeValidAddr(addr) ? dcContext.createContact(name, addr) : 0;
+      if (contactId == 0) {
+        Toast.makeText(this, getString(R.string.login_error_mail), Toast.LENGTH_LONG).show();
         return true;
-      case R.id.menu_create_contact:
-        String addr = addrInput.getText() == null? "" : addrInput.getText().toString();
-        String name = nameInput.getText() == null? "" : nameInput.getText().toString();
-        if (name.isEmpty()) name = null;
-        int contactId = dcContext.mayBeValidAddr(addr)? dcContext.createContact(name, addr): 0;
-        if (contactId == 0) {
-          Toast.makeText(this, getString(R.string.login_error_mail), Toast.LENGTH_LONG).show();
-          return true;
-        }
-        if (getCallingActivity() != null) { // called for result
-          Intent intent = new Intent();
-          intent.putExtra(ADDR_EXTRA, addr);
-          setResult(RESULT_OK, intent);
-        } else {
-          int chatId = dcContext.createChatByContactId(contactId);
-          Intent intent = new Intent(this, ConversationActivity.class);
-          intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
-          startActivity(intent);
-        }
-        finish();
-        return true;
+      }
+      if (getCallingActivity() != null) { // called for result
+        Intent intent = new Intent();
+        intent.putExtra(ADDR_EXTRA, addr);
+        setResult(RESULT_OK, intent);
+      } else {
+        int chatId = dcContext.createChatByContactId(contactId);
+        Intent intent = new Intent(this, ConversationActivity.class);
+        intent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
+        startActivity(intent);
+      }
+      finish();
+      return true;
     }
     return false;
   }

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -143,14 +143,13 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
       super.onOptionsItemSelected(item);
 
-      switch (item.getItemId()) {
-        case R.id.copy:
-          if (dcBackupProvider != null) {
-              Util.writeTextToClipboard(getActivity(), dcBackupProvider.getQr());
-              Toast.makeText(getActivity(), getString(R.string.done), Toast.LENGTH_SHORT).show();
-              getTransferActivity().warnAboutCopiedQrCodeOnAbort = true;
-          }
-          return true;
+      if (item.getItemId() == R.id.copy) {
+        if (dcBackupProvider != null) {
+          Util.writeTextToClipboard(getActivity(), dcBackupProvider.getQr());
+          Toast.makeText(getActivity(), getString(R.string.done), Toast.LENGTH_SHORT).show();
+          getTransferActivity().warnAboutCopiedQrCodeOnAbort = true;
+        }
+        return true;
       }
 
       return false;

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -112,17 +112,17 @@ public class BackupTransferActivity extends BaseActionBarActivity {
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         super.onOptionsItemSelected(item);
 
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finishOrAskToFinish();
-                return true;
-            case R.id.troubleshooting:
-                DcHelper.openHelp(this, "#multiclient");
-                return true;
-            case R.id.view_log_button:
-                startActivity(new Intent(this, LogViewActivity.class));
-                return true;
-        }
+      int itemId = item.getItemId();
+      if (itemId == android.R.id.home) {
+        finishOrAskToFinish();
+        return true;
+      } else if (itemId == R.id.troubleshooting) {
+        DcHelper.openHelp(this, "#multiclient");
+        return true;
+      } else if (itemId == R.id.view_log_button) {
+        startActivity(new Intent(this, LogViewActivity.class));
+        return true;
+      }
 
         return false;
     }

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
@@ -126,24 +126,20 @@ public class QrActivity extends BaseActionBarActivity implements View.OnClickLis
     public boolean onOptionsItemSelected(MenuItem item) {
         super.onOptionsItemSelected(item);
 
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-            case R.id.new_classic_contact:
-                this.startActivity(new Intent(this, NewContactActivity.class));
-                break;
-            case R.id.withdraw:
-                qrShowFragment.withdrawQr();
-                break;
-            case R.id.load_from_image:
-                AttachmentManager.selectImage(this, REQUEST_CODE_IMAGE);
-                break;
-            case R.id.paste:
-                QrCodeHandler qrCodeHandler = new QrCodeHandler(this);
-                qrCodeHandler.handleQrData(Util.getTextFromClipboard(this));
-                break;
-        }
+      int itemId = item.getItemId();
+      if (itemId == android.R.id.home) {
+        finish();
+        return true;
+      } else if (itemId == R.id.new_classic_contact) {
+        this.startActivity(new Intent(this, NewContactActivity.class));
+      } else if (itemId == R.id.withdraw) {
+        qrShowFragment.withdrawQr();
+      } else if (itemId == R.id.load_from_image) {
+        AttachmentManager.selectImage(this, REQUEST_CODE_IMAGE);
+      } else if (itemId == R.id.paste) {
+        QrCodeHandler qrCodeHandler = new QrCodeHandler(this);
+        qrCodeHandler.handleQrData(Util.getTextFromClipboard(this));
+      }
 
         return false;
     }

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrShowActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrShowActivity.java
@@ -83,14 +83,13 @@ public class QrShowActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         super.onOptionsItemSelected(item);
 
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-            case R.id.withdraw:
-                fragment.withdrawQr();
-                break;
-        }
+      int itemId = item.getItemId();
+      if (itemId == android.R.id.home) {
+        finish();
+        return true;
+      } else if (itemId == R.id.withdraw) {
+        fragment.withdrawQr();
+      }
 
         return false;
     }

--- a/src/main/java/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/RegistrationQrActivity.java
@@ -77,20 +77,20 @@ public class RegistrationQrActivity extends BaseActionBarActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         super.onOptionsItemSelected(item);
 
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-            case R.id.troubleshooting:
-                DcHelper.openHelp(this, "#multiclient");
-                return true;
-            case R.id.menu_paste:
-                Intent intent = new Intent();
-                intent.putExtra(QRDATA_EXTRA, Util.getTextFromClipboard(this));
-                setResult(Activity.RESULT_OK, intent);
-                finish();
-                return true;
-        }
+      int itemId = item.getItemId();
+      if (itemId == android.R.id.home) {
+        finish();
+        return true;
+      } else if (itemId == R.id.troubleshooting) {
+        DcHelper.openHelp(this, "#multiclient");
+        return true;
+      } else if (itemId == R.id.menu_paste) {
+        Intent intent = new Intent();
+        intent.putExtra(QRDATA_EXTRA, Util.getTextFromClipboard(this));
+        setResult(Activity.RESULT_OK, intent);
+        finish();
+        return true;
+      }
 
         return false;
     }


### PR DESCRIPTION
according to Google they moved to dynamic IDs because it makes it faster to compile, etc.

the `switch` statements got converted to `if` automatically by AndroidStudio

![image](https://github.com/user-attachments/assets/d25d4ffe-8cfa-4c7b-aee5-279682c249ae)
