### PR TITLE
fix crash in JSONRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * fix: webxdc.selfName uses the name otherwise displayed
+* fix potential crash on startup
 
 ## v1.58.2
 2025-04

--- a/src/main/java/com/b44t/messenger/rpc/Rpc.java
+++ b/src/main/java/com/b44t/messenger/rpc/Rpc.java
@@ -30,9 +30,13 @@ public class Rpc {
 
     private void processResponse() throws JsonSyntaxException {
         String jsonResponse = dcJsonrpcInstance.getNextResponse();
-        Response response = gson.fromJson(jsonResponse, Response.class);
 
-        if (response == null || response.id == 0) { // Got JSON-RPC notification/event, ignore
+        Response response = gson.fromJson(jsonResponse, Response.class);
+        if (response == null) {
+            Log.e(TAG, "Error parsing JSON: " + jsonResponse);
+            return;
+        } else if (response.id == 0) {
+            // Got JSON-RPC notification/event, ignore
             return;
         }
 

--- a/src/main/java/com/b44t/messenger/rpc/Rpc.java
+++ b/src/main/java/com/b44t/messenger/rpc/Rpc.java
@@ -32,7 +32,7 @@ public class Rpc {
         String jsonResponse = dcJsonrpcInstance.getNextResponse();
         Response response = gson.fromJson(jsonResponse, Response.class);
 
-        if (response.id == 0) { // Got JSON-RPC notification/event, ignore
+        if (response == null || response.id == 0) { // Got JSON-RPC notification/event, ignore
             return;
         }
 
@@ -63,7 +63,7 @@ public class Rpc {
             while (true) {
                 try {
                     processResponse();
-                } catch (JsonSyntaxException e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }


### PR DESCRIPTION
the fix could have been avoid by checking for null or not being overly specific with the exception.

as this is a very sensible area,
where any failure is dramatic,
we do both.

as said, this error pops up on monikas device,
unclear if related to an app update (she is on 1.58.2) or by some message.

~~did not test yet, still trying to get this patch on the phone~~ EDIT: tested, it fixes the issue at hand