### PR TITLE
drop disappearing messages options 1 and 30 minutes

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
+++ b/src/main/java/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
@@ -60,14 +60,12 @@ public class EphemeralMessagesDialog {
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     final long burnAfter;
                     switch (selectedChoice[0]) {
-                        case 1:  burnAfter = TimeUnit.MINUTES.toSeconds(1); break;
-                        case 2:  burnAfter = TimeUnit.MINUTES.toSeconds(5); break;
-                        case 3:  burnAfter = TimeUnit.MINUTES.toSeconds(30); break;
-                        case 4:  burnAfter = TimeUnit.HOURS.toSeconds(1); break;
-                        case 5:  burnAfter = TimeUnit.DAYS.toSeconds(1);  break;
-                        case 6:  burnAfter = TimeUnit.DAYS.toSeconds(7);  break;
-                        case 7:  burnAfter = TimeUnit.DAYS.toSeconds(35); break;
-                        case 8:  burnAfter = TimeUnit.DAYS.toSeconds(365); break;
+                        case 1:  burnAfter = TimeUnit.MINUTES.toSeconds(5); break;
+                        case 2:  burnAfter = TimeUnit.HOURS.toSeconds(1); break;
+                        case 3:  burnAfter = TimeUnit.DAYS.toSeconds(1);  break;
+                        case 4:  burnAfter = TimeUnit.DAYS.toSeconds(7);  break;
+                        case 5:  burnAfter = TimeUnit.DAYS.toSeconds(35); break;
+                        case 6:  burnAfter = TimeUnit.DAYS.toSeconds(365); break;
                         default: burnAfter = 0; break;
                     }
                     listener.onTimeSelected(burnAfter);

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -49,14 +49,12 @@
 
     <string-array name="ephemeral_message_durations">
         <!-- 0 --> <item>@string/off</item>
-        <!-- 1 --> <item>@string/after_1_minute</item>
-        <!-- 2 --> <item>@string/after_5_minutes</item>
-        <!-- 3 --> <item>@string/after_30_minutes</item>
-        <!-- 4 --> <item>@string/autodel_after_1_hour</item>
-        <!-- 5 --> <item>@string/autodel_after_1_day</item>
-        <!-- 6 --> <item>@string/autodel_after_1_week</item>
-        <!-- 7 --> <item>@string/after_5_weeks</item>
-        <!-- 8 --> <item>@string/autodel_after_1_year</item>
+        <!-- 1 --> <item>@string/after_5_minutes</item>
+        <!-- 2 --> <item>@string/autodel_after_1_hour</item>
+        <!-- 3 --> <item>@string/autodel_after_1_day</item>
+        <!-- 4 --> <item>@string/autodel_after_1_week</item>
+        <!-- 5 --> <item>@string/after_5_weeks</item>
+        <!-- 6 --> <item>@string/autodel_after_1_year</item>
     </string-array>
 
     <string-array name="mute_durations">


### PR DESCRIPTION
- with the recent change to start the timer when the chat is opened, one minute is too easy too short to miss important information

- "30 minutes" does not really fit into the distribution; all other option have at least the factor 5 to the previous one, from "30 minutes" to "60 minutes", the time is doubled only.

removing the overall number of options and dropping the ones without larger usecases, does not only simplifies UI;
having less tiny details also reduces noise in groups where ppl people changing it very often for various weird reasons (found the latter point somewhere in the Signal forum, btw)

this is a successor of the "added 1 year option", by that, apart form the "5 minutes", we are also very close to "delete old messages".

came over that when thinking https://github.com/deltachat/deltachat-pages/pull/1172 over.