### PR TITLE
don't force circle shape for shared shortcuts

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
@@ -151,11 +151,11 @@ public class DirectShareUtil {
   }
 
   private static @NonNull Bitmap getShortcutInfoBitmap(@NonNull Context context, @NonNull Recipient recipient) throws ExecutionException, InterruptedException {
-    return DrawableUtil.wrapBitmapForShortcutInfo(request(GlideApp.with(context).asBitmap(), context, recipient).circleCrop().submit().get());
+    return DrawableUtil.wrapBitmapForShortcutInfo(request(GlideApp.with(context).asBitmap(), context, recipient).submit().get());
   }
 
   private static Bitmap getFallbackDrawable(Context context, @NonNull Recipient recipient) {
-    return BitmapUtil.createFromDrawable(recipient.getFallbackAvatarDrawable(context),
+    return BitmapUtil.createFromDrawable(recipient.getFallbackAvatarDrawable(context, false),
             context.getResources().getDimensionPixelSize(android.R.dimen.notification_large_icon_width),
             context.getResources().getDimensionPixelSize(android.R.dimen.notification_large_icon_height));
   }


### PR DESCRIPTION
close #3948 

leave image unmodified as square, don't force circle shape so system can apply their icon shapes without some black areas caused by the cropped circle avatar, example in my system with "pebble" shaped icons:

<img width="1024" height="1119" alt="image" src="https://github.com/user-attachments/assets/72878ea9-3ee4-4e96-ac30-1fe52e20b5fd" />
