### PR TITLE
Add a toast to inform user a call is ongoing

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/calls/CallUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallUtil.java
@@ -1,11 +1,13 @@
 package org.thoughtcrime.securesms.calls;
 
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.util.Log;
+import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.telecom.CallEndpointCompat;
@@ -41,8 +43,16 @@ public class CallUtil {
     }
 
     CallCoordinator coordinator = CallCoordinator.getInstance(context);
-    int accId = DcHelper.getContext(context).getAccountId();
 
+    if (coordinator.hasActiveCall()) {
+      Toast.makeText(context, R.string.already_in_call, Toast.LENGTH_SHORT).show();
+      Intent intent = new Intent(context, CallActivity.class);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      context.startActivity(intent);
+      return;
+    }
+
+    int accId = DcHelper.getContext(context).getAccountId();
     coordinator.initiateOutgoingCall(accId, chatId, startsWithVideo);
   }
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -420,6 +420,7 @@
     <string name="declined_call">Declined call</string>
     <string name="canceled_call">Canceled call</string>
     <string name="missed_call">Missed call</string>
+    <string name="already_in_call">Already in a call</string>
 
     <!-- get confirmations -->
     <!-- confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well -->


### PR DESCRIPTION
It also brings up the existing call screen.

The reason I do not use a dialog is because it can be obscured by PiP.

fixes #4286

#skip-changelog