### PR TITLE
fix selfName if displayname is not set, avoid breaking apps layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat Android Changelog
 
+## Unreleased
+
+* fix: webxdc.selfName uses the name otherwise displayed
+
 ## v1.58.2
 2025-04
 

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -527,11 +527,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     /** @noinspection unused*/
     @JavascriptInterface
     public String selfName() {
-      String name = WebxdcActivity.this.dcContext.getConfig("displayname");
-      if (TextUtils.isEmpty(name)) {
-        name = selfAddr();
-      }
-      return name;
+      return WebxdcActivity.this.dcContext.getName();
     }
 
     /** @noinspection unused*/


### PR DESCRIPTION
classic onboarding allows not setting a displayname on purpose, however, that results in broken webxdc layouts
as the name is then replaced by a 40-or-so-chars-hash-without-spaces.

one can argue, that apps should handle that gracefully, but most do not and just look buggy.

it seems reasonable,
to use the email address in that case,
same as we do at other places if the name is unknwon. (tbh, i thought it was like that, but i mixed sth up in OS comparison). this was also the situation before we changed selfAddr calculation, btw. it is anyway a cornercase, webxdc cannot send the address somewhere nor can correlate reasonably, and if the user sets a name, things are fine (and more often than not we nudge user to set one :)

cmp https://github.com/deltachat/deltachat-desktop/issues/5022