### PR TITLE
streamline Multi-Device Mode wording

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -818,7 +818,7 @@
     <string name="pref_watch_sent_folder">Watch Sent Folder</string>
     <!-- No need to be literal here, you can also use "Use Multiple Devices", "Support Multiple Devices" or other fitting terms. However, it should fit to the wording or your language at https://delta.chat/help  -->
     <string name="pref_send_copy_to_self">Multi-Device Mode</string>
-    <string name="pref_send_copy_to_self_explain">Exchange data for device synchronization. Automatically enabled on adding a second device</string>
+    <string name="pref_send_copy_to_self_explain">Synchronize your messages with your other devices. Automatically enabled on adding a second device</string>
     <string name="pref_multidevice_change_warn">Multi-Device Mode must be enabled when using the same profile on multiple devices. Only disable this setting if you have removed this profile from all your other devices.\n\nDisabling Multi-Device Mode while using the profile on multiple devices will result in missed messages and other problems.</string>
     <string name="pref_auto_folder_moves">Move automatically to DeltaChat Folder</string>
     <string name="pref_auto_folder_moves_explain">Chat conversations are moved to avoid cluttering the Inbox</string>


### PR DESCRIPTION
came over that while filing issues for iOS/desktop ...

we are saying Real-Time as well, so i think that should be upper cased as well, in general we upper case most key words

more tricky is the other change, i think "send background messages" may be too confusing, also hard to translate. user may think, real messages are exchanged, maybe smth visible, maybe even some action is needed "Send".

not totally sure if "Exchange data" is better, but want to bring up the idea. i will not die on that hill :)

successor of https://github.com/deltachat/deltachat-android/pull/4019

cc @adbenitez @link2xt 