### PR TITLE
avoid causing and logging exception in getWebxdcInfo

### DIFF
--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -142,11 +142,12 @@ public class DcMsg {
     public native byte[]  getWebxdcBlob      (String filename);
     public JSONObject     getWebxdcInfo      () {
       try {
-        return new JSONObject(getWebxdcInfoJson());
+        String json = getWebxdcInfoJson();
+        if (json != null && !json.isEmpty()) return new JSONObject(json);
       } catch(Exception e) {
         e.printStackTrace();
-        return new JSONObject();
       }
+      return new JSONObject();
     }
     public native String  getWebxdcHref      ();
     public native boolean isForwarded        ();


### PR DESCRIPTION
 if getWebxdcInfoJson returns empty string don't pollute the logs


#skip-changelog