### PR TITLE
feat: In ndk-make.sh, support custom CARGO_TARGET_DIR

### DIFF
--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -65,6 +65,10 @@ if test -z "$NDK_HOST_TAG"; then
     NDK_HOST_TAG="$KERNEL-$ARCH"
 fi
 
+if test -z "$CARGO_TARGET_DIR"; then
+    CARGO_TARGET_DIR=target
+fi
+
 unset RUSTFLAGS
 
 TOOLCHAIN="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$NDK_HOST_TAG"
@@ -120,7 +124,7 @@ if test -z $1 || test $1 = armeabi-v7a; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target armv7-linux-androideabi -p deltachat_ffi
-    cp target/armv7-linux-androideabi/$RELEASE/libdeltachat.a $jnidir/armeabi-v7a
+    cp $CARGO_TARGET_DIR/armv7-linux-androideabi/$RELEASE/libdeltachat.a $jnidir/armeabi-v7a
 fi
 
 if test -z $1 || test $1 = arm64-v8a; then
@@ -129,7 +133,7 @@ if test -z $1 || test $1 = arm64-v8a; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target aarch64-linux-android -p deltachat_ffi
-    cp target/aarch64-linux-android/$RELEASE/libdeltachat.a $jnidir/arm64-v8a
+    cp $CARGO_TARGET_DIR/aarch64-linux-android/$RELEASE/libdeltachat.a $jnidir/arm64-v8a
 fi
 
 if test -z $1 || test $1 = x86; then
@@ -138,7 +142,7 @@ if test -z $1 || test $1 = x86; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target i686-linux-android -p deltachat_ffi
-    cp target/i686-linux-android/$RELEASE/libdeltachat.a $jnidir/x86
+    cp $CARGO_TARGET_DIR/i686-linux-android/$RELEASE/libdeltachat.a $jnidir/x86
 fi
 
 if test -z $1 || test $1 = x86_64; then
@@ -147,7 +151,7 @@ if test -z $1 || test $1 = x86_64; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target x86_64-linux-android -p deltachat_ffi
-    cp target/x86_64-linux-android/$RELEASE/libdeltachat.a $jnidir/x86_64
+    cp $CARGO_TARGET_DIR/x86_64-linux-android/$RELEASE/libdeltachat.a $jnidir/x86_64
 fi
 
 rm -fr "$TMPLIB"

--- a/scripts/ndk-make.sh
+++ b/scripts/ndk-make.sh
@@ -124,7 +124,7 @@ if test -z $1 || test $1 = armeabi-v7a; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target armv7-linux-androideabi -p deltachat_ffi
-    cp $CARGO_TARGET_DIR/armv7-linux-androideabi/$RELEASE/libdeltachat.a $jnidir/armeabi-v7a
+    cp "$CARGO_TARGET_DIR/armv7-linux-androideabi/$RELEASE/libdeltachat.a" "$jnidir/armeabi-v7a"
 fi
 
 if test -z $1 || test $1 = arm64-v8a; then
@@ -133,7 +133,7 @@ if test -z $1 || test $1 = arm64-v8a; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target aarch64-linux-android -p deltachat_ffi
-    cp $CARGO_TARGET_DIR/aarch64-linux-android/$RELEASE/libdeltachat.a $jnidir/arm64-v8a
+    cp "$CARGO_TARGET_DIR/aarch64-linux-android/$RELEASE/libdeltachat.a" "$jnidir/arm64-v8a"
 fi
 
 if test -z $1 || test $1 = x86; then
@@ -142,7 +142,7 @@ if test -z $1 || test $1 = x86; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target i686-linux-android -p deltachat_ffi
-    cp $CARGO_TARGET_DIR/i686-linux-android/$RELEASE/libdeltachat.a $jnidir/x86
+    cp "$CARGO_TARGET_DIR/i686-linux-android/$RELEASE/libdeltachat.a" "$jnidir/x86"
 fi
 
 if test -z $1 || test $1 = x86_64; then
@@ -151,7 +151,7 @@ if test -z $1 || test $1 = x86_64; then
     TARGET_AR="$TOOLCHAIN/bin/llvm-ar" \
     TARGET_RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
     cargo build $RELEASEFLAG --target x86_64-linux-android -p deltachat_ffi
-    cp $CARGO_TARGET_DIR/x86_64-linux-android/$RELEASE/libdeltachat.a $jnidir/x86_64
+    cp "$CARGO_TARGET_DIR/x86_64-linux-android/$RELEASE/libdeltachat.a" "$jnidir/x86_64"
 fi
 
 rm -fr "$TMPLIB"


### PR DESCRIPTION
Running ndk-make.sh triggers a complete rust rebuild, because some compiler flags are changed. Then when you run a normal cargo command again (`cargo check` etc.), there is another rebuild. My solution is to locally change the target directory. This PR makes ndk-make.sh support such custom target directories.

If others are bugged by the same problem as me, we could consider to even always set `CARGO_TARGET_DIR=.cache/ndkmake`.

<details><summary>Details</summary>
<p>

This is how I quickly build&install core for Android:

```bash
nmake () {
	(
		cd ../..
		nix develop --command bash -c "CARGO_TARGET_DIR=.cache/ndkmake scripts/ndk-make.sh --debug arm64-v8a && ./gradlew installFossDebug"
		notify-send "Install finished"
	)
}
```

</p>
</details> 