### PR TITLE
remove superfluous DynamicTheme usage

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/EditTransportActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/EditTransportActivity.java
@@ -36,7 +36,6 @@ import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.proxy.ProxySettingsActivity;
-import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -57,8 +56,6 @@ public class EditTransportActivity extends BaseActionBarActivity implements DcEv
         SERVER,
         PORT,
     }
-
-    private final DynamicTheme dynamicTheme    = new DynamicTheme();
 
     private TextInputEditText emailInput;
     private TextInputEditText passwordInput;
@@ -85,7 +82,6 @@ public class EditTransportActivity extends BaseActionBarActivity implements DcEv
     @Override
     public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
-        dynamicTheme.onCreate(this);
         rpc = DcHelper.getRpc(this);
         accId = DcHelper.getContext(this).getAccountId();
 
@@ -218,7 +214,6 @@ public class EditTransportActivity extends BaseActionBarActivity implements DcEv
     @Override
     public void onResume() {
         super.onResume();
-        dynamicTheme.onResume(this);
         proxySwitch.setChecked(DcHelper.getInt(this, CONFIG_PROXY_ENABLED) == 1);
     }
 

--- a/src/main/java/org/thoughtcrime/securesms/proxy/ProxySettingsActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/proxy/ProxySettingsActivity.java
@@ -28,7 +28,6 @@ import org.thoughtcrime.securesms.BaseActionBarActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
@@ -37,14 +36,12 @@ import java.util.LinkedList;
 public class ProxySettingsActivity extends BaseActionBarActivity
   implements ProxyListAdapter.ItemClickListener, DcEventCenter.DcEventDelegate {
 
-  private final DynamicTheme dynamicTheme = new DynamicTheme();
   private SwitchCompat proxySwitch;
   private ProxyListAdapter adapter;
 
   @Override
   public void onCreate(Bundle bundle) {
     super.onCreate(bundle);
-    dynamicTheme.onCreate(this);
     setContentView(R.layout.proxy_settings_activity);
 
     ActionBar actionBar = getSupportActionBar();
@@ -87,12 +84,6 @@ public class ProxySettingsActivity extends BaseActionBarActivity
   protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
     handleOpenProxyUrl();
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
-    dynamicTheme.onResume(this);
   }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrShowActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrShowActivity.java
@@ -12,13 +12,10 @@ import org.thoughtcrime.securesms.BaseActionBarActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class QrShowActivity extends BaseActionBarActivity {
-
-    private final DynamicTheme dynamicTheme = new DynamicTheme();
 
     public final static String CHAT_ID = "chat_id";
 
@@ -30,7 +27,6 @@ public class QrShowActivity extends BaseActionBarActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        dynamicTheme.onCreate(this);
 
         setContentView(R.layout.activity_qr_show);
         fragment = (QrShowFragment)getSupportFragmentManager().findFragmentById(R.id.qrScannerFragment);
@@ -76,12 +72,6 @@ public class QrShowActivity extends BaseActionBarActivity {
       menu.findItem(R.id.load_from_image).setVisible(false);
       Util.redMenuItem(menu, R.id.withdraw);
       return super.onCreateOptionsMenu(menu);
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        dynamicTheme.onResume(this);
     }
 
     @Override


### PR DESCRIPTION
`DynamicTheme` is already setup/handled in the parent class `BaseActionBarActivity`

#skip-changelog