### PR TITLE
sticker alerts: do not repeat text in title and message

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -1034,7 +1034,6 @@ public class ConversationFragment extends MessageSelectorFragment {
     @Override
     public void onStickerClicked(DcMsg messageRecord) {
       new AlertDialog.Builder(getContext())
-          .setTitle(R.string.add_to_sticker_collection)
           .setMessage(R.string.ask_add_sticker_to_collection)
           .setPositiveButton(
               R.string.ok,

--- a/src/main/java/org/thoughtcrime/securesms/components/emoji/StickerPickerView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/emoji/StickerPickerView.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -18,6 +19,7 @@ import java.util.List;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.GlideRequests;
+import org.thoughtcrime.securesms.util.Util;
 
 public class StickerPickerView extends RecyclerView {
 
@@ -130,25 +132,26 @@ public class StickerPickerView extends RecyclerView {
 
     private void deleteSticker(File stickerFile) {
       if (stickerFile != null && stickerFile.exists()) {
-        new androidx.appcompat.app.AlertDialog.Builder(context)
-            .setTitle(R.string.delete)
-            .setMessage(R.string.ask_delete_sticker)
-            .setPositiveButton(
-                R.string.delete,
-                (dialog, which) -> {
-                  if (stickerFile.delete()) {
-                    int position = stickerFiles.indexOf(stickerFile);
-                    if (position >= 0) {
-                      stickerFiles.remove(position);
-                      notifyItemRemoved(position);
-                    }
-                    if (listener != null) {
-                      listener.onStickerDeleted(stickerFile);
-                    }
-                  }
-                })
-            .setNegativeButton(R.string.cancel, null)
-            .show();
+        AlertDialog dialog =
+            new AlertDialog.Builder(context)
+                .setMessage(R.string.ask_delete_sticker)
+                .setPositiveButton(
+                    R.string.delete,
+                    (d, which) -> {
+                      if (stickerFile.delete()) {
+                        int position = stickerFiles.indexOf(stickerFile);
+                        if (position >= 0) {
+                          stickerFiles.remove(position);
+                          notifyItemRemoved(position);
+                        }
+                        if (listener != null) {
+                          listener.onStickerDeleted(stickerFile);
+                        }
+                      }
+                    })
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+        Util.redPositiveButton(dialog);
       }
     }
 


### PR DESCRIPTION
moreover, the "Delete" button is shown as being destructive. this removes noise and is more consistent with other confirmations.

#skip-changelog as this is a minor change

## adding before / after
<img width="378" height="799" alt="Screenshot 2026-03-29 at 12 39 08" src="https://github.com/user-attachments/assets/79de6323-46e3-47d2-94bc-cb8283d1515b" />
<img width="378" height="799" alt="Screenshot 2026-03-29 at 12 40 13" src="https://github.com/user-attachments/assets/9e67b853-9ea3-4dde-81c0-64e6c5a78b88" />

## delete before / after
<img width="378" height="799" alt="Screenshot 2026-03-29 at 12 39 20" src="https://github.com/user-attachments/assets/0589375b-8be9-4e52-ac90-c0ca5be2ce15" />
<img width="378" height="799" alt="Screenshot 2026-03-29 at 12 40 25" src="https://github.com/user-attachments/assets/b8a75152-57f2-4eaa-9a25-47cfabeecf38" />
