### PR TITLE
unify singular/plural in attach menu

### DIFF
--- a/src/main/res/layout/attachment_type_selector.xml
+++ b/src/main/res/layout/attachment_type_selector.xml
@@ -197,7 +197,7 @@
                         android:layout_height="53dp"
                         android:src="@drawable/ic_apps_24"
                         android:scaleType="center"
-                        android:contentDescription="@string/webxdc_apps"
+                        android:contentDescription="@string/webxdc_app"
                         app:circleColor="@color/apps_icon"
                         />
 
@@ -205,7 +205,7 @@
                           android:layout_width="wrap_content"
                           android:layout_height="wrap_content"
                           style="@style/AttachmentTypeLabel"
-                          android:text="@string/webxdc_apps"/>
+                          android:text="@string/webxdc_app"/>
 
             </LinearLayout>
 


### PR DESCRIPTION
also otherwise, we say "[attach] Contact", "[attach] File", "[attach] Video" etc. - so it should be "[attach] App" as well.

this is also what desktop/iOS are doing.

the title in the app picker itself, however,
is fine with reading "Apps" - it shows multiple ones