### PR TITLE
 Experiment: Use blocking JsonRPC call 

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -2045,3 +2045,14 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcJsonrpcInstance_getNextResponse(JNIE
     dc_str_unref(temp);
     return ret;
 }
+
+
+JNIEXPORT jstring Java_com_b44t_messenger_DcJsonrpcInstance_blockingCall(JNIEnv *env, jobject obj, jstring request)
+{
+CHAR_REF(request);
+char* temp = dc_jsonrpc_blocking_call(get_dc_jsonrpc_instance(env, obj), requestPtr);
+CHAR_UNREF(request);
+jstring ret = JSTRING_NEW(temp);
+dc_str_unref(temp);
+return ret;
+}

--- a/src/main/java/com/b44t/messenger/DcJsonrpcInstance.java
+++ b/src/main/java/com/b44t/messenger/DcJsonrpcInstance.java
@@ -14,6 +14,7 @@ public class DcJsonrpcInstance {
 
     public native void request(String request);
     public native String getNextResponse();
+    public native String blockingCall(String request);
 
     // working with raw c-data
     private long        jsonrpcInstanceCPtr;    // CAVE: the name is referenced in the JNI

--- a/src/main/java/org/thoughtcrime/securesms/search/SearchListAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/search/SearchListAdapter.java
@@ -104,7 +104,7 @@ class SearchListAdapter extends BaseConversationListAdapter<SearchListAdapter.Se
   public long getHeaderId(int position) {
     if (getConversationResult(position) != null) {
       return TYPE_CHATS;
-    } else if (getContactResult(position) != null) {
+    } else if (position >= getFirstContactIndex() && position < getFirstMessageIndex()) {
       return TYPE_CONTACTS;
     } else {
       return TYPE_MESSAGES;
@@ -172,6 +172,7 @@ class SearchListAdapter extends BaseConversationListAdapter<SearchListAdapter.Se
   private Contact getContactResult(int position) {
     if (position >= getFirstContactIndex() && position < getFirstMessageIndex()) {
       try {
+        dcContext.getContact(searchResult.getContacts()[position - getFirstContactIndex()]);
         return rpc.getContact(dcContext.getAccountId(), searchResult.getContacts()[position - getFirstContactIndex()]);
       } catch (RpcException e) {
         Log.e(TAG, "error in Rpc.getContact", e);


### PR DESCRIPTION
I wanted to try out how fast a blocking JsonRPC API would be. The performance advantage isn't big enough to be immediately visible, at least.

<details><summary>I also added some more logging to core</summary>
<p>

```diff
diff --git a/deltachat-jsonrpc/src/api.rs b/deltachat-jsonrpc/src/api.rs
index e60be8a23..5b83c65ae 100644
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1418,11 +1418,16 @@ async fn get_contact(&self, account_id: u32, contact_id: u32) -> Result<ContactO
         let ctx = self.get_context(account_id).await?;
         let contact_id = ContactId::new(contact_id);
 
-        ContactObject::try_from_dc_contact(
+        let start = std::time::Instant::now();
+        let get_by_id = deltachat::contact::Contact::get_by_id(&ctx, contact_id).await?;
+        info!(&ctx, "HOCURI get_by_id took {:?}", start.elapsed());
+        let res = ContactObject::try_from_dc_contact(&ctx, get_by_id).await;
+        info!(
             &ctx,
-            deltachat::contact::Contact::get_by_id(&ctx, contact_id).await?,
-        )
-        .await
+            "HOCURI get_contact in total took {:?}",
+            start.elapsed()
+        );
+        res
     }
 
     /// Add a single contact as a result of an explicit user action.
```

</p>
</details> 

In a random, somewhat representative sample,

- Calling `toJson()` in Java takes 236µs
- Loading the contact from the database takes 274.479µs
- Converting to Json with `ContactObject::try_from_dc_contact` in Rust then takes 379µs, so that the total `get_contact()` function in api.rs takes  653.125µs
- The total `blockingCall()` function takes 1050µs, the difference to the 653.125µs is probably encoding & decoding the request as Json
- Then there are two `fromJson()` calls in Java, which together take 615µs.

So, a _lot_ of time spent encoding & decoding Json.

<details><summary>Raw Output which only makes sense if you read the source</summary>
<p>

```
[415]toJson, now 236micros
[accId=3] deltachat-jsonrpc/src/api.rs:1423: HOCURI get_by_id took 274.479µs
[accId=3] deltachat-jsonrpc/src/api.rs:1425: HOCURI get_contact in total took 653.125µs
[415]blockingCall, now 1286micros
[415]fromJson#1, now 1632micros
[415]fromJson#2, now 1901micros
```


</p>
</details> 