### PR TITLE
Do not launch WelcomeActivity as singleTask

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -221,7 +221,7 @@
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".WelcomeActivity"
-              android:launchMode="singleTask"
+              android:launchMode="singleTop"
               android:theme="@style/TextSecure.LightNoActionBar"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 


### PR DESCRIPTION
My understanding of what happened:

 - `AccountManager` launches `WelcomeActivity` with `singleTask`, which creates a new task
 - This makes `WelcomeActivity` the root of current task
 - When creation is finished, `finishAffinity()` is called, which removes the activity and everything below it, but this doesn't change the task root
 - When exited and resumed from Recent, Android tried to restore task root, thus launching `WelcomeActivity` instead
 
 Since we probably just want to prevent multiple `WelcomeActivity` occur at once, `singleTop` is enough.
 
 closes #3686

#skip-changelog