### PR TITLE
add a hint to 'Add Second Device' for ASM

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -861,11 +861,13 @@
 
     <!-- autocrypt -->
     <string name="autocrypt_send_asm_title">Send Autocrypt Setup Message</string>
-    <string name="autocrypt_send_asm_explain_before">An Autocrypt Setup Message securely shares your end-to-end setup with other Autocrypt-compliant apps.\n\nThe setup will be encrypted by a setup code displayed here and must be typed on the other device.</string>
+    <string name="autocrypt_send_asm_explain_before">An Autocrypt Setup Message securely shares your end-to-end setup with other Autocrypt-compliant apps.\n\nIf you use Delta Chat on the other device as well, use \"Settings / Add Second Device\" instead.</string>
     <string name="autocrypt_send_asm_button">Send Autocrypt Setup Message</string>
     <string name="autocrypt_send_asm_explain_after">Your setup has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:</string>
     <string name="autocrypt_prefer_e2ee">Prefer End-To-End Encryption</string>
+    <!-- deprecated -->
     <string name="autocrypt_asm_subject">Autocrypt Setup Message</string>
+    <!-- deprecated -->
     <string name="autocrypt_asm_general_body">This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\nTo decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.</string>
 
 


### PR DESCRIPTION
this PR adds a hint to "Add Second Device" to the confirmation dialog when sending ASM.

counterpart of https://github.com/chatmail/core/pull/6777

<img width=320 src=https://github.com/user-attachments/assets/88d6da42-1515-4395-af7f-4f6b0fe852f0>
