### PR TITLE
feat: Remove AEAP message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * ignore click in info-messages from deleted in-chat apps
+* Disable AEAP to enable us to overhaul some things - there are big changes underway in this area, which will come in a few months
 
 ## v1.56.0
 2025-03

--- a/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -283,19 +283,7 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
         int id = item.getItemId();
 
         if (id == R.id.do_register) {
-            String oldAddr = DcHelper.getSelfAddr(this);
-            String newAddr = emailInput.getText().toString();
-            if (!TextUtils.isEmpty(oldAddr)
-                    && !TextUtils.equals(oldAddr.toLowerCase(Locale.ROOT), newAddr.toLowerCase(Locale.ROOT))) {
-                // Tell the user about AEAP if they are about to change their address
-                new AlertDialog.Builder(this)
-                        .setMessage(getString(R.string.aeap_explanation, oldAddr, newAddr))
-                        .setNegativeButton(R.string.cancel, (d, w) -> {})
-                        .setPositiveButton(R.string.perm_continue, (d, w) -> do_register())
-                        .show();
-            } else {
-                do_register();
-            }
+            do_register();
             return true;
         } else if (id == android.R.id.home) {
             // handle close button click here

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -237,7 +237,6 @@ public class DcHelper {
     dcContext.setStockTranslation(120, context.getString(R.string.qrshow_join_group_hint).replace("\"", ""));
     dcContext.setStockTranslation(121, context.getString(R.string.connectivity_not_connected));
     dcContext.setStockTranslation(122, context.getString(R.string.aeap_addr_changed));
-    dcContext.setStockTranslation(123, context.getString(R.string.aeap_explanation));
     dcContext.setStockTranslation(162, context.getString(R.string.multidevice_qr_subtitle));
     dcContext.setStockTranslation(163, context.getString(R.string.multidevice_transfer_done_devicemsg));
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -531,7 +531,7 @@
     <string name="send_message">Send Message</string>
     <!-- Placeholder %1$s will be replaced by the name of the contact changing their address. Placeholders %2$s and %3$s will be replaced by old/new email addresses. -->
     <string name="aeap_addr_changed">%1$s changed their address from %2$s to %3$s</string>
-    <!-- the explanation is shown (1) as a modal dialog with the buttons "Cancel" and "Continue" as well as (2) as a device message -->
+    <!-- deprecated -->
     <string name="aeap_explanation">You changed your email address from %1$s to %2$s.\n\nIf you now send a message to a verified group, contacts there will automatically replace the old with your new address.\n\nIt\'s highly advised to set up your old email provider to forward all emails to your new email address. Otherwise you might miss messages of contacts who did not get your new address yet.</string>
 
 


### PR DESCRIPTION
Based on #3676. AEAP is disabled in core until it is replaced by multi-transport; this PR removes the (now-wrong) info message.