### PR TITLE
feat: Add missing core stock strings

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -171,6 +171,11 @@ public class DcHelper {
     dcContext.setStockTranslation(118, context.getString(R.string.secure_join_replies));
     dcContext.setStockTranslation(119, context.getString(R.string.qrshow_join_contact_hint));
 
+    // HACK: svg does not handle entities correctly and shows `&quot;` as the text `quot;`.
+    // until that is fixed, we fix the most obvious errors (core uses encode_minimal, so this does not affect so many characters)
+    // cmp. https://github.com/deltachat/deltachat-android/issues/2187
+    dcContext.setStockTranslation(120, context.getString(R.string.qrshow_join_group_hint).replace("\"", ""));
+    dcContext.setStockTranslation(121, context.getString(R.string.connectivity_not_connected));
     dcContext.setStockTranslation(124, context.getString(R.string.group_name_changed_by_you));
     dcContext.setStockTranslation(125, context.getString(R.string.group_name_changed_by_other));
     dcContext.setStockTranslation(126, context.getString(R.string.group_image_changed_by_you));
@@ -205,12 +210,6 @@ public class DcHelper {
     dcContext.setStockTranslation(157, context.getString(R.string.ephemeral_timer_weeks_by_other));
     dcContext.setStockTranslation(158, context.getString(R.string.ephemeral_timer_1_year_by_you));
     dcContext.setStockTranslation(159, context.getString(R.string.ephemeral_timer_1_year_by_other));
-
-    // HACK: svg does not handle entities correctly and shows `&quot;` as the text `quot;`.
-    // until that is fixed, we fix the most obvious errors (core uses encode_minimal, so this does not affect so many characters)
-    // cmp. https://github.com/deltachat/deltachat-android/issues/2187
-    dcContext.setStockTranslation(120, context.getString(R.string.qrshow_join_group_hint).replace("\"", ""));
-    dcContext.setStockTranslation(121, context.getString(R.string.connectivity_not_connected));
     dcContext.setStockTranslation(162, context.getString(R.string.multidevice_qr_subtitle));
     dcContext.setStockTranslation(163, context.getString(R.string.multidevice_transfer_done_devicemsg));
     dcContext.setStockTranslation(170, context.getString(R.string.chat_protection_enabled_tap_to_learn_more));
@@ -219,6 +218,7 @@ public class DcHelper {
     dcContext.setStockTranslation(174, context.getString(R.string.invalid_unencrypted_tap_to_learn_more));
     dcContext.setStockTranslation(176, context.getString(R.string.reaction_by_you));
     dcContext.setStockTranslation(177, context.getString(R.string.reaction_by_other));
+    dcContext.setStockTranslation(178, context.getString(R.string.member_x_removed));
     dcContext.setStockTranslation(190, context.getString(R.string.secure_join_wait));
     dcContext.setStockTranslation(193, context.getString(R.string.donate_device_msg));
     dcContext.setStockTranslation(194, context.getString(R.string.outgoing_call));
@@ -226,6 +226,14 @@ public class DcHelper {
     dcContext.setStockTranslation(196, context.getString(R.string.declined_call));
     dcContext.setStockTranslation(197, context.getString(R.string.canceled_call));
     dcContext.setStockTranslation(198, context.getString(R.string.missed_call));
+    dcContext.setStockTranslation(200, context.getString(R.string.channel_left_by_you));
+    dcContext.setStockTranslation(201, context.getString(R.string.qrshow_join_channel_hint));
+    dcContext.setStockTranslation(202, context.getString(R.string.you_joined_the_channel));
+    dcContext.setStockTranslation(203, context.getString(R.string.secure_join_channel_started));
+    dcContext.setStockTranslation(210, context.getString(R.string.stats_msg_body));
+    dcContext.setStockTranslation(220, context.getString(R.string.proxy_enabled));
+    dcContext.setStockTranslation(221, context.getString(R.string.proxy_enabled_hint));
+    dcContext.setStockTranslation(230, context.getString(R.string.chat_unencrypted_explanation));
   }
 
   public static File getImexDir() {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -842,6 +842,7 @@
     <string name="disable_imap_idle">Disable IMAP IDLE</string>
     <string name="disable_imap_idle_explain">Do not use IMAP IDLE extension even if the server supports it. Enabling this option will delay message retrieval, enable it only for testing.</string>
     <string name="send_stats_to_devs">Send statistics to Delta Chat\'s developers</string>
+    <string name="stats_msg_body">The attachment contains anonymous usage statistics, which helps us improve Delta Chat. Thank you!</string>
 
 
     <!-- Emoji picker and categories -->
@@ -915,6 +916,8 @@
     <string name="remove_member_by_you">You removed member %1$s.</string>
     <!-- %1$s will be replaced by name of the contact removed from the group, %2$s will be replaced by name of the contact who did the action -->
     <string name="remove_member_by_other">Member %1$s removed by %2$s.</string>
+    <!-- %1$s will be replaced by name of the contact removed from the group; this string is used when it's unclear who did the action -->
+    <string name="member_x_removed">Member %1$s removed.</string>
     <!-- "left" in the meaning of "exited". -->
     <string name="group_left_by_you">You left the group.</string>
     <!-- "left" in the meaning of "exited". -->
@@ -1029,6 +1032,8 @@
     <string name="qrlogin_ask_login_another">Log into \"%1$s\"?\n\nYour existing profile will not be deleted. Use the \"Switch Profile\" item to switch between your profiles.</string>
     <!-- first placeholder will be replaced by name of the inviter, second placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_started">%1$s invited you to join this group.\n\nWaiting for the device of %2$s to reply…</string>
+    <!-- first placeholder will be replaced by name of the inviter, second placeholder will be replaced by the name of the inviter. -->
+    <string name="secure_join_channel_started">%1$s invited you to join this channel.\n\nWaiting for the device of %2$s to reply…</string>
     <!-- placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_replies">%1$s replied, waiting for being added to the group…</string>
     <string name="secure_join_wait">Establishing connection, please wait…</string>


### PR DESCRIPTION
I added all core stock strings from `stock_str.rs` >= 178 that were missing previously; most importantly, all the channel and statistics strings.

Some of these are not in a core release yet, but this is not a problem; core only prints a warning if we set an unknown string.

While there are some other strings in `stock_str.rs` that are missing here, it's not clear that these should be translated; probably we can just remove these from core.

I also moved strings 120 and 121 to the correct place.

#skip-changelog