### PR TITLE
remove notifications from chat that was deleted from other device

### DIFF
--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -17,6 +17,7 @@ public class DcContext {
     public final static int DC_EVENT_MSG_READ                    = 2015;
     public final static int DC_EVENT_CHAT_MODIFIED               = 2020;
     public final static int DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED = 2021;
+    public final static int DC_EVENT_CHAT_DELETED                = 2023;
     public final static int DC_EVENT_CONTACTS_CHANGED            = 2030;
     public final static int DC_EVENT_LOCATION_CHANGED            = 2035;
     public final static int DC_EVENT_CONFIGURE_PROGRESS          = 2041;

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -80,6 +80,7 @@ public class ConversationListFragment extends BaseConversationListFragment
     DcEventCenter eventCenter = DcHelper.getEventCenter(requireActivity());
     eventCenter.addMultiAccountObserver(DcContext.DC_EVENT_INCOMING_MSG, this);
     eventCenter.addMultiAccountObserver(DcContext.DC_EVENT_MSGS_NOTICED, this);
+    eventCenter.addMultiAccountObserver(DcContext.DC_EVENT_CHAT_DELETED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_CHAT_MODIFIED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_CONTACTS_CHANGED, this);
     eventCenter.addObserver(DcContext.DC_EVENT_MSGS_CHANGED, this);
@@ -321,7 +322,10 @@ public class ConversationListFragment extends BaseConversationListFragment
 
   @Override
   public void handleEvent(@NonNull DcEvent event) {
-    if (event.getAccountId() != DcHelper.getContext(requireActivity()).getAccountId()) {
+    final int accId = event.getAccountId();
+    if (event.getId() == DcContext.DC_EVENT_CHAT_DELETED) {
+      DcHelper.getNotificationCenter(requireActivity()).removeNotifications(accId, event.getData1Int());
+    } else if (accId != DcHelper.getContext(requireActivity()).getAccountId()) {
       Activity activity = getActivity();
       if (activity instanceof ConversationListActivity) {
         ((ConversationListActivity) activity).refreshUnreadIndicator();


### PR DESCRIPTION
this needs new core with `DC_EVENT_CHAT_DELETED` to actually work as expected