### PR TITLE
CI: Change preview APK architecture from 32-bit to 64-bit

### DIFF
--- a/.github/workflows/preview-apk.yml
+++ b/.github/workflows/preview-apk.yml
@@ -43,10 +43,10 @@ jobs:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           export PATH="${PATH}:${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/"
-          scripts/install-toolchains.sh && scripts/ndk-make.sh armeabi-v7a
+          scripts/install-toolchains.sh && scripts/ndk-make.sh arm64-v8a
 
       - name: Build APK
-        run: ./gradlew --no-daemon -PABI_FILTER=armeabi-v7a assembleGplayDebug
+        run: ./gradlew --no-daemon -PABI_FILTER=arm64-v8a assembleGplayDebug
 
       - name: Upload APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
New phones don't allow installing armeabi-v7a (ARM 32-bit) apps. So, instead build in CI for arm64-v8a (ARM 64-bit) apps