### PR TITLE
remove 'experimental, 1.36 required' hint from add-second-device

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -38,7 +38,6 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
     private ProgressBar      progressBar;
     private View             topText;
     private SVGImageView     qrImageView;
-    private View             bottomText;
     private boolean          isFinishing;
     private  Thread          prepareThread;
     private  Thread          waitThread;
@@ -56,7 +55,6 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
         progressBar = view.findViewById(R.id.progress_bar);
         topText = view.findViewById(R.id.top_text);
         qrImageView = view.findViewById(R.id.qrImage);
-        bottomText = view.findViewById(R.id.bottom_text);
         setHasOptionsMenu(true);
 
         statusLine.setText(R.string.preparing_account);
@@ -88,7 +86,6 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
                 } catch (SVGParseException e) {
                     e.printStackTrace();
                 }
-                bottomText.setVisibility(View.VISIBLE);
                 waitThread = new Thread(() -> {
                     Log.i(TAG, "##### waitForReceiver() with qr: "+dcBackupProvider.getQr());
                     dcBackupProvider.waitForReceiver();
@@ -196,7 +193,6 @@ public class BackupProviderFragment extends Fragment implements DcEventCenter.Dc
             if (hideQrCode && qrImageView.getVisibility() != View.GONE) {
                 qrImageView.setVisibility(View.GONE);
                 topText.setVisibility(View.GONE);
-                bottomText.setVisibility(View.GONE);
                 statusLine.setVisibility(View.VISIBLE);
                 progressBar.setVisibility(permille == 1000 ? View.GONE : View.VISIBLE);
             }

--- a/src/main/res/layout/activity_registration_2nd_device_qr.xml
+++ b/src/main/res/layout/activity_registration_2nd_device_qr.xml
@@ -86,16 +86,4 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"/>
 
-    <TextView
-        android:id="@+id/bottom_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/multidevice_experimental_hint"
-        android:gravity="center"
-        android:textColor="?attr/emoji_text_color"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginBottom="16dp"
-        android:textSize="16sp" />
-
 </LinearLayout>

--- a/src/main/res/layout/backup_provider_fragment.xml
+++ b/src/main/res/layout/backup_provider_fragment.xml
@@ -109,18 +109,4 @@
 		android:visibility="gone"
 		android:contentDescription="@string/qrscan_title" />
 
-	<TextView
-		android:id="@+id/bottom_text"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:text="@string/multidevice_experimental_hint"
-		android:gravity="center"
-		android:textColor="?attr/emoji_text_color"
-		android:layout_marginLeft="16dp"
-		android:layout_marginRight="16dp"
-		android:layout_marginBottom="16dp"
-		android:textSize="16sp"
-		android:visibility="gone"
-		tools:visibility="visible"/>
-
 </LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -559,6 +559,7 @@
     <string name="multidevice_receiver_needs_update">The profile you want to import is from a newer Delta Chat version.\n\nTo continue setting up second device, please update this device to the latest version of Delta Chat.</string>
     <string name="multidevice_abort">Abort setting up second device?</string>
     <string name="multidevice_abort_will_invalidate_copied_qr">This will invalidate the QR code copied to clipboard.</string>
+    <!-- deprecated -->
     <string name="multidevice_experimental_hint">(experimental, version 1.36 required)</string>
     <string name="multidevice_transfer_done_devicemsg">ℹ️ Profile transferred to your second device.</string>
     <!-- Shown beside progress bar, stay short -->
@@ -1118,6 +1119,7 @@
     <string name="explain_desktop_minimized_disabled_tray_pref" tools:ignore="TypographyDashes">Tray icon cannot be disabled as Delta Chat was started with the --minimized option.</string>
     <string name="no_spellcheck_suggestions_found">No spelling suggestions found.</string>
     <string name="show_window">Show Window</string>
+    <!-- deprecated -->
     <string name="login_socks5_experimental_warning">SOCKS5 support is currently experimental. Please use at your own risk. If you type in an address in the e-mail field, there will be DNS lookup that won\'t get tunneled through SOCKS5.</string>
 
     <!-- title of the "keybindings" dialog (for the keybindings names as such, where possible the normal command strings are used) -->


### PR DESCRIPTION
add-second-device is arguably no longer experimental, we're pointing to that options officially and often.

#skip-changelog as rewordings usually do not make it to the changelog
