### PR TITLE
improve info messages for dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat Android Changelog
 
+## Unreleased
+
+* Improve readability of info messages in dark mode
+
 ## v2.11.0
 2025-08
 

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -189,7 +189,7 @@
         <item name="conversation_item_outgoing_text_secondary_color">@color/light_pink</item>
 
         <item name="conversation_item_update_bg_color">@color/universal_overlay</item>
-        <item name="conversation_item_update_text_color">@color/core_light_35</item>
+        <item name="conversation_item_update_text_color">@color/white</item>
 
         <item name="conversation_item_sent_indicator_text_background">@drawable/conversation_item_sent_indicator_text_shape_dark</item>
         <item name="conversation_item_date_line_color">@color/core_dark_55</item>


### PR DESCRIPTION
this improves readability of info messages
by setting the foreground to while.
`universal_overlay` was made for that;
it is in use like that on iOS/desktop since a long time.

moreover, other parts using the combination of
`conversation_item_update_bg_color`/`conversation_item_update_text_color` are improved equally, eg. the day titles.

before / after using the standard background:

<img width="390" height="402" alt="Screenshot 2025-08-16 at 16 55 56" src="https://github.com/user-attachments/assets/390a0b70-9495-4ce0-aebf-bce16cff7749" /> &nbsp; <img width="390" height="402" alt="Screenshot 2025-08-16 at 16 55 29" src="https://github.com/user-attachments/assets/2020dda7-5971-454e-adde-b16e6a6153f4" />

before after using a harder background:

<img width="390" height="402" alt="Screenshot 2025-08-16 at 16 49 07" src="https://github.com/user-attachments/assets/8a3485d9-3dab-41fd-be78-3a7e35884ca9" /> &nbsp; <img width="390" height="402" alt="Screenshot 2025-08-16 at 16 49 36" src="https://github.com/user-attachments/assets/b8da0eb2-d356-48b0-a63f-206f63858cf0" />


