### PR TITLE
add 'Save Message' string

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -471,6 +471,8 @@
     <string name="chat_no_messages">No messages.</string>
     <string name="chat_self_talk_subtitle">Messages to Self</string>
     <string name="archive_empty_hint">Archived chats will appear here.</string>
+    <!-- Action to add a message to "Saved Messages". The longer form (instead of "Save" only) is needed esp. on desktop to make clear this is not about saving a file to disk -->
+    <string name="save_message">Save Message</string>
     <string name="saved_messages">Saved Messages</string>
     <string name="saved_messages_explain">• Forward messages here for easy access\n\n• Take notes or voice memos\n\n• Attach media to save them</string>
     <!-- Should match "Saved" from "Saved messages" -->


### PR DESCRIPTION
the string can be used for the action to put a message to 'Saved Messages'.

it will be useful esp. on desktop,
where plain 'Save' often has the mindset of 'Files', esp. for older ppl :)
the added noun tries to break that.

additionally, desktop can resort menu items,
but that alone would not solve the issue.

android/ios does not really have that issue as it is far less about "Files" there, still, they can use the new string at some point.

there are also thoughs about renaming that alltogether, eg. to bookmark, but that is a larger and more breaking change, also the messages are not just 'bookmarked' on purpose, to eg. survive auto deletion.

once this is merged, we can pick the new string on desktop (maybe give it a bit time to be translated)