### PR TITLE
improve copy-qr-code success wording

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1012,7 +1012,7 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Changed setup for %1$s.</string>
     <string name="verified_contact_required_explain">To guarantee end-to-end-encryption, you can only add contacts with a green checkmark to this group.\n\nYou may meet contacts in person and scan their QR Code to introduce them.</string>
-    <string name="copy_qr_data_success">Copied QR url to clipboard</string>
+    <string name="copy_qr_data_success">QR code copied to clipboard</string>
     <string name="mailto_dialog_header_select_chat">Select chat to send the message to</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s already has a draft message, do you want to replace it?</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1012,7 +1012,8 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Changed setup for %1$s.</string>
     <string name="verified_contact_required_explain">To guarantee end-to-end-encryption, you can only add contacts with a green checkmark to this group.\n\nYou may meet contacts in person and scan their QR Code to introduce them.</string>
-    <string name="copy_qr_data_success">QR code copied to clipboard</string>
+    <!-- deprecated -->
+    <string name="copy_qr_data_success">Copied QR url to clipboard</string>
     <string name="mailto_dialog_header_select_chat">Select chat to send the message to</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s already has a draft message, do you want to replace it?</string>


### PR DESCRIPTION
~~what is a "QR url"? thanks for a translator's hint (to avoid retranslation of all translations, once merged, ./scripts/tx-update-changed-sources.sh needs to be run)~~

EDIT: did the following and changed the string on desktop at https://github.com/deltachat/deltachat-android/pull/3697:

alternatively, we can deprecated the string (it is used as a toast on desktop), and just go for `copied_to_clipboard`, maybe that's better, don't make me think, it only matters that whatever was pasted can be copied to the app later
