### PR TITLE
truncate file names in the middle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Don't notify notification-to-all from in-chat apps if the chat is muted
 * Allow to see inbox quota for all relays in connectivity screen
+* Truncate file names in the middle, not at the end; important information are more often at the end
 * Update to core 2.36.0
 
 ## v2.35.0

--- a/src/main/res/layout/document_view.xml
+++ b/src/main/res/layout/document_view.xml
@@ -37,9 +37,8 @@
                           android:layout_height="wrap_content"
                           style="@style/Signal.Text.Body"
                           android:singleLine="true"
-                          android:maxLines="1"
                           android:clickable="false"
-                          android:ellipsize="end"
+                          android:ellipsize="middle"
                           android:textColor="@color/document_icon_text"
                           tools:text="The-Anarchist-Tension-by-Alfredo-Bonanno.pdf"/>
 


### PR DESCRIPTION
that way, the end is always visible,
which contains important information more often than the middle.

this is common knowledge since the 90's or so
however, as quite some previously stable ux patterns, lost on the way. (cmp. Scott Jensen, https://www.youtube.com/watch?v=1fZTOjd_bOQ )

sidenote: this issue might have been part of some ticket confusion, cc @hpk42

counterpart of https://github.com/deltachat/deltachat-ios/pull/2978

# before

<img width="320" src="https://github.com/user-attachments/assets/531f8807-b9cf-46a4-bc78-3c9da295ffa7" />
<img width="320" src="https://github.com/user-attachments/assets/e8262d30-c21c-44d2-823f-299b0e1b864b" />

# after

<img width="320" src="https://github.com/user-attachments/assets/0b941f01-845b-4a2a-a066-00c847ccea6f" />
<img width="320" src="https://github.com/user-attachments/assets/3bc4cd19-0ef2-4d42-abca-73cadfa1d482" />

it is not only about the extension (which was visible before as well), but also about suffixes as names, numbers.

the uppercase "type" can be removed probably, esp. if that is the extension only. but that is another PR/issue
