### PR TITLE
Add WebxdcGarbageCollectionWorker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.concurrent:concurrent-futures:1.3.0'
     implementation 'androidx.sharetarget:sharetarget:1.2.0'
     implementation 'androidx.webkit:webkit:1.14.0'
     implementation 'androidx.multidex:multidex:2.0.1'

--- a/src/main/java/org/thoughtcrime/securesms/connect/WebxdcGarbageCollectionWorker.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/WebxdcGarbageCollectionWorker.java
@@ -1,0 +1,71 @@
+package org.thoughtcrime.securesms.connect;
+
+import android.content.Context;
+import android.util.Log;
+import android.webkit.WebStorage;
+import androidx.annotation.NonNull;
+import androidx.concurrent.futures.CallbackToFutureAdapter;
+import androidx.work.ListenableWorker;
+import androidx.work.WorkerParameters;
+import chat.delta.rpc.Rpc;
+import chat.delta.rpc.RpcException;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.util.Util;
+
+public class WebxdcGarbageCollectionWorker extends ListenableWorker {
+  private static final String TAG = WebxdcGarbageCollectionWorker.class.getSimpleName();
+  private Rpc rpc;
+
+  public WebxdcGarbageCollectionWorker(Context context, WorkerParameters params) {
+    super(context, params);
+    rpc = DcHelper.getRpc(context);
+  }
+
+  @Override
+  public @NonNull ListenableFuture<Result> startWork() {
+    Log.i(TAG, "Running Webxdc storage garbage collection...");
+
+    final Pattern WEBXDC_URL_PATTERN =
+      Pattern.compile("^https?://acc(\\d+)-msg(\\d+)\\.localhost/?");
+
+    return CallbackToFutureAdapter.getFuture(completer -> {
+      WebStorage webStorage = WebStorage.getInstance();
+
+      webStorage.getOrigins((origins) -> {
+        if (origins == null || origins.isEmpty()) {
+          Log.i(TAG, "Done, no WebView origins found.");
+          completer.set(Result.success());
+          return;
+        }
+
+        for (Object key : origins.keySet()) {
+          String url = (String)key;
+          Matcher m = WEBXDC_URL_PATTERN.matcher(url);
+          if (m.matches()) {
+            int accId = Integer.parseInt(m.group(1));
+            int msgId = Integer.parseInt(m.group(2));
+            try {
+              rpc.getMessage(accId, msgId);
+              Log.i(TAG, String.format("Existing webxdc origin: %s", url));
+            } catch (RpcException ignore) {
+              // msg doesn't exist anymore, clean storage
+              webStorage.deleteOrigin(url);
+              Log.i(TAG, String.format("Deleted webxdc origin: %s", url));
+            }
+          } else { // old webxdc URL schemes, etc
+            webStorage.deleteOrigin(url);
+            Log.i(TAG, String.format("Deleted unknown origin: %s", url));
+          }
+        }
+
+        Log.i(TAG, "Done running Webxdc storage garbage collection.");
+        completer.set(Result.success());
+      });
+
+      return "Webxdc Garbage Collector";
+    });
+  }
+}


### PR DESCRIPTION
Based on https://github.com/deltachat/deltachat-android/pull/4050

Example logs:
```
11-22 17:25:25.895 12044 12044 I WebxdcGarbageCollectionWorker: Running Webxdc storage garbage collection...
11-22 17:25:25.980 12044 12044 I WebxdcGarbageCollectionWorker: Existing webxdc origin: https://acc1-msg946529.localhost/
11-22 17:25:25.980 12044 12044 I WebxdcGarbageCollectionWorker: Done running Webxdc storage garbage collection.
11-22 17:25:25.983 12044 12109 I WM-WorkerWrapper: Worker result SUCCESS for Work [ id=f811e836-b1b1-44e9-b4ab-d71fcda92d9a, tags={ org.thoughtcrime.securesms.connect.WebxdcGarbageCollectionWorker } ]
```

Some time later after message deletion:
```
11-22 17:40:26.047 12044 12044 I WebxdcGarbageCollectionWorker: Running Webxdc storage garbage collection...
11-22 17:40:26.172 12044 12044 I WebxdcGarbageCollectionWorker: Deleted webxdc origin: https://acc1-msg946529.localhost/
11-22 17:40:26.172 12044 12044 I WebxdcGarbageCollectionWorker: Done running Webxdc storage garbage collection.
11-22 17:40:26.173 12044 12078 I WM-WorkerWrapper: Worker result SUCCESS for Work [ id=f811e836-b1b1-44e9-b4ab-d71fcda92d9a, tags={ org.thoughtcrime.securesms.connect.WebxdcGarbageCollectionWorker } ]
```