### PR TITLE
make clear, the blockage comes from user action

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1002,7 +1002,7 @@
     <string name="secure_join_replies">%1$s replied, waiting for being added to the group…</string>
     <string name="secure_join_wait">Establishing connection, please wait…</string>
     <string name="contact_verified">%1$s introduced.</string>
-    <string name="contact_blocked">This contact is blocked</string>
+    <string name="contact_blocked">You blocked the contact</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
     <string name="verified_by">Introduced by %1$s</string>
     <string name="verified_by_you">Introduced by me</string>


### PR DESCRIPTION
this is the same length, but shows clearer why the contact is blocked, implicitly saying that you can unblock them (for the latter one could be explicit, but that lengthens the string, it seem good enough)

came over that for the german translation, intuitively, i wanted to write smth like "you blocked ..."