### PR TITLE
hide 'show classic email' for chatmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* 'Show all email' is the default for chatmail, no need for an option
+* hide superfluous "Show Classic E-mails" advanced setting for chatmail
 
 ## v1.56.1
 2025-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat Android Changelog
 
+## Unreleased
+
+* 'Show all email' is the default for chatmail, no need for an option
+
 ## v1.56.1
 2025-03
 

--- a/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -250,6 +250,7 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     }
 
     if (dcContext.isChatmail()) {
+      showEmails.setVisible(false);
       showSystemContacts.setVisible(false);
       sentboxWatchCheckbox.setVisible(false);
       bccSelfCheckbox.setVisible(false);

--- a/src/main/res/xml/preferences_advanced.xml
+++ b/src/main/res/xml/preferences_advanced.xml
@@ -2,11 +2,8 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <ListPreference
-        android:key="pref_show_emails"
-        android:title="@string/pref_show_emails"
-        android:entries="@array/pref_show_emails_entries"
-        android:entryValues="@array/pref_show_emails_values" />
+    <Preference android:key="pref_view_log"
+        android:title="@string/pref_view_log"/>
 
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
         android:defaultValue="true"
@@ -16,9 +13,6 @@
 
     <Preference android:key="pref_self_reporting"
         android:title="@string/send_stats_to_devs"/>
-
-    <Preference android:key="pref_view_log"
-        android:title="@string/pref_view_log"/>
 
     <PreferenceCategory android:title="@string/pref_experimental_features">
 
@@ -86,6 +80,12 @@
 
         <Preference android:key="proxy_settings_button"
             android:title="@string/proxy_settings"/>
+
+        <ListPreference
+            android:key="pref_show_emails"
+            android:title="@string/pref_show_emails"
+            android:entries="@array/pref_show_emails_entries"
+            android:entryValues="@array/pref_show_emails_values" />
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="true"


### PR DESCRIPTION
moreover for non-chatmail the option is moved to the other questionable (shared account) options as "watch sent"

first item at advanced is now "Show Log" - same as on desktop and iOS

when this is merged, we should file corresponding issues/pr for desktop/ios