### PR TITLE
don't set channel description on channel creation if it is empty

### DIFF
--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -36,6 +36,7 @@ public class DcMsg {
     public final static int DC_INFO_INVALID_UNENCRYPTED_MAIL  = 13;
     public final static int DC_INFO_WEBXDC_INFO_MESSAGE       = 32;
     public final static int DC_INFO_CHAT_E2EE                 = 50;
+    public final static int DC_INFO_CHAT_DESCRIPTION_CHANGED  = 70;
 
     public final static int DC_STATE_UNDEFINED =  0;
     public final static int DC_STATE_IN_FRESH = 10;

--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -835,6 +835,11 @@ public class ConversationFragment extends MessageSelectorFragment
                     WebxdcActivity.openWebxdcActivity(getContext(), messageRecord.getParent(), messageRecord.getWebxdcHref());
                 }
             }
+            else if (messageRecord.getInfoType() == DcMsg.DC_INFO_CHAT_DESCRIPTION_CHANGED) {
+                Intent intent = new Intent(getContext(), ProfileActivity.class);
+                intent.putExtra(ProfileActivity.CHAT_ID_EXTRA, (int) chatId);
+                startActivity(intent);
+            }
             else {
                 int infoContactId = messageRecord.getInfoContactId();
                 if (infoContactId != 0 && infoContactId != DC_CONTACT_ID_SELF) {


### PR DESCRIPTION
when user creates a channel, only call rpc.setChatDescription if there is actually some description to set, otherwise there will be a "you changed the description" info-message when the user didn't set anything

in groups this was not noticed because they are not promoted on creation, but channels are created promoted then the call to set the description causes a system message, this looks a bit like a core issue because description didn't change (well from unset to empty string) and core should probably ignore it as it does when it is called with the same string/description twice 

#skip-changelog: not released feature