### PR TITLE
disable insets change in setComposePanelVisibility()

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1059,16 +1059,20 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (dcChat.canSend()) {
       composePanel.setVisibility(View.VISIBLE);
       attachmentManager.setHidden(false);
-      ViewUtil.forceApplyWindowInsets(findViewById(R.id.root_layout), true, false, true, true);
-      fragment.handleRemoveBottomInsets();
+      // FIXME: disabled for now to avoid problems with chat scrolling and keyboard covering input bar
+      // ViewUtil.forceApplyWindowInsets(findViewById(R.id.root_layout), true, false, true, true);
+      // fragment.handleRemoveBottomInsets();
     } else {
       composePanel.setVisibility(View.GONE);
       attachmentManager.setHidden(true);
       hideSoftKeyboard();
+      // FIXME: disabled for now to avoid problems with chat scrolling and keyboard covering input bar
+      /*
       if (isInitialization) {
         ViewUtil.forceApplyWindowInsets(findViewById(R.id.root_layout), true, false, true, false);
         fragment.handleAddBottomInsets();
       }
+      */
     }
   }
 


### PR DESCRIPTION
sadly with the changes introduced in #4198 the conversation doesn't properly scroll to bottom under some circumstances and what is worse: while typing suddenly the input bar is behind the keyboard, this PR restores previous state

#skip-changelog