### PR TITLE
add stock string needed when securejoin takes longer than expected

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -252,7 +252,7 @@ public class DcHelper {
     dcContext.setStockTranslation(176, context.getString(R.string.reaction_by_you));
     dcContext.setStockTranslation(177, context.getString(R.string.reaction_by_other));
     dcContext.setStockTranslation(190, context.getString(R.string.secure_join_wait));
-    dcContext.setStockTranslation(191, context.getString(R.string.secure_join_wait_timeout));
+    dcContext.setStockTranslation(192, context.getString(R.string.secure_join_takes_longer));
   }
 
   public static File getImexDir() {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1003,7 +1003,9 @@
     <!-- placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_replies">%1$s replied, waiting for being added to the group…</string>
     <string name="secure_join_wait">Establishing guaranteed end-to-end encryption, please wait…</string>
+    <!-- deprecated -->
     <string name="secure_join_wait_timeout">Could not yet establish guaranteed end-to-end encryption, but you may already send a message.</string>
+    <string name="secure_join_takes_longer">This takes longer than expected, maybe devices are offline…\n\nHowever, the process continues in background, you can do something else 🕺</string>
     <string name="contact_verified">%1$s introduced.</string>
     <string name="contact_not_verified">Cannot establish guaranteed end-to-end encryption with %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1005,7 +1005,7 @@
     <string name="secure_join_wait">Establishing guaranteed end-to-end encryption, please wait…</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Could not yet establish guaranteed end-to-end encryption, but you may already send a message.</string>
-    <string name="secure_join_takes_longer">This takes longer than expected, maybe devices are offline…\n\nHowever, the process continues in background, you can do something else 🕺</string>
+    <string name="secure_join_takes_longer">This is taking longer than expected, maybe the contact or you are offline.\n\nHowever, the process continues in background, you can do something else…</string>
     <string name="contact_verified">%1$s introduced.</string>
     <string name="contact_not_verified">Cannot establish guaranteed end-to-end encryption with %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1005,7 +1005,7 @@
     <string name="secure_join_wait">Establishing guaranteed end-to-end encryption, please wait…</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Could not yet establish guaranteed end-to-end encryption, but you may already send a message.</string>
-    <string name="secure_join_takes_longer">This is taking longer than expected, maybe the contact or you are offline.\n\nHowever, the process continues in background, you can do something else…</string>
+    <string name="secure_join_takes_longer">That seems to take longer, maybe the contact or you are offline.\n\nHowever, the process continues in background, you can do something else…</string>
     <string name="contact_verified">%1$s introduced.</string>
     <string name="contact_not_verified">Cannot establish guaranteed end-to-end encryption with %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->


### PR DESCRIPTION
this PR is to make the string needed  for https://github.com/chatmail/core/pull/6722 translatable

there were some previous discussions about the wording at https://github.com/chatmail/core/pull/6722/files#r2022229455

the string shows up only when the securejoin process takes more than 15 seconds, here, see the second message in the screenshots:

<img width=250 src=https://github.com/user-attachments/assets/97dee6de-77cd-44a2-9b9c-1f1722f460ee>
<img width=250 src=https://github.com/user-attachments/assets/f6572f8f-82e1-4fc6-a2cb-fe2f649d1a58>
<img width=250 src=https://github.com/user-attachments/assets/440fae13-1c9d-4a31-a2c1-3d36d5aa8f67>

once this is merged, the string should be pushed to transifex and used on desktop/ios as well

ftr: i did not change the existing string as a new ID is anyway needed and to avoid confusion and to allow smooth transition in other clients

#skip-changelog as the visible change comes from core update