### PR TITLE
clearify, how to recode multiple videos

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -712,7 +712,7 @@
     <!-- first placeholder is replaced by the number of files (always 2 or more); second placeholder is replaced by a chat name -->
     <string name="ask_send_files_to_chat">Send %1$d files to \"%2$s\"?</string>
     <string name="ask_send_files_to_selected_chats">Send %1$d file(s) to %2$d chats?</string>
-    <string name="videos_sent_without_recoding">(Videos are sent as original, big files. To make them smaller and save data, send them as single messages, one at a time)</string>
+    <string name="videos_sent_without_recoding">(Sending multiple videos will send them as-is, which may be large. To make them smaller and save data, you can send each video in its own message)</string>
     <string name="share_text_multiple_chats">Send this text to %1$d chats?\n\n\"%2$s\"</string>
     <string name="share_abort">Sharing aborted due to missing permissions.</string>
 


### PR DESCRIPTION
two translators, independently, had no idea what "attach them separately" mean, tho using Delta Chat.

the wording from the first commit was regarded as clearer, but i modified that as well and avoided "recode" in a second commit.

best would be if we would just recode multiple selected videos, and would not need this string, but iirc, this is a bit more complex - if not @adbenitez @wchen342 please create an issue :)

#skip-changelog