### PR TITLE
only open links directly in offline help

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
@@ -15,6 +15,9 @@ public class LocalHelpActivity extends WebViewActivity
   public static final String SECTION_EXTRA = "section_extra";
 
   @Override
+  protected boolean shouldAskToOpenLink() { return false; }
+
+  @Override
   protected boolean allowInLockedMode() { return true; }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
@@ -37,7 +37,7 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
 
   protected WebView webView;
 
-  protected boolean shouldAskToOpenLink() { return false; }
+  protected boolean shouldAskToOpenLink() { return true; }
 
   protected void toggleFakeProxy(boolean enable) {
     if (WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -339,9 +339,6 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     }
   }
 
-  @Override
-  protected boolean shouldAskToOpenLink() { return true; }
-
   // This is usually only called when internetAccess == true or for mailto/openpgp4fpr scheme,
   // because when internetAccess == false, the page is loaded inside an iframe,
   // and WebViewClient.shouldOverrideUrlLoading is not called for HTTP(S) links inside the iframe unless target=_blank is used


### PR DESCRIPTION
follow-up to #4045 

only allow to open links directly without asking user in trusted offline help, otherwise it might be unexpected for some potentially malicious crafted HTML email

#skip-changelog