### PR TITLE
Update Android SDK Build Tools to 35.0.0 in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         pkgs = import nixpkgs { inherit system overlays; };
         android-sdk = android.sdk.${system} (sdkPkgs:
           with sdkPkgs; [
-            build-tools-34-0-0
+            build-tools-35-0-0
             cmdline-tools-latest
             platform-tools
             platforms-android-34


### PR DESCRIPTION
Since buildToolsVersion is not specified in `build.gradle`, default version is set by Android Gradle Plugin.
Gradle plugin was updated in a77b1a5dd66fd30267e01c9ee97152d53240cc62, so build tools version should be updated in flake.nix to the corresponding version, otherwise building
fails while trying to install 35.0.0 into
read-only path managed by Nix.