### PR TITLE
Migrate deprecated `onBackPressed` calls

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -55,7 +55,6 @@
                  android:requestLegacyExternalStorage="true"
                  tools:targetApi="TIRAMISU"
                  android:hasFragileUserData="true"
-                 android:enableOnBackInvokedCallback="false"
         >
 
     <!-- android car support, see https://developer.android.com/training/auto/start/,

--- a/src/main/java/org/thoughtcrime/securesms/ContactSelectionActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ContactSelectionActivity.java
@@ -81,8 +81,9 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
 
-    switch (item.getItemId()) {
-      case android.R.id.home:   super.onBackPressed(); return true;
+    if (item.getItemId() == android.R.id.home) {
+      getOnBackPressedDispatcher().onBackPressed();
+      return true;
     }
 
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -57,6 +57,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -233,6 +234,17 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           }
         });
       }
+    });
+
+    getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            if (container.isInputOpen()) {
+                container.hideCurrentInput(composeText);
+            } else {
+                handleReturnToConversationList();
+            }
+        }
     });
 
     DcEventCenter eventCenter = DcHelper.getEventCenter(this);
@@ -564,15 +576,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
 
     return false;
-  }
-
-  @Override
-  public void onBackPressed() {
-    if (container.isInputOpen()){
-      container.hideCurrentInput(composeText);
-    } else {
-      handleReturnToConversationList();
-    }
   }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -45,6 +45,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -173,6 +174,22 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     conversationListFragment = initFragment(R.id.fragment_container, new ConversationListFragment(), bundle);
 
     initializeSearchListener();
+
+    getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+      @Override
+      public void handleOnBackPressed() {
+        if (searchToolbar.isVisible()) {
+          searchToolbar.collapse();
+        } else {
+          if (isRelayingMessageContent(ConversationListActivity.this)) {
+            handleResetRelaying();
+          }
+
+          setEnabled(false);
+          getOnBackPressedDispatcher().onBackPressed();
+        }
+      }
+    });
 
     TooltipCompat.setTooltipText(searchAction, getText(R.string.search_explain));
 
@@ -445,7 +462,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       startActivity(new Intent(this, ProxySettingsActivity.class));
       return true;
     } else if (itemId == android.R.id.home) {
-      onBackPressed();
+      getOnBackPressedDispatcher().onBackPressed();
       return true;
     } else if (itemId == R.id.menu_all_media) {
       startActivity(new Intent(this, AllMediaActivity.class));
@@ -485,7 +502,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     };
     SaveAttachmentTask saveTask = new SaveAttachmentTask(this);
     saveTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, attachments);
-    onBackPressed();
+    getOnBackPressedDispatcher().onBackPressed();
   }
 
   private void handleOpenpgp4fpr() {
@@ -546,15 +563,6 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     }
     startActivity(intent);
     overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out);
-  }
-
-  @Override
-  public void onBackPressed() {
-    if (searchToolbar.isVisible()) searchToolbar.collapse();
-    else if (isRelayingMessageContent(this)) {
-      handleResetRelaying();
-      finish();
-    } else super.onBackPressed();
   }
 
   private void createChat() {

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
@@ -12,6 +12,8 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
+
 import com.b44t.messenger.DcChat;
 
 import org.thoughtcrime.securesms.connect.DcHelper;
@@ -33,6 +35,21 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
     Bundle bundle = new Bundle();
     bundle.putBoolean(ConversationListFragment.ARCHIVE, true);
     initFragment(R.id.fragment, new ConversationListFragment(), bundle);
+
+    getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+      @Override
+      public void handleOnBackPressed() {
+        if (!isRelayingMessageContent(ConversationListArchiveActivity.this)) {
+          // Load the ConversationListActivity in case it's not existent for some reason
+          Intent intent = new Intent(ConversationListArchiveActivity.this, ConversationListActivity.class);
+          intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+          startActivity(intent);
+        }
+
+        setEnabled(false);
+        getOnBackPressedDispatcher().onBackPressed();
+      }
+    });
   }
 
   @Override
@@ -63,7 +80,7 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
 
     int itemId = item.getItemId();
     if (itemId == android.R.id.home) {
-      onBackPressed();
+      getOnBackPressedDispatcher().onBackPressed();
       return true;
     } else if (itemId == R.id.mark_as_read) {
       DcHelper.getContext(this).marknoticedChat(DcChat.DC_CHAT_ID_ARCHIVED_LINK);
@@ -71,20 +88,6 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
     }
 
     return false;
-  }
-
-  @Override
-  public void onBackPressed() {
-    if (isRelayingMessageContent(this)) {
-      // Go back to the ConversationListRelayingActivity
-      super.onBackPressed();
-    } else {
-      // Load the ConversationListActivity in case it's not existent for some reason
-      Intent intent = new Intent(this, ConversationListActivity.class);
-      intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-      startActivity(intent);
-      finish();
-    }
   }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -20,6 +20,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.loader.app.LoaderManager;
 
@@ -79,6 +80,18 @@ public class CreateProfileActivity extends BaseActionBarActivity {
     initializeProfileName();
     initializeProfileAvatar();
     initializeStatusText();
+
+    getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+      @Override
+      public void handleOnBackPressed() {
+        if (container.isInputOpen()) {
+          container.hideCurrentInput(name);
+        } else {
+          setEnabled(false);
+          getOnBackPressedDispatcher().onBackPressed();
+        }
+      }
+    });
   }
 
   @Override
@@ -93,22 +106,13 @@ public class CreateProfileActivity extends BaseActionBarActivity {
     super.onOptionsItemSelected(item);
     int itemId = item.getItemId();
     if (itemId == android.R.id.home) {
-      onBackPressed();
+      getOnBackPressedDispatcher().onBackPressed();
       return true;
     } else if (itemId == R.id.menu_create_profile) {
       updateProfile();
     }
 
     return false;
-  }
-
-  @Override
-  public void onBackPressed() {
-    if (container.isInputOpen()) {
-      container.hideCurrentInput(name);
-    } else {
-      super.onBackPressed();
-    }
   }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/LocalHelpActivity.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
+
 import org.thoughtcrime.securesms.util.TextUtil;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -44,6 +46,18 @@ public class LocalHelpActivity extends WebViewActivity
     } catch(Exception e) {
       e.printStackTrace();
     }
+
+    getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+      @Override
+      public void handleOnBackPressed() {
+        if (webView.canGoBack()) {
+          webView.goBack();
+        } else {
+          setEnabled(false);
+          getOnBackPressedDispatcher().onBackPressed();
+        }
+      }
+    });
 
     webView.loadUrl("file:///android_asset/" + helpPath.replace("LANG", helpLang) + (section!=null? section : ""));
   }
@@ -98,15 +112,6 @@ public class LocalHelpActivity extends WebViewActivity
       return true;
     }
     return false;
-  }
-
-  @Override
-  public void onBackPressed() {
-    if (webView.canGoBack()) {
-      webView.goBack();
-    } else {
-      super.onBackPressed();
-    }
   }
 
   private boolean assetExists(String fileName) {

--- a/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -15,6 +15,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -90,6 +91,19 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
         registerForEvents();
         initializeActionBar();
 
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                AccountManager accountManager = AccountManager.getInstance();
+                if (accountManager.canRollbackAccountCreation(WelcomeActivity.this)) {
+                    accountManager.rollbackAccountCreation(WelcomeActivity.this);
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        });
+
         DcHelper.maybeShowMigrationError(this);
     }
 
@@ -135,7 +149,7 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
 
         switch (item.getItemId()) {
         case android.R.id.home:
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
 
@@ -382,16 +396,6 @@ public class WelcomeActivity extends BaseActionBarActivity implements DcEventCen
             }
         } catch (Exception e) {
             e.printStackTrace();
-        }
-    }
-
-    @Override
-    public void onBackPressed() {
-        AccountManager accountManager = AccountManager.getInstance();
-        if (accountManager.canRollbackAccountCreation(this)) {
-            accountManager.rollbackAccountCreation(this);
-        } else {
-            super.onBackPressed();
         }
     }
 }

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -11,6 +11,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -56,6 +57,8 @@ public class BackupTransferActivity extends BaseActionBarActivity {
     private boolean notificationControllerClosed = false;
     public boolean warnAboutCopiedQrCodeOnAbort = false;
 
+    private OnBackPressedCallback backPressedCallback;
+
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
@@ -89,6 +92,15 @@ public class BackupTransferActivity extends BaseActionBarActivity {
 
         // add padding to avoid content hidden behind system bars
         ViewUtil.applyWindowInsets(findViewById(R.id.backup_provider_fragment));
+
+        backPressedCallback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+              finishOrAskToFinish();
+            }
+        };
+
+        getOnBackPressedDispatcher().addCallback(this, backPressedCallback);
     }
 
     @Override
@@ -108,17 +120,12 @@ public class BackupTransferActivity extends BaseActionBarActivity {
     }
 
     @Override
-    public void onBackPressed() {
-        finishOrAskToFinish();
-    }
-
-    @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         super.onOptionsItemSelected(item);
 
       int itemId = item.getItemId();
       if (itemId == android.R.id.home) {
-        finishOrAskToFinish();
+        getOnBackPressedDispatcher().onBackPressed();
         return true;
       } else if (itemId == R.id.troubleshooting) {
         DcHelper.openHelp(this, "#multiclient");

--- a/src/main/java/org/thoughtcrime/securesms/scribbles/ScribbleActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/scribbles/ScribbleActivity.java
@@ -27,11 +27,4 @@ public class ScribbleActivity extends PassphraseRequiredActionBarActivity {
     boolean cropAvatar = getIntent().getBooleanExtra(CROP_AVATAR, false);
     imageEditorFragment = initFragment(R.id.scribble_container, ImageEditorFragment.newInstance(getIntent().getData(), cropAvatar));
   }
-
-/*  @Override
-  public void onBackPressed() {
-    if (!imageEditorFragment.onBackPressed()) {
-      super.onBackPressed();
-    }
-  } */
 }

--- a/src/main/java/org/thoughtcrime/securesms/scribbles/StickerSelectActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/scribbles/StickerSelectActivity.java
@@ -63,7 +63,7 @@ public class StickerSelectActivity extends FragmentActivity implements StickerSe
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     if (item.getItemId() == android.R.id.home) {
-      onBackPressed();
+      getOnBackPressedDispatcher().onBackPressed();
       return true;
     }
     return super.onOptionsItemSelected(item);


### PR DESCRIPTION
Here is a list of Activities changed and I have tested navigation on them:

- [x] `WelcomeActivity`
  - [x] When there were no existing account
  - [x] When there are existing accounts
- [x] `LocalHelpActivity`
  - [x] WebView back navigation
  - [x] Go back to last Activity
- [x] ~`InstantOnboardingActivity`~
  - [x] ~Open from `dcaccount` link, app has no existing account~
  - [x] ~Open from `dclogin` link, app has existing accounts~
- [x] `CreateProfileActivity`
  - [x] Up button works correctly
  - [x] Go back to last Activity
- [x] `ConversationListArchiveActivity`
  - [x] Go back to `ConversationListActivity`
  - [x] Go back when forwarding message
- [x] `ConversationListActivity`
  - [x] Collapse Search Bar
  - [x] Go Back to Home Screen
  - [x] Go Back whe forwarding message
  - [x] Export Attachment from WebXDC
  - [x] `Up` button works correctly
- [x] `ConversationActivity`
  - [x] Go Back to `ConversationList`
  - [x] `emojiPicker` closes correctly
- [x] `ContactSelectionActivity`/`ContactMultiSelectionActivity`
  - [x] `Up` button works correctly
- [x] `BackupTransferActivity`
  - [x] (Sender) Warning dialog before go back
  - [x] (Receiver) Activity finishes normally

Some other notes:
- `isInputOpen` branch in `CreateProfileActivity` seems unreachable, since we cannot open emoji picker from there
- `StickerSelectActivity` doesn't have a three dot menu, so `onOptionsItemSelected` cannot be reached

@adbenitez @r10s If you can help test if there is anything I missed, it will be great. Thanks!

closes #4140

#skip-changelog