### PR TITLE
simpler 'really delete?' wordings

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -400,16 +400,16 @@
     <!-- confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well -->
     <string name="ask_leave_group">Are you sure you want to leave?</string>
     <plurals name="ask_delete_chat">
-        <item quantity="one">Delete %d chat on all your devices?</item>
-        <item quantity="other">Delete %d chats on all your devices?</item>
+        <item quantity="one">Delete %d chat?</item>
+        <item quantity="other">Delete %d chats?</item>
     </plurals>
-    <string name="ask_delete_named_chat">Delete chat \"%1$s\" on all your devices?</string>
-    <string name="ask_delete_message">Delete this message on all your devices?</string>
+    <string name="ask_delete_named_chat">Delete chat \"%1$s\"?</string>
+    <string name="ask_delete_message">Delete this message?</string>
     <plurals name="ask_delete_messages">
-        <item quantity="one">Delete %d message on all your devices?</item>
-        <item quantity="other">Delete %d messages on all your devices?</item>
+        <item quantity="one">Delete %d message?</item>
+        <item quantity="other">Delete %d messages?</item>
     </plurals>
-    <!-- Used for the deletion of Device messages -->
+    <!-- deprecated, use ask_delete_messages -->
     <plurals name="ask_delete_messages_simple">
         <item quantity="one">Delete %d message?</item>
         <item quantity="other">Delete %d messages?</item>
@@ -483,6 +483,7 @@
 
     <!-- mailing lists -->
     <string name="mailing_list">Mailing List</string>
+    <!-- deprecated -->
     <string name="mailing_list_profile_info">Changes to mailing list name and image apply on this device only.</string>
 
     <!-- webxdc -->


### PR DESCRIPTION
this PR removes the addendum 'from your devices'
from the 'really delete?' questions.

- after polls, and looking at what other apps are doing, it is just the default expectation, that a message is deleted from all devices, also, we do not have an option (nor do not want to have)

- so, at that point - fresh user, one device - there is no need to clutter with other convepts and relativation. also, most user will never have more devices.

- ppl anyway do not read - but if they do, it is good to have things as much on point as possible :)

- the question fits better to the "delete for everyone" option

- simplify code and strings, as device message deletion is no longer special (there, we never said "on all your devices")

the addendum 'from your devices' was added as
one year ago, for technical limitations, deletion was really on one device. when we removed that limitation, we added to addendum, so ppl used to old apps have a chance to get the change. meanwhile, the new default is clear and settled and the addendum does more harm and raise questions than doing good.