### PR TITLE
don't use FetchWorker if we have push notifications

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -197,30 +197,30 @@ public class ApplicationContext extends MultiDexApplication {
         }
     }, filter);
 
-    // MAYBE TODO: i think the ApplicationContext is also created
-    // when the app is stated by FetchWorker timeouts.
-    // in this case, the normal threads shall not be started.
-    Constraints constraints = new Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build();
-    PeriodicWorkRequest fetchWorkRequest = new PeriodicWorkRequest.Builder(
-            FetchWorker.class,
-            PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS, // usually 15 minutes
-            TimeUnit.MILLISECONDS,
-            PeriodicWorkRequest.MIN_PERIODIC_FLEX_MILLIS, // the start may be preferred by up to 5 minutes, so we run every 10-15 minutes
-            TimeUnit.MILLISECONDS)
-            .setConstraints(constraints)
-            .build();
-    WorkManager.getInstance(this).enqueueUniquePeriodicWork(
-            "FetchWorker",
-            ExistingPeriodicWorkPolicy.KEEP,
-            fetchWorkRequest);
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
     if (Prefs.isPushEnabled(this)) {
       FcmReceiveService.register(this);
     } else {
       Log.i(TAG, "FCM disabled at build time");
+      // MAYBE TODO: i think the ApplicationContext is also created
+      // when the app is stated by FetchWorker timeouts.
+      // in this case, the normal threads shall not be started.
+      Constraints constraints = new Constraints.Builder()
+              .setRequiredNetworkType(NetworkType.CONNECTED)
+              .build();
+      PeriodicWorkRequest fetchWorkRequest = new PeriodicWorkRequest.Builder(
+              FetchWorker.class,
+              PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS, // usually 15 minutes
+              TimeUnit.MILLISECONDS,
+              PeriodicWorkRequest.MIN_PERIODIC_FLEX_MILLIS, // the start may be preferred by up to 5 minutes, so we run every 10-15 minutes
+              TimeUnit.MILLISECONDS)
+              .setConstraints(constraints)
+              .build();
+      WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+              "FetchWorker",
+              ExistingPeriodicWorkPolicy.KEEP,
+              fetchWorkRequest);
     }
   }
 


### PR DESCRIPTION
`FetchWorker` was polluting the logs and adding confusion while trying to figure out https://github.com/chatmail/core/issues/6477

on top of that the whole class is a bit of a deprecated approach from when we didn't have push notifications nor "background fetch API" so it is just a dummy class sleeping for some seconds without knowing if core really finished fetching etc., also not sure how good it actually works, because if such "periodically schedule jobs" API would actually work we wouldn't need so much push notifications, probably the app doesn't really get woke up in several devices, I was considering to remove it completely initially, however to avoid unexpected deterioration for f-droid users I decided to keep it if push notifications are not available, it will not hurt to at least try that woke up method as last resort in that case