### PR TITLE
stop using deprecated ask_delete_messages_simple

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -344,9 +344,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     DcMsg dcMsg = dcContext.getMsg(mediaItem.msgId);
     DcChat dcChat = dcContext.getChat(dcMsg.getChatId());
 
-    String text = getResources().getQuantityString(
-      dcChat.isDeviceTalk() ? R.plurals.ask_delete_messages_simple : R.plurals.ask_delete_messages,
-      1, 1);
+    String text = getResources().getQuantityString(R.plurals.ask_delete_messages,1, 1);
     int positiveBtnLabel = dcChat.isSelfTalk() ? R.string.delete : R.string.delete_for_me;
     final int[] messageIds = new int[]{mediaItem.msgId};
 

--- a/src/main/java/org/thoughtcrime/securesms/MessageSelectorFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/MessageSelectorFragment.java
@@ -76,9 +76,7 @@ public abstract class MessageSelectorFragment
       canDeleteForAll = false;
     }
 
-    String text = getActivity().getResources().getQuantityString(
-      dcChat.isDeviceTalk() ? R.plurals.ask_delete_messages_simple : R.plurals.ask_delete_messages,
-      messageIds.length, messageIds.length);
+    String text = getActivity().getResources().getQuantityString(R.plurals.ask_delete_messages, messageIds.length, messageIds.length);
     int positiveBtnLabel = dcChat.isSelfTalk() ? R.string.delete : R.string.delete_for_me;
 
     AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity())


### PR DESCRIPTION
follow-up to https://github.com/deltachat/deltachat-android/pull/4125

counterpart of https://github.com/deltachat/deltachat-ios/pull/2955/changes/4a6be2210e7f4684282a8626b434f3c1d9560021 

desktop was never differentiating between ask_delete_messages_simple and ask_delete_messages - so that is fine now without doing anything :) 

#skip-changelog as this change is not user-visible (both strings are the same since #4125)