### PR TITLE
don't try to open ConversationActivity if chatId is zero

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
@@ -266,7 +266,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
       accId = dcContext.getAccountId();
     }
     Intent composeIntent;
-    if (accId != -1 && chatId != -1) {
+    if (accId != -1 && chatId > 0) {
       composeIntent = getBaseShareIntent(ConversationActivity.class);
       composeIntent.putExtra(ConversationActivity.CHAT_ID_EXTRA, chatId);
       composeIntent.putExtra(ConversationActivity.ACCOUNT_ID_EXTRA, accId);


### PR DESCRIPTION
after some more feedback from an user having this problem, it is happening when clicking a mailto-link inside a webxdc, then the ShareActivity is opened and for some reason the resolving of that mailto-link ends up with a chatId ZERO, I didn't investigate much on the specifics but in general `createChatByContactId()` returns ZERO on errors and in any case it is better to fallback to showing the chatlist for selection in ShareActivity instead of trying to open a "ghost chat" and crashing

close #3494 

#skip-changelog: there is already a "other small bug fixes" this fix is hard to explain, rare and not worth mentioning