### PR TITLE
remove misleading 'App Access' headline

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -744,7 +744,8 @@
     <string name="pref_use_system_emoji_explain">Turn off Delta Chat\'s built-in emoji support</string>
     <string name="pref_show_system_contacts">Read System Address Book</string>
     <string name="pref_show_system_contacts_explain">Offer to create chats with contacts from the address book. Some providers need end-to-end encryption setup first.</string>
-    <string name="pref_app_access">System Integration</string>
+    <!-- deprecated -->
+    <string name="pref_app_access">App Access</string>
     <string name="pref_chats">Chats</string>
     <string name="pref_in_chat_sounds">In-Chat Sounds</string>
     <string name="pref_view_log">View Log</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -744,7 +744,7 @@
     <string name="pref_use_system_emoji_explain">Turn off Delta Chat\'s built-in emoji support</string>
     <string name="pref_show_system_contacts">Read System Address Book</string>
     <string name="pref_show_system_contacts_explain">Offer to create chats with contacts from the address book. Some providers need end-to-end encryption setup first.</string>
-    <string name="pref_app_access">App Access</string>
+    <string name="pref_app_access">System Integration</string>
     <string name="pref_chats">Chats</string>
     <string name="pref_in_chat_sounds">In-Chat Sounds</string>
     <string name="pref_view_log">View Log</string>

--- a/src/main/res/xml/preferences_advanced.xml
+++ b/src/main/res/xml/preferences_advanced.xml
@@ -42,7 +42,7 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/pref_app_access">
+    <PreferenceCategory>
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"


### PR DESCRIPTION
'App Access' is not about webxdc as the other options few lines above, therefore quite misleading.

i tried first a rewording, only to have _some_ headline, but i think, it is better to not try to get an artificial headline, layout is okay, no one will care :)

<img size=250 src=https://github.com/user-attachments/assets/dcaedd29-6cf9-42ee-8063-fbe72a05035e>

nb: for non-chatmail, also "read address book" goes there

#skip-changelog 