### PR TITLE
Fix layout problems inside in-chat apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix: Update menu when using "select all" in contact selection
 * Fix: Avoid empty profiles after using "add as second device" from welcome screen
 * Fix multi-device seen messages synchronization when using multiple relays
+* Fix layout problems inside in-chat apps
 * Avoid crash when the app is minimized with profile switcher or reactions dialogs open
 * Update to core 2.39.0
 

--- a/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
@@ -77,7 +77,7 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
       findViewById(R.id.status_bar_background).setBackgroundResource(R.drawable.search_toolbar_shadow);
     } else {
       // add padding to avoid content hidden behind system bars
-      ViewUtil.applyWindowInsets(findViewById(R.id.content_container));
+      ViewUtil.applyWindowInsets(findViewById(R.id.content_container), true, true, true, true, true);
     }
 
     webView.setWebViewClient(new WebViewClient() {

--- a/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -390,11 +390,27 @@ public class ViewUtil {
   /**
    * Apply window insets to a view by adding padding to avoid  drawing elements behind system bars.
    * Convenience method that applies insets to all sides.
+   * IME insets are propagated to child views.
    * 
    * @param view The view to apply insets to
    */
   public static void applyWindowInsets(@NonNull View view) {
-    applyWindowInsets(view, true, true, true, true);
+    applyWindowInsets(view, true, true, true, true, false);
+  }
+
+  /**
+   * Apply window insets to a view by adding padding to avoid drawing elements behind system bars.
+   *
+   * IME insets are propagated to child views.
+   *
+   * @param view The view to apply insets to
+   * @param left Whether to apply left inset
+   * @param top Whether to apply top inset
+   * @param right Whether to apply right inset
+   * @param bottom Whether to apply bottom inset
+   */
+  public static void applyWindowInsets(@NonNull View view, boolean left, boolean top, boolean right, boolean bottom) {
+    applyWindowInsets(view, left, top, right, bottom, false);
   }
 
   /**
@@ -408,8 +424,9 @@ public class ViewUtil {
    * @param top Whether to apply top inset
    * @param right Whether to apply right inset
    * @param bottom Whether to apply bottom inset
+   * @param consumeImeInsets Whether to consume IME insets so they don't propagate to child views
    */
-  public static void applyWindowInsets(@NonNull View view, boolean left, boolean top, boolean right, boolean bottom) {
+  public static void applyWindowInsets(@NonNull View view, boolean left, boolean top, boolean right, boolean bottom, boolean consumeImeInsets) {
     // Only enable on API 30+ where WindowInsets APIs work correctly
     if (!isEdgeToEdgeSupported()) return;
 
@@ -442,6 +459,11 @@ public class ViewUtil {
           bottom ? basePaddingBottom + insets.bottom : basePaddingBottom
       );
 
+      if (consumeImeInsets) {
+        windowInsets = new WindowInsetsCompat.Builder(windowInsets)
+          .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE)
+          .build();
+      }
       return windowInsets;
     });
 


### PR DESCRIPTION
with the recent changes to support edge-to-edge, a weird extra empty space of the size of the keyboard was being added to the webxdc apps, this is because apparently the webview was adding additional insets for the IME

this PR restores the expected behavior that was available for webxdc apps in  2.34.0 and prior

close #4203 