### PR TITLE
don't tint error icon red in chatlist and info-messages

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListItem.java
@@ -268,12 +268,6 @@ public class ConversationListItem extends RelativeLayout
       } else {
         deliveryStatusIndicator.setNone();
       }
-
-      if (state == DcMsg.DC_STATE_OUT_FAILED) {
-        deliveryStatusIndicator.setTint(Color.RED);
-      } else {
-        deliveryStatusIndicator.resetTint();
-      }
     }
 
     int unreadCount = thread.getUnreadCount();

--- a/src/main/java/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -123,12 +123,6 @@ public class ConversationUpdateItem extends BaseConversationItem
     else if (messageRecord.isPreparing())  deliveryStatusView.setPreparing();
     else if (messageRecord.isPending())    deliveryStatusView.setPending();
     else                                   deliveryStatusView.setNone();
-
-    if (messageRecord.isFailed()) {
-      deliveryStatusView.setTint(Color.RED);
-    } else {
-      deliveryStatusView.setTint(textColor);
-    }
   }
 
   @Override


### PR DESCRIPTION
part of #4207 

this was missing in https://github.com/deltachat/deltachat-android/pull/4215

#skip-changelog