### PR TITLE
check for CHANGELOG in PRs changing .java files

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,22 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    name: "Changelog check"
+    validate:
+      - do: or
+        validate:
+        - do: description
+          must_include:
+            regex: '#skip-changelog'
+        - do: and
+          validate:
+            - do: dependent
+              changed:
+                file: '**/*.java'
+                required: ['CHANGELOG.md']
+    fail:
+      - do: checks
+        status: 'action_required'
+        payload:
+          title: CHANGELOG.md might need an update
+          summary: "Please update CHANGELOG.md or add #skip-changelog to the description"


### PR DESCRIPTION
this PR checks if `CHANGELOG.md` is updated in case any `.java` file is modified. the condition can probably be more advanced, but in practise, the extension check went very well for iOS

inspiration taken from https://github.com/deltachat/deltachat-ios/pull/2515, https://github.com/deltachat/deltachat-core-rust/pull/2999 and https://github.com/deltachat/deltachat-desktop/pull/4357

documentation: https://mergeable.readthedocs.io/en/latest/configuration.html

"mergeable" needs to be added/enabled at https://github.com/deltachat/deltachat-android/settings/installations EDIT: i added it there

