### PR TITLE
temporarily don't require android.permission.USE_FULL_SCREEN_INTENT for gplay

### DIFF
--- a/src/foss/AndroidManifest.xml
+++ b/src/foss/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <application>
         <service

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -37,7 +37,6 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
@@ -1310,7 +1310,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
     }
 
     // Check full screen intent permission on Android 14+
-    boolean canUseFullScreen;
+    boolean canUseFullScreen = false;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
       canUseFullScreen = canUseFullScreenIntent();
       if (!canUseFullScreen) {
@@ -1354,7 +1354,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
             PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     Notification.Builder builder;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    if (canUseFullScreen && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       // Android 12+, CallStyle
       Person caller =
           new Person.Builder().setName(callerName).setIcon(callerIcon).setImportant(true).build();


### PR DESCRIPTION
google play rejected the app, doing some changes to app and app description and appealing again would take time and not warranty approval so first better get a release out without USE_FULL_SCREEN_INTENT, this only means the incoming call notification will stay in the past without red & green buttons to answer the call 

#skip-changelog