### PR TITLE
add instructions about decoding symbols in core crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ You have 2 ways to do this:
 
 2. Or set them via environment variables.
 
+# Decoding Symbols in Crash Reports
+
+```
+$ANDROID_NDK_ROOT/ndk-stack --sym obj/local/armeabi-v7a --dump crash.txt > decoded.txt
+```
+
+`obj/local/armeabi-v7a` is the extracted path from `deltachat-gplay-release-X.X.X.apk-symbols.zip` file from https://download.delta.chat/android/symbols/
+
+Replace `armeabi-v7a` by the correct architecture the logs come from (can be guessed by trial and error)
+
 # Translations
 
 Android metadata and changelogs are translated using [Weblate](https://hosted.weblate.org/projects/deltachat/android-metadata/).


### PR DESCRIPTION
#skip-changelog