### PR TITLE
remove need for READ_CONTACTS permission

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 
     <!-- dangerous permissions - we need to as the user with a PermissionsRequest -->
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />

--- a/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -19,13 +19,9 @@ package org.thoughtcrime.securesms;
 
 import static org.thoughtcrime.securesms.util.RelayUtil.isRelayingMessageContent;
 
-import android.Manifest;
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
-import android.util.Log;
 import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -51,13 +47,11 @@ import com.b44t.messenger.DcEvent;
 import org.thoughtcrime.securesms.connect.DcContactsLoader;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.contacts.ContactAccessor;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListAdapter;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListItem;
 import org.thoughtcrime.securesms.contacts.NewContactActivity;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.permissions.Permissions;
-import org.thoughtcrime.securesms.qr.QrActivity;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
@@ -112,13 +106,6 @@ public class ContactSelectionListFragment extends    Fragment
   public void onStart() {
     super.onStart();
     this.getLoaderManager().initLoader(0, null, this);
-    if (dcContext.getConfigInt("ui.android.show_system_contacts") != 0 && !dcContext.isChatmail()) {
-      Permissions.with(this)
-        .request(Manifest.permission.READ_CONTACTS)
-        .ifNecessary()
-        .onAllGranted(this::handleContactPermissionGranted)
-        .execute();
-    }
   }
 
   @Override
@@ -287,38 +274,6 @@ public class ContactSelectionListFragment extends    Fragment
   @Override
   public void onLoaderReset(Loader<DcContactsLoader.Ret> loader) {
     ((ContactSelectionListAdapter) recyclerView.getAdapter()).changeData(null);
-  }
-
-  @SuppressLint("StaticFieldLeak")
-  private void handleContactPermissionGranted() {
-    new AsyncTask<Void, Void, Void>() {
-
-      @Override
-      protected Void doInBackground(Void... voids) {
-        loadSystemContacts();
-        return null;
-      }
-
-    }.execute();
-  }
-
-  private void loadSystemContacts() {
-    Thread thread = new Thread() {
-      @Override
-      public void run() {
-        try {
-          ContactAccessor contactAccessor = ContactAccessor.getInstance();
-          String allSystemContacts = contactAccessor.getAllSystemContactsAsString(getContext());
-          if (!allSystemContacts.isEmpty()) {
-            dcContext.addAddressBook(allSystemContacts);
-          }
-        } catch (SecurityException e) {
-          Log.e(TAG, "Caught a weird bug in the Android OS https://github.com/deltachat/deltachat-android/issues/1639: " + e);
-          e.printStackTrace();
-        }
-      }
-    };
-    thread.start();
   }
 
   private class ListClickListener implements ContactSelectionListAdapter.ItemClickListener {

--- a/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -61,7 +61,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
   CheckBoxPreference mvboxMoveCheckbox;
   CheckBoxPreference onlyFetchMvboxCheckbox;
   CheckBoxPreference webxdcRealtimeCheckbox;
-  CheckBoxPreference showSystemContacts;
 
   @Override
   public void onCreate(Bundle paramBundle) {
@@ -132,15 +131,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
       webxdcRealtimeCheckbox.setOnPreferenceChangeListener((preference, newValue) -> {
         boolean enabled = (Boolean) newValue;
         dcContext.setConfigInt(CONFIG_WEBXDC_REALTIME_ENABLED, enabled? 1 : 0);
-        return true;
-      });
-    }
-
-    showSystemContacts = (CheckBoxPreference) this.findPreference("pref_show_system_contacts");
-    if (showSystemContacts != null) {
-      showSystemContacts.setOnPreferenceChangeListener((preference, newValue) -> {
-        boolean enabled = (Boolean) newValue;
-        dcContext.setConfigInt("ui.android.show_system_contacts", enabled? 1 : 0);
         return true;
       });
     }
@@ -251,7 +241,6 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     mvboxMoveCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_MVBOX_MOVE));
     onlyFetchMvboxCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_ONLY_FETCH_MVBOX));
     webxdcRealtimeCheckbox.setChecked(0!=dcContext.getConfigInt(CONFIG_WEBXDC_REALTIME_ENABLED));
-    showSystemContacts.setChecked(0!=dcContext.getConfigInt("ui.android.show_system_contacts"));
   }
 
   @Override

--- a/src/main/res/xml/preferences_advanced.xml
+++ b/src/main/res/xml/preferences_advanced.xml
@@ -84,11 +84,6 @@
             android:key="pref_only_fetch_mvbox"
             android:title="@string/pref_only_fetch_mvbox_title" />
 
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="pref_show_system_contacts"
-            android:title="@string/pref_show_system_contacts"/>
-
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
this is a dangerous permission wrt privacy and it scares users when installing an unknown app that claims to not require phone numbers etc. which is the default onboarding and then it looks really scammy that the app requires access to contacts list