### PR TITLE
use updated texts in tests

### DIFF
--- a/src/androidTest/java/com/b44t/messenger/uitests/online/OnboardingTest.java
+++ b/src/androidTest/java/com/b44t/messenger/uitests/online/OnboardingTest.java
@@ -41,7 +41,7 @@ public class OnboardingTest {
     }
     onView(withText(R.string.scan_invitation_code)).check(matches(isClickable()));
     onView(withText(R.string.import_backup_title)).check(matches(isClickable()));
-    onView(withText(R.string.login_header)).perform(click());
+    onView(withText(R.string.manual_account_setup_option)).perform(click());
     onView(withHint(R.string.email_address)).perform(replaceText(BuildConfig.TEST_ADDR));
     onView(withHint(R.string.existing_password)).perform(replaceText(BuildConfig.TEST_MAIL_PW));
     onView(withContentDescription(R.string.ok)).perform(click());


### PR DESCRIPTION
the string is deprecated, so the test is just wrong.

as i never set up test-running environment on my machine, could not test the changes (came over that while caring for the strings)

#skip-changelog as there are no user-visible changes