### PR TITLE
fix direct share shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * target Android 15
-* Improve readability of info messages in dark mode
+* improve readability of info messages in dark mode
+* fix Direct Share shortcuts
 
 ## v2.11.0
 2025-08

--- a/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
@@ -32,6 +32,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.pm.ShortcutManagerCompat;
 
 import com.b44t.messenger.DcContext;
 
@@ -208,6 +209,16 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
   private void handleResolvedMedia(Intent intent) {
     int       accId            = intent.getIntExtra(EXTRA_ACC_ID, -1);
     int       chatId           = intent.getIntExtra(EXTRA_CHAT_ID, -1);
+
+    // the intent coming from shortcuts in the share selector might not include the custom extras but the shortcut ID
+    String shortcutId = intent.getStringExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID);
+    if ((chatId == -1 || accId == -1) && shortcutId != null && shortcutId.startsWith("chat-")) {
+      String[] args = shortcutId.split("-");
+      if (args.length == 3) {
+        accId = Integer.parseInt(args[1]);
+        chatId = Integer.parseInt(args[2]);
+      }
+    }
 
     String[] extraEmail = getIntent().getStringArrayExtra(Intent.EXTRA_EMAIL);
     /*

--- a/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
@@ -128,7 +128,7 @@ public class DirectShareUtil {
 
       Recipient recipient = new Recipient(context, chat);
       Bitmap avatar = getIconForShortcut(context, recipient);
-      results.add(new ShortcutInfoCompat.Builder(context, Integer.toString(chat.getId()))
+      results.add(new ShortcutInfoCompat.Builder(context, "chat-" + dcContext.getAccountId() + "-" + chat.getId())
               .setShortLabel(chat.getName())
               .setLongLived(true)
               .setRank(i+1)


### PR DESCRIPTION
close #3853 

this problem was introduced in https://github.com/deltachat/deltachat-android/pull/3558 (in [this lines](https://github.com/deltachat/deltachat-android/pull/3558/files#diff-676161241c610355e67385e50f4acb3aba922047a8161cd134062739315f2754L211-L214))

the problem is that, at least in some devices, when the shortcut is opened from direct share, it doesn't contains the custom extras we set, but the shortcut's ID, which we need to parse then