### PR TITLE
Recommend Lix instead of Determinate Nix Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ dcrpcgen java --schema schema.json -o ./src/main/java/
 The repository contains [Nix](https://nixos.org/) development environment
 described in `flake.nix` file.
 If you don't have Nix installed,
-the easiest way is to use [The Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer)
-which installs Nix with [Flakes](https://nixos.wiki/wiki/Flakes) feature enabled out of the box
+the easiest way is to follow the [Lix installation instructions](https://lix.systems/install/)
+as this results in a setup with [Flakes](https://nixos.wiki/wiki/Flakes) feature enabled out of the box
 and can be cleanly uninstalled with `/nix/nix-installer uninstall` once you don't need it anymore.
 
 Once you have Nix with Flakes feature set up start the development environment shell:


### PR DESCRIPTION
Determinate Systems server is installing its own fork of Nix that is apparently not open source:
<https://lobste.rs/s/be78ef/dropping_upstream_nix_from_determinate#c_m3hq6r> The company behind it also pushes the users to use FlakeHub and has other problems.

[Lix] installer is a fork of The Determinate Nix Installer. I uninstalled Nix preivously installed with The Determinate Nix Installer and installed Lix, it works just the same for Android builds.

Upstream Nix would also be fine,
but it still has old installer that does not enable Flakes and breaks on macOS on upgrades apparently,
so we cannot recommend it as the easiest way.

[Lix]: https://lix.systems/