### PR TITLE
remove redundant subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat Android Changelog
 
+## Unreleased
+
+* Clearer app lists by removing redundant "App" subtitle
+
 ## v1.58.4
 2025-05
 

--- a/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsAdapter.java
@@ -102,6 +102,7 @@ class ProfileDocumentsAdapter extends StickyHeaderGridAdapter {
       viewHolder.audioView.setOnLongClickListener(view -> { itemClickListener.onMediaLongClicked(dcMsg); return true; });
       viewHolder.audioView.disablePlayer(!selected.isEmpty());
       viewHolder.itemView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));
+      viewHolder.date.setVisibility(View.VISIBLE);
     }
     else if (slide != null && slide.isWebxdcDocument()) {
       viewHolder.audioView.setVisibility(View.GONE);
@@ -112,6 +113,7 @@ class ProfileDocumentsAdapter extends StickyHeaderGridAdapter {
       viewHolder.webxdcView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));
       viewHolder.webxdcView.setOnLongClickListener(view -> { itemClickListener.onMediaLongClicked(dcMsg); return true; });
       viewHolder.itemView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));
+      viewHolder.date.setVisibility(View.GONE);
     }
     else if (slide != null && slide.hasDocument()) {
       viewHolder.audioView.setVisibility(View.GONE);
@@ -122,11 +124,13 @@ class ProfileDocumentsAdapter extends StickyHeaderGridAdapter {
       viewHolder.documentView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));
       viewHolder.documentView.setOnLongClickListener(view -> { itemClickListener.onMediaLongClicked(dcMsg); return true; });
       viewHolder.itemView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));
+      viewHolder.date.setVisibility(View.VISIBLE);
     }
     else {
       viewHolder.documentView.setVisibility(View.GONE);
       viewHolder.audioView.setVisibility(View.GONE);
       viewHolder.webxdcView.setVisibility(View.GONE);
+      viewHolder.date.setVisibility(View.GONE);
     }
 
     viewHolder.itemView.setOnLongClickListener(view -> { itemClickListener.onMediaLongClicked(dcMsg); return true; });

--- a/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileDocumentsAdapter.java
@@ -108,7 +108,7 @@ class ProfileDocumentsAdapter extends StickyHeaderGridAdapter {
       viewHolder.documentView.setVisibility(View.GONE);
 
       viewHolder.webxdcView.setVisibility(View.VISIBLE);
-      viewHolder.webxdcView.setWebxdc(dcMsg, context.getString(R.string.webxdc_app));
+      viewHolder.webxdcView.setWebxdc(dcMsg, "");
       viewHolder.webxdcView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));
       viewHolder.webxdcView.setOnLongClickListener(view -> { itemClickListener.onMediaLongClicked(dcMsg); return true; });
       viewHolder.itemView.setOnClickListener(view -> itemClickListener.onMediaClicked(dcMsg));

--- a/src/main/java/org/thoughtcrime/securesms/components/WebxdcView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/WebxdcView.java
@@ -86,7 +86,12 @@ public class WebxdcView extends FrameLayout {
     if (summary.isEmpty()) {
       summary = defaultSummary;
     }
-    appSubtitle.setText(summary);
+    if (summary.isEmpty()) {
+      appSubtitle.setVisibility(View.GONE);
+    } else {
+      appSubtitle.setVisibility(View.VISIBLE);
+      appSubtitle.setText(summary);
+    }
   }
 
   public String getDescription() {


### PR DESCRIPTION
there is no need to say "App" beside every app in the app list.

moreover, for uncluttered list, the time is removed as well - it is ambigious anyway, see commit message for more reasoning (also  the "Today" header is questionable here, btw. apps may be added months ago and are still super-recent, we are considering to sort the list by recently updated, therefore, let's leave that part unchanged for now)

with icon, name, summary and document name, there are already enough information :)

counterpart of https://github.com/deltachat/deltachat-ios/pull/2721

<img width=320 src=https://github.com/user-attachments/assets/5c464b05-f1c2-4c81-902f-aa06593c9ca6>

