### PR TITLE
fix ConversationActivity on Android <11

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -37,8 +37,8 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
     onPreCreate();
     super.onCreate(savedInstanceState);
 
-    // Only enable Edge-to-Edge on API 30+
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    // Only enable Edge-to-Edge if it is well supported
+    if (ViewUtil.isEdgeToEdgeSupported()) {
       // docs says to use: WindowCompat.enableEdgeToEdge(getWindow());
       // but it actually makes things worse, the next takes care of setting the 3-buttons navigation bar background
       EdgeToEdge.enable(this);

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -873,6 +873,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     ImageButton quickCameraToggle = ViewUtil.findById(this, R.id.quick_camera_toggle);
 
+    if (!ViewUtil.isEdgeToEdgeSupported()) {
+      // since insets will not be applied, we need to set top padding to avoid drawing behind toolbar
+      try (TypedArray typedArray = obtainStyledAttributes(new int[]{android.R.attr.actionBarSize})) {
+        int paddingTop = typedArray.getDimensionPixelSize(0, 0);
+        container.setPadding(container.getPaddingLeft(), paddingTop, container.getPaddingRight() , container.getPaddingBottom());
+      }
+    }
     // apply padding top to avoid drawing behind top bar
     ViewUtil.applyWindowInsets(findViewById(R.id.fragment_content), false, true, false, false);
     // apply padding to root to avoid collision with system bars

--- a/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -299,6 +299,11 @@ public class ViewUtil {
     return selection;
   }
 
+  /** Return true if the system supports edge-to-edge properly */
+  public static boolean isEdgeToEdgeSupported() {
+    return Build.VERSION.SDK_INT >= VERSION_CODES.R;
+  }
+
   /**
    * Get combined insets from status bar, navigation bar and display cutout areas.
    * 
@@ -335,7 +340,7 @@ public class ViewUtil {
    */
   public static void applyWindowInsetsAsMargin(@NonNull View view, boolean left, boolean top, boolean right, boolean bottom) {
     // Only enable on API 30+ where WindowInsets APIs work correctly
-    if (Build.VERSION.SDK_INT < VERSION_CODES.R) return;
+    if (!isEdgeToEdgeSupported()) return;
 
     // Store the original margin as a tag only if not already stored
     // This prevents losing the true original margin on subsequent calls
@@ -406,7 +411,7 @@ public class ViewUtil {
    */
   public static void applyWindowInsets(@NonNull View view, boolean left, boolean top, boolean right, boolean bottom) {
     // Only enable on API 30+ where WindowInsets APIs work correctly
-    if (Build.VERSION.SDK_INT < VERSION_CODES.R) return;
+    if (!isEdgeToEdgeSupported()) return;
 
     // Store the original padding as a tag only if not already stored
     // This prevents losing the true original padding on subsequent calls
@@ -475,7 +480,7 @@ public class ViewUtil {
    */
   public static void adjustToolbarForE2E(@NonNull AppCompatActivity activity) {
     // Only enable on API 30+ where WindowInsets APIs work correctly
-    if (Build.VERSION.SDK_INT < VERSION_CODES.R) return;
+    if (!isEdgeToEdgeSupported()) return;
 
     // The toolbar/app bar should extend behind the status bar with padding applied
     View toolbar = activity.findViewById(R.id.toolbar);


### PR DESCRIPTION
add top padding to messages list container to avoid drawing behind toolbar when edge-to-edge insets are disabled in android <11