### PR TITLE
fix: Small channel fixes

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileActivity.java
@@ -334,7 +334,10 @@ public class ProfileActivity extends PassphraseRequiredActionBarActivity
       Intent intent = new Intent(this, MediaPreviewActivity.class);
       intent.setDataAndType(profileImageUri, type);
       intent.putExtra(MediaPreviewActivity.ACTIVITY_TITLE_EXTRA, title);
-      intent.putExtra(MediaPreviewActivity.EDIT_AVATAR_CHAT_ID, chatIsMultiUser ? chatId : 0); // shows edit-button, might be 0 for a contact-profile
+      intent.putExtra( // show edit-button, might be 0 for a contact-profile
+              MediaPreviewActivity.EDIT_AVATAR_CHAT_ID,
+              (chatIsMultiUser && !chatIsInBroadcast) ? chatId : 0
+      );
       startActivity(intent);
     } else if (chatIsMultiUser){
       onEditName();

--- a/src/main/java/org/thoughtcrime/securesms/ProfileAvatarItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileAvatarItem.java
@@ -61,8 +61,6 @@ public class ProfileAvatarItem extends LinearLayout implements RecipientModified
         subtitle = dcChat.getMailinglistAddr();
       } else if (dcChat.isOutBroadcast()) {
         subtitle = getContext().getResources().getQuantityString(R.plurals.n_recipients, memberCount, memberCount);
-      } else if (dcChat.isInBroadcast()) {
-        subtitle = getContext().getString(R.string.contact);
       } else if (dcChat.getType() == DcChat.DC_CHAT_TYPE_GROUP) {
         subtitle = getContext().getResources().getQuantityString(R.plurals.n_members, memberCount, memberCount);
       }


### PR DESCRIPTION
Follow-up for #3783, part of https://github.com/chatmail/core/issues/6884.

- In the profile view of an InBroadcast, the subtitle said "Contact". I just removed the subtitle, because it already says "Channel" at the top.
- When tapping on the avatar of an InBroadcast, an "Edit" button was shown

#skip-changelog because this was not released.