### PR TITLE
clearly say that experiments may be unstable/changed/removed

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -827,6 +827,7 @@
     <string name="pref_show_emails_accepted_contacts">For accepted contacts</string>
     <string name="pref_show_emails_all">All</string>
     <string name="pref_experimental_features">Experimental Features</string>
+    <string name="pref_experimental_features_explain">These features may be unstable and may be changed or removed</string>
     <string name="pref_on_demand_location_streaming">On-demand Location Streaming</string>
     <!-- deprecated -->
     <string name="pref_developer_mode">Developer Mode</string>

--- a/src/main/res/xml/preferences_advanced.xml
+++ b/src/main/res/xml/preferences_advanced.xml
@@ -23,9 +23,9 @@
 
     <PreferenceCategory android:title="@string/pref_experimental_features">
 
-        <Preference android:key="pref_webxdc_store_url"
-            android:title="@string/webxdc_store_url"
-            android:summary="@string/none"/>
+        <Preference
+            android:summary="@string/pref_experimental_features_explain"
+            android:selectable="false" />
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:defaultValue="false"
@@ -41,6 +41,10 @@
             android:defaultValue="false"
             android:key="pref_location_streaming_enabled"
             android:title="@string/pref_on_demand_location_streaming"/>
+
+        <Preference android:key="pref_webxdc_store_url"
+            android:title="@string/webxdc_store_url"
+            android:summary="@string/none"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
expectation management: 

by the bare title, this is not clear to everyone, eg. recently at https://support.delta.chat/t/broadcast-funktioniert-nach-update-nicht-mehr/3694 (german, ppl very sad about not being able to add ppl manually to channels - as in broadcasts before)

ftr, the [faq](https://delta.chat/en/help#experimental-features) was also updated recently and is clear on that aspect now (details about experiments are omited there on purpose; int the past they were at best incomplete, often enough outdated and wrong) 

technically, i also tried <PreferenceCategory summary>, but that does not wrap text.
moved down 'app picker' for better layout and to match order of other UI

<img width="405" height="327" alt="Screenshot 2025-12-03 at 14 00 34" src="https://github.com/user-attachments/assets/984ea83c-147d-4845-82d0-f6966081835d" />

once merged and agreed on, issues/pr for iOS/desktop should be filed

