### PR TITLE
fix: add members, not subscribers to emails

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -149,7 +149,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
 
     initializeAvatarView();
 
-    SelectedContactsAdapter adapter = new SelectedContactsAdapter(this, GlideApp.with(this), broadcast, unencrypted);
+    SelectedContactsAdapter adapter = new SelectedContactsAdapter(this, GlideApp.with(this), broadcast);
     adapter.setItemClickListener(this);
     lv.setAdapter(adapter);
 

--- a/src/main/java/org/thoughtcrime/securesms/ProfileAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileAdapter.java
@@ -163,11 +163,7 @@ public class ProfileAdapter extends RecyclerView.Adapter
       String addr = null;
 
       if (contactId == DcContact.DC_CONTACT_ID_ADD_MEMBER) {
-        if (isOutBroadcast) {
-          name = context.getString(R.string.add_recipients);
-        } else {
-          name = context.getString(R.string.group_add_members);
-        }
+        name = context.getString(R.string.group_add_members);
       }
       else if (contactId == DcContact.DC_CONTACT_ID_QR_INVITE) {
         name = context.getString(R.string.qrshow_title);

--- a/src/main/java/org/thoughtcrime/securesms/util/SelectedContactsAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SelectedContactsAdapter.java
@@ -37,18 +37,16 @@ public class SelectedContactsAdapter extends BaseAdapter {
   @Nullable private ItemClickListener            itemClickListener;
   @NonNull  private final List<Integer>          contacts = new LinkedList<>();
   private final boolean isBroadcast;
-  private final boolean isUnencrypted;
   @NonNull  private final DcContext              dcContext;
   @NonNull  private final GlideRequests          glideRequests;
 
   public SelectedContactsAdapter(@NonNull Context context,
                                    @NonNull  GlideRequests glideRequests,
-                                   boolean isBroadcast, boolean isUnencrypted)
+                                   boolean isBroadcast)
   {
     this.context       = context;
     this.glideRequests = glideRequests;
     this.isBroadcast   = isBroadcast;
-    this.isUnencrypted   = isUnencrypted;
     this.dcContext     = DcHelper.getContext(context);
   }
 
@@ -115,7 +113,7 @@ public class SelectedContactsAdapter extends BaseAdapter {
     Recipient recipient = null;
 
     if(contactId == DcContact.DC_CONTACT_ID_ADD_MEMBER) {
-      name.setText(context.getString(isBroadcast || isUnencrypted? R.string.add_recipients : R.string.group_add_members));
+      name.setText(context.getString(R.string.group_add_members));
       name.setTypeface(null, Typeface.BOLD);
       phone.setVisibility(View.GONE);
     } else {


### PR DESCRIPTION
we rececntly renamed "Recipients" to "Subscriber" because of channels - but we've overseen, that this also changes "New Email"

as this was always inconsistent (eg. we said "Add Recipient" - but then "123 Members"), and few ppl seem to use that (we never got complains), just stay with the "Member" wording here - we were using that for years, and while not perfect,  it is kind of fine - and definetly better than "Subscriber"

adding a 3rd wording group and pushing that consistent everywhere, including help etc., seems too much effort, esp. for an advanced area most ppl never see

moreover, the PR stops using the deprecated "Add Subscriber" string also elsewhere - if channels really change that, which seems totally unclear, we can re-add. up to then, it does not make sense to maintain the string

before / after:

<img width="300" src="https://github.com/user-attachments/assets/15b0808c-f263-46dc-8d39-28cf396ba634" />
<img width="300" src="https://github.com/user-attachments/assets/085105c7-4dc9-4142-9734-364151309046" />

#skip-changelog as a minor change
