### PR TITLE
Select correct account when returning from conversations launched through shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Mark external links with " ↗" to make them clear
 * Make QR code larger on "Add Second Device" screen
 * Fix: Show dialog if pasted QR codes are invalid
+* Fix: Select correct account when returning from conversation launched through home screen shortcut from different account
 * Update to core 2.36.0
 
 ## v2.35.0

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -152,6 +152,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public static final String FROM_ARCHIVED_CHATS_EXTRA = "from_archived";
   public static final String TEXT_EXTRA              = "draft_text";
   public static final String STARTING_POSITION_EXTRA = "starting_position";
+  public static final String FROM_HOME_SHORTCUT           = "from_home_shortcut";
 
   private static final int PICK_GALLERY        = 1;
   private static final int PICK_DOCUMENT       = 2;
@@ -608,11 +609,23 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleReturnToConversationList(@Nullable Bundle extras) {
     boolean archived = getIntent().getBooleanExtra(FROM_ARCHIVED_CHATS_EXTRA, false);
-    Intent intent = new Intent(this, (archived ? ConversationListArchiveActivity.class : ConversationListActivity.class));
-    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-    if (extras != null) intent.putExtras(extras);
-    startActivity(intent);
-    finish();
+    boolean fromShortcut = getIntent().getBooleanExtra(FROM_HOME_SHORTCUT, false);
+
+    if (fromShortcut) {
+      // Always reset selected account when launched from shortcut.
+      // Shouldn't need to reload list in this case.
+      int accountId = getIntent().getIntExtra(
+        ACCOUNT_ID_EXTRA,
+        DcHelper.getAccounts(this).getSelectedAccount().getAccountId()
+      );
+      AccountManager.getInstance().switchAccountAndStartActivity(this, accountId);
+    } else {
+      Intent intent = new Intent(this, (archived ? ConversationListArchiveActivity.class : ConversationListActivity.class));
+      intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+      if (extras != null) intent.putExtras(extras);
+      startActivity(intent);
+      finish();
+    }
   }
 
   private void handleMuteNotifications() {

--- a/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
@@ -269,6 +269,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity implement
       composeIntent = getBaseShareIntent(ConversationActivity.class);
       composeIntent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
       composeIntent.putExtra(ConversationActivity.ACCOUNT_ID_EXTRA, accId);
+      composeIntent.putExtra(ConversationActivity.FROM_HOME_SHORTCUT, true);
       ShareUtil.setSharedUris(composeIntent, resolvedExtras);
       startActivity(composeIntent);
     } else {


### PR DESCRIPTION
Previously, the current selected account is not changed, if the home screen shortcut launches into a conversation under a different account than the current one.

Now, if we see a conversation that is launched from a shortcut, we always reset the current selected account based on which account the conversation is under.

closes #3913