### PR TITLE
no 'delete on all devices' for device messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * allow to edit messages
 * allow to delete messages for everyone
 * add menu option to easily save/unsave selected message
+* improve deletion confirmation for "Device Messages"
 
 ## v1.54.4
 2025-03

--- a/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -344,7 +344,9 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     DcMsg dcMsg = dcContext.getMsg(mediaItem.msgId);
     DcChat dcChat = dcContext.getChat(dcMsg.getChatId());
 
-    String text = getResources().getQuantityString(R.plurals.ask_delete_messages, 1, 1);
+    String text = getResources().getQuantityString(
+      dcChat.isDeviceTalk() ? R.plurals.ask_delete_messages_simple : R.plurals.ask_delete_messages,
+      1, 1);
     int positiveBtnLabel = dcChat.isSelfTalk() ? R.string.delete : R.string.delete_for_me;
     final int[] messageIds = new int[]{mediaItem.msgId};
 

--- a/src/main/java/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -75,7 +75,9 @@ public abstract class MessageSelectorFragment
       canDeleteForAll = false;
     }
 
-    String text = requireActivity().getResources().getQuantityString(R.plurals.ask_delete_messages, messageIds.length, messageIds.length);
+    String text = getActivity().getResources().getQuantityString(
+      dcChat.isDeviceTalk() ? R.plurals.ask_delete_messages_simple : R.plurals.ask_delete_messages,
+      messageIds.length, messageIds.length);
     int positiveBtnLabel = dcChat.isSelfTalk() ? R.string.delete : R.string.delete_for_me;
 
     AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity())

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -377,7 +377,7 @@
         <item quantity="one">Delete %d message on all your devices?</item>
         <item quantity="other">Delete %d messages on all your devices?</item>
     </plurals>
-    <!-- deprecated, use ask_delete_messages -->
+    <!-- Used for the deletion of Device messages -->
     <plurals name="ask_delete_messages_simple">
         <item quantity="one">Delete %d message?</item>
         <item quantity="other">Delete %d messages?</item>


### PR DESCRIPTION
do not say "Delete on all your devices"
when deleting a message in the "Device Messages" chat.

while this is a minor,
it is one of the first things the user may see,
better be correct there to not give a false first impression of correctness :)