### PR TITLE
fix: leave and delete finishes activity

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -754,7 +754,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private void handleDeleteChat() {
     AlertDialog dialog = new AlertDialog.Builder(this)
         .setMessage(getResources().getString(R.string.ask_delete_named_chat, dcChat.getName()))
-        .setPositiveButton(R.string.delete, (d, which) -> {
+        .setPositiveButton(R.string.delete_for_me, (d, which) -> {
           DcHelper.getContext(context).deleteChat(chatId);
           DirectShareUtil.clearShortcut(this, chatId);
           finish();


### PR DESCRIPTION
the chat is gone after leave&delete - without finishing the activity, we end up in ghost chat zero :)

moreover, the fix removes shortcuts from the homescreen.

a toast is no longer needed, as there is enough visual feedback; we're also not showing a toast on plain deletion.

successor of #4262

#skip-changelog as the bug was not released