### PR TITLE
add a warning when scanning a too new backup QR code

### DIFF
--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -51,8 +51,8 @@ public class DcContext {
     public final static int DC_QR_FPR_MISMATCH      = 220;
     public final static int DC_QR_FPR_WITHOUT_ADDR  = 230;
     public final static int DC_QR_ACCOUNT           = 250;
-    public final static int DC_QR_BACKUP            = 251;
     public final static int DC_QR_BACKUP2           = 252;
+    public final static int DC_QR_BACKUP_TOO_NEW    = 255;
     public final static int DC_QR_WEBRTC            = 260;
     public final static int DC_QR_PROXY             = 271;
     public final static int DC_QR_ADDR              = 320;

--- a/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -349,7 +349,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
             }
             DcLot qrParsed = dcContext.checkQr(qrRaw);
             switch (qrParsed.getState()) {
-                case DcContext.DC_QR_BACKUP:
                 case DcContext.DC_QR_BACKUP2:
                   final String finalQrRaw = qrRaw;
                   new AlertDialog.Builder(this)
@@ -358,6 +357,14 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
                             .setPositiveButton(R.string.perm_continue, (dialog, which) -> startBackupTransfer(finalQrRaw))
                             .setNegativeButton(R.string.cancel, null)
                             .setCancelable(false)
+                            .show();
+                    break;
+
+                case DcContext.DC_QR_BACKUP_TOO_NEW:
+                    new AlertDialog.Builder(this)
+                            .setTitle(R.string.multidevice_receiver_title)
+                            .setMessage(R.string.multidevice_receiver_needs_update)
+                            .setPositiveButton(R.string.ok, null)
                             .show();
                     break;
 

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -74,7 +74,6 @@ public class QrCodeHandler {
                 builder.setCancelable(false);
                 break;
 
-            case DcContext.DC_QR_BACKUP:
             case DcContext.DC_QR_BACKUP2:
                 builder.setTitle(R.string.multidevice_receiver_title);
                 builder.setMessage(activity.getString(R.string.multidevice_receiver_scanning_ask) + "\n\n" + activity.getString(R.string.multidevice_same_network_hint));
@@ -88,6 +87,12 @@ public class QrCodeHandler {
                 alertDialog.show();
                 BackupTransferActivity.appendSSID(activity, alertDialog.findViewById(android.R.id.message));
                 return;
+
+            case DcContext.DC_QR_BACKUP_TOO_NEW:
+                builder.setTitle(R.string.multidevice_receiver_title);
+                builder.setMessage(activity.getString(R.string.multidevice_receiver_needs_update));
+                builder.setNegativeButton(R.string.ok, null);
+                break;
 
             case DcContext.DC_QR_PROXY:
                 builder.setTitle(R.string.proxy_use_proxy);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -550,6 +550,7 @@
     <string name="multidevice_receiver_title">Add as Second Device</string>
     <string name="multidevice_open_settings_on_other_device">On the first device, go to “Settings / Add Second Device“ and scan the code shown there</string>
     <string name="multidevice_receiver_scanning_ask">Copy the profile from the other device to this device?</string>
+    <string name="multidevice_receiver_needs_update">The profile you want to import is from a newer Delta Chat version.\n\nTo continue setting up second device, please update this device to the latest version of Delta Chat.</string>
     <string name="multidevice_abort">Abort setting up second device?</string>
     <string name="multidevice_abort_will_invalidate_copied_qr">This will invalidate the QR code copied to clipboard.</string>
     <string name="multidevice_experimental_hint">(experimental, version 1.36 required)</string>


### PR DESCRIPTION
this PR shows a warning if the user scans a backup QR code from a too new Delta Chat version.

the user has to update their device first.

<img width="425" alt="Screenshot 2025-02-27 at 18 19 20" src="https://github.com/user-attachments/assets/9e5bbb96-83f8-49f3-a356-e95422e507b8" />
