### PR TITLE
feat: Add cant_decrypt_outgoing_msgs stock string

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -237,6 +237,7 @@ public class DcHelper {
     dcContext.setStockTranslation(172, context.getString(R.string.chat_new_group_hint));
     dcContext.setStockTranslation(173, context.getString(R.string.member_x_added));
     dcContext.setStockTranslation(174, context.getString(R.string.invalid_unencrypted_tap_to_learn_more));
+    dcContext.setStockTranslation(175, context.getString(R.string.cant_decrypt_outgoing_msgs));
     dcContext.setStockTranslation(176, context.getString(R.string.reaction_by_you));
     dcContext.setStockTranslation(177, context.getString(R.string.reaction_by_other));
     dcContext.setStockTranslation(190, context.getString(R.string.secure_join_wait));

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -928,6 +928,7 @@
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">This message cannot be decrypted.\n\n• It might already help to simply reply to this message and ask the sender to send the message again.\n\n• If you just re-installed Delta Chat then it is best if you re-setup Delta Chat now and choose "Add as second device" or import a backup.</string>
+    <string name="cant_decrypt_outgoing_msgs">⚠️ It seems you are using Delta Chat on multiple devices that cannot decrypt each other's outgoing messages. To fix this, on the older device use \"Settings / Add Second Device\" and follow the instructions.</string>
     <string name="systemmsg_unknown_sender_for_chat">Unknown sender for this chat. See \'info\' for more details.</string>
     <string name="systemmsg_subject_for_new_contact">Message from %1$s</string>
     <string name="systemmsg_failed_sending_to">Failed to send message to %1$s.</string>


### PR DESCRIPTION
This string was translatable in Core, but apparently we forgot to add it to Transifex.

Or, do we even still want to make it translatable? Since few people even know their password, it might be fine to just always show this error message in English, and remove the stock string from core?

See also https://github.com/deltachat/deltachat-desktop/pull/5587.