### PR TITLE
simplify 'call' wording

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/components/CallItemView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/CallItemView.java
@@ -71,9 +71,9 @@ public class CallItemView extends FrameLayout {
     } else if (callInfo.state instanceof CallState.Declined) {
       title.setText(R.string.declined_call);
     } else if (callInfo.hasVideo) {
-      title.setText(isOutgoing? R.string.outgoing_video_call : R.string.incoming_video_call);
+      title.setText(R.string.video_call);
     } else {
-      title.setText(isOutgoing? R.string.outgoing_audio_call : R.string.incoming_audio_call);
+      title.setText(R.string.audio_call);
     }
 
     icon.setImageResource(callInfo.hasVideo? R.drawable.ic_videocam_white_24dp : R.drawable.baseline_call_24);

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -220,10 +220,10 @@ public class DcHelper {
     dcContext.setStockTranslation(220, context.getString(R.string.proxy_enabled));
     dcContext.setStockTranslation(221, context.getString(R.string.proxy_enabled_hint));
     dcContext.setStockTranslation(230, context.getString(R.string.chat_unencrypted_explanation));
-    dcContext.setStockTranslation(232, context.getString(R.string.outgoing_audio_call));
-    dcContext.setStockTranslation(233, context.getString(R.string.outgoing_video_call));
-    dcContext.setStockTranslation(234, context.getString(R.string.incoming_audio_call));
-    dcContext.setStockTranslation(235, context.getString(R.string.incoming_video_call));
+    dcContext.setStockTranslation(232, context.getString(R.string.audio_call));
+    dcContext.setStockTranslation(233, context.getString(R.string.video_call));
+    dcContext.setStockTranslation(234, context.getString(R.string.audio_call));
+    dcContext.setStockTranslation(235, context.getString(R.string.video_call));
     dcContext.setStockTranslation(240, context.getString(R.string.chat_description_changed_by_you));
     dcContext.setStockTranslation(241, context.getString(R.string.chat_description_changed_by_other));
   }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -387,15 +387,25 @@
 
     <!-- the action "to call someone", used as a tooltip for the "phone" icon. not: "the call" -->
     <string name="start_call">Call</string>
+    <!-- Menu item to start an audio call; verbs as "start" are probably superfluous in many translations -->
     <string name="start_audio_call">Audio Call</string>
+    <!-- Menu item to start a video call; verbs as "start" are probably superfluous in many translations -->
     <string name="start_video_call">Video Call</string>
     <!-- the action "to answer" or to "accept" or to "pick up" a call. not: "the answer" -->
     <string name="answer_call">Answer</string>
     <!-- the action "to decline" a call, not: "the decline" -->
     <string name="end_call">Decline</string>
+    <!-- Used in call bubbles, summaries, notifications -->
+    <string name="audio_call">Audio call</string>
+    <!-- Used in call bubbles, summaries, notifications -->
+    <string name="video_call">Video call</string>
+    <!-- deprecated, use "Audio call" instead -->
     <string name="outgoing_audio_call">Outgoing audio call</string>
+    <!-- deprecated, use "Video call" instead -->
     <string name="outgoing_video_call">Outgoing video call</string>
+    <!-- deprecated, use "Audio call" instead -->
     <string name="incoming_audio_call">Incoming audio call</string>
+    <!-- deprecated, use "Video call" instead -->
     <string name="incoming_video_call">Incoming video call</string>
     <string name="declined_call">Declined call</string>
     <string name="canceled_call">Canceled call</string>


### PR DESCRIPTION
this PR simplifies the wording of "calls" by just saying "audio call" and "video call", omitting  the prefix "incoming"/"outgoing"- it is implicit clear by the bubble order if a call is incoming or outgoing - and also does not matter much.

this is the outcome of some internal discussion.

this PR does not change core stock strings, to not add noise everywhere, this can be done in a later iteration. but it also seems not really important. maybe even useful for other layout, cli or so.

once merged, we should ensure this happens on desktop/iOS as well

#skip-changelog as a minor, affecting a not-yet-released feature