### PR TITLE
use DcContext.getInfo() in LogViewFragment

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/LogViewFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/LogViewFragment.java
@@ -274,10 +274,10 @@ public class LogViewFragment extends Fragment {
     builder.append("\n");
     try {
       builder.append(rpc.getStorageUsageReportString(accId));
-      builder.append(rpc.getInfo(accId));
     } catch (RpcException e) {
       builder.append(e);
     }
+    builder.append(DcHelper.getContext(context).getInfo());
 
     return builder.toString();
   }


### PR DESCRIPTION
`Rpc.getInfo()` returns a Map not a string, this bug was introduced by #4060 

#skip-changelog