### PR TITLE
remove all png files before help creation

### DIFF
--- a/scripts/create-local-help.sh
+++ b/scripts/create-local-help.sh
@@ -1,1 +1,2 @@
+rm src/main/assets/help/*.png
 ../deltachat-pages/tools/create-local-help.py ../deltachat-pages/result src/main/assets/help


### PR DESCRIPTION
this PR removes all `*.png` files from `assets/help` dir; needed/new files are copied from the help generation script directly afterwards.

(this will remove the old comic and the old padlock)

(cleaning whole dir comes to mind as well, but there is *.css in, the dir is filled by both, android and pages, so this line fixes the issue at hand)