### PR TITLE
add dotdotdot to 'share with'

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -459,7 +459,7 @@
     <string name="chat_record_explain">Tap and hold to record a voice message, release to send</string>
     <string name="chat_no_chats_yet_title">No Chats.\nPress \"+\" to start a new chat.</string>
     <string name="chat_all_archived">All chats archived.\nPress \"+\" to start a new chat.</string>
-    <string name="chat_share_with_title">Share with</string>
+    <string name="chat_share_with_title">Share with…</string>
     <string name="chat_input_placeholder">Message</string>
     <string name="chat_archived_label">Archived</string>
     <string name="chat_request_label">Request</string>


### PR DESCRIPTION
this string is used in titles only (just checked that) and the dots are  for consistency with "Forward to…".

came over then when doing the share rework on iOS, cmp https://github.com/deltachat/deltachat-ios/pull/2890 and https://github.com/deltachat/deltachat-ios/pull/2879

once merged, ./scripts/tx-update-changed-sources.sh should be run

#skip-changelog