### PR TITLE
'which help' refers to 'statistics', so it should be plural

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -842,7 +842,7 @@
     <string name="disable_imap_idle">Disable IMAP IDLE</string>
     <string name="disable_imap_idle_explain">Do not use IMAP IDLE extension even if the server supports it. Enabling this option will delay message retrieval, enable it only for testing.</string>
     <string name="send_stats_to_devs">Send statistics to Delta Chat\'s developers</string>
-    <string name="stats_msg_body">The attachment contains anonymous usage statistics, which helps us improve Delta Chat. Thank you!</string>
+    <string name="stats_msg_body">The attachment contains anonymous usage statistics, which help us improve Delta Chat. Thank you!</string>
 
 
     <!-- Emoji picker and categories -->


### PR DESCRIPTION
this PR changes grammar of the message shown in bubbles of statistics sent.

successor of https://github.com/deltachat/deltachat-android/pull/4044