### PR TITLE
reword 'Shared Chats' to 'Chats in Common'

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -511,7 +511,7 @@
     <string name="group_add_members">Add Members</string>
     <string name="group_self_not_in_group">You must be a member of the group to perform this action.</string>
     <string name="profile_encryption">Encryption</string>
-    <string name="profile_shared_chats">Shared Chats</string>
+    <string name="profile_shared_chats">Chats in Common</string>
     <string name="related_chats">Related Chats</string>
     <!-- Separator between the list of actual members and past members -->
     <string name="past_members">Past Members</string>


### PR DESCRIPTION
this PR rewords "Shared Chats" to "Chats in Common" as discussed recently in a one-to-one meeting.

- the old wording is easily mixed with the action of actively sharing sth ("Share to Delta", "Share From Delta")

- "Chats in Common" is also used by other larger messengers, so quite known to the user

a follow-up to update the help is needed
