### PR TITLE
change "transport" to "relay" wording

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1145,6 +1145,7 @@
     <string name="export_backup_desktop">Export Backup</string>
     <!-- deprecated -->
     <string name="autocrypt_correct_desktop">Autocrypt setup transferred.</string>
+    <!-- deprecated, use delete_account + delete_account_ask + delete_account_explain_with_name -->
     <string name="forget_login_confirmation_desktop">Delete this profile? Everything will be deleted, including your end-to-end setup, contacts, chats, messages and media. This action cannot be undone.</string>
     <string name="message_detail_sent_desktop">sent</string>
     <string name="message_detail_received_desktop">received</string>


### PR DESCRIPTION
the wording change is the outcome of internal discussions.

moreover, the PR removes the "email" reference from the very exposed "welcome" message