### PR TITLE
'Start Messaging' does no longer exist

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -678,7 +678,7 @@
     <string name="login_error_required_fields">Please enter a valid e-mail address and a password</string>
     <string name="import_backup_title">Restore from Backup</string>
     <string name="import_backup_ask">Backup found at \"%1$s\".\n\nDo you want to import and use all data and settings from it?</string>
-    <string name="import_backup_no_backup_found">No backups found.\n\nCopy the backup to \"%1$s\" and try again. Alternatively, press \"Start messaging\" to continue with the normal setup process.</string>
+    <string name="import_backup_no_backup_found">No backups found.\n\nCopy the backup to \"%1$s\" and try again.</string>
     <!-- %1$s will be replaced by the failing address -->
     <string name="login_error_cannot_login">Cannot login as \"%1$s\". Please check if the address and the password are correct.</string>
     <!-- TLS certificate checks -->


### PR DESCRIPTION
this PR removes the string 'Start Messaging' from the hint shown on failed backup import.

the button was changed since then, however, the flow is also clear without that hint and the string is anyway only used on older phones

> thanks a lot to the translator pointing to that issue

<img width="394" height="887" alt="Screenshot 2025-10-24 at 22 54 17" src="https://github.com/user-attachments/assets/829268a0-8542-4a13-8d8c-a1f3b1dccaf6" />

