### PR TITLE
allow to "move to top" accounts in the accounts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 * Improved separation between unencryted chats/contacts and encrypted ones, avoiding mixing of encrypted and unencrypted messages in the same chat
 * Removed padlocks, as encrypted is the default "normal" state. Instead, unencrypted email is marked with a small email / letter  (✉️) icon
 * Classic email chats/threads get a big email / letter icon making it easy to recognize
-* Update to core 2.0.0
+* Allow to sort profiles up in the profile switcher
+* Update to core 2.1.0
 
 ## v1.58.4
 2025-05

--- a/src/main/java/com/b44t/messenger/rpc/Rpc.java
+++ b/src/main/java/com/b44t/messenger/rpc/Rpc.java
@@ -164,6 +164,10 @@ public class Rpc {
         return gson.fromJson(getResult("create_broadcast", accountId, chatName), Integer.class);
     }
 
+    public void setAccountsOrder(List<Integer> order) throws RpcException {
+        getResult("set_accounts_order", order);
+    }
+
     private static class Request {
         private final String jsonrpc = "2.0";
         public final String method;

--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
@@ -41,6 +41,8 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
+import java.util.Arrays;
+
 public class AccountSelectionListFragment extends DialogFragment implements DcEventCenter.DcEventDelegate
 {
   private static final String TAG = AccountSelectionListFragment.class.getSimpleName();
@@ -134,7 +136,33 @@ public class AccountSelectionListFragment extends DialogFragment implements DcEv
       onToggleMute(accountId);
     } else if (itemId == R.id.menu_set_tag) {
       onSetTag(accountId);
+    } else if (itemId == R.id.menu_move_to_top) {
+      onMoveToTop(accountId);
     }
+  }
+
+  private void onMoveToTop(int accountId) {
+    Activity activity = getActivity();
+    if (activity == null) return;
+
+    int[] accountIds = DcHelper.getAccounts(activity).getAll();
+    Integer[] ids = new Integer[accountIds.length];
+    ids[0] = accountId;
+    int j = 1;
+    for (int accId : accountIds) {
+      if (accId != accountId) {
+        ids[j++] = accId;
+      }
+    }
+
+    Rpc rpc = DcHelper.getRpc(activity);
+    try {
+      rpc.setAccountsOrder(Arrays.asList(ids));
+    } catch (RpcException e) {
+      Log.e(TAG, "Error calling rpc.setAccountsOrder()", e);
+    }
+
+    refreshData();
   }
 
   private void onSetTag(int accountId) {

--- a/src/main/res/menu/account_item_context.xml
+++ b/src/main/res/menu/account_item_context.xml
@@ -8,6 +8,9 @@
   <item android:title="@string/profile_tag"
       android:id="@+id/menu_set_tag"/>
 
+  <item android:title="@string/move_to_top"
+        android:id="@+id/menu_move_to_top"/>
+
   <item android:title="@string/delete"
         android:id="@+id/delete"/>
 


### PR DESCRIPTION
this uses the new `set_accounts_order` JSON-RPC API introduced in https://github.com/chatmail/core/pull/6993

- [x] expose `set_accounts_order` via `Rpc.setAccountsOrder()`
- [x] add "move to top" option to account's context menu and use `Rpc.setAccountsOrder()`
- [x] wait for new core release with `set_accounts_order` support
- [x] update changelog