### PR TITLE
Fix wrong states when an incoming call is answered on a second device

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
@@ -373,6 +373,7 @@ public class CallActivity extends AppCompatActivity {
                   case INITIALIZING:
                   case PROMPTING_USER_ACCEPT:
                   case ENDED:
+                  case ANSWERED_ELSEWHERE:
                   case ERROR:
                   default:
                     finish();
@@ -578,6 +579,23 @@ public class CallActivity extends AppCompatActivity {
 
       case RECONNECTING:
         statusText.setText(R.string.call_reconnecting);
+        break;
+
+      case ANSWERED_ELSEWHERE:
+        statusText.setText(R.string.call_answered_elsewhere);
+        incomingCallPrompt.setVisibility(View.GONE);
+        bottomLayoutContainer.setVisibility(View.GONE);
+        callerIconContainer.setVisibility(View.GONE);
+        answerModeSelector.setVisibility(View.GONE);
+
+        new Handler(Looper.getMainLooper())
+            .postDelayed(
+                () -> {
+                  if (!isFinishing()) {
+                    finish();
+                  }
+                },
+                1500);
         break;
 
       case ENDED:
@@ -840,6 +858,7 @@ public class CallActivity extends AppCompatActivity {
           case INITIALIZING:
           case PROMPTING_USER_ACCEPT:
           case ENDED:
+          case ANSWERED_ELSEWHERE:
           case ERROR:
           default:
             finish();
@@ -890,7 +909,9 @@ public class CallActivity extends AppCompatActivity {
   protected void onDestroy() {
     super.onDestroy();
 
-    detachAllTracks();
+    if (viewModel != null) {
+      detachAllTracks();
+    }
 
     // Release video renderers
     if (localVideoView != null) {

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
@@ -95,6 +95,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
   private final MutableLiveData<String> displayName = new MutableLiveData<>();
   private final MutableLiveData<Icon> displayIcon = new MutableLiveData<>();
   private final MutableLiveData<Boolean> outgoingCallPlaced = new MutableLiveData<>(false);
+  private final MutableLiveData<Boolean> answeredElsewhere = new MutableLiveData<>(false);
   private final MutableLiveData<Boolean> isFrontCamera = new MutableLiveData<>(true);
 
   // Audio Routing Support
@@ -316,6 +317,10 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
 
   public LiveData<Boolean> getOutgoingCallPlaced() {
     return outgoingCallPlaced;
+  }
+
+  public LiveData<Boolean> getAnsweredElsewhere() {
+    return answeredElsewhere;
   }
 
   public LiveData<CallEndpointCompat> getCurrentAudioEndpoint() {
@@ -856,7 +861,8 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
               onIncomingCall(accId, callId, event.getData2Str(), hasVideo);
               break;
             case DcContext.DC_EVENT_INCOMING_CALL_ACCEPTED:
-              onIncomingCallAccepted(callId);
+              boolean fromThisDevice = event.getData2Int() != 0; // Data2 is from_this_device
+              onIncomingCallAccepted(callId, fromThisDevice);
               break;
             case DcContext.DC_EVENT_OUTGOING_CALL_ACCEPTED:
               String answerSDP = event.getData2Str();
@@ -912,8 +918,13 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
     startAndBindService();
   }
 
-  private synchronized void onIncomingCallAccepted(int callId) {
-    Log.d(TAG, "onIncomingCallAccepted: callId=" + callId);
+  private synchronized void onIncomingCallAccepted(int callId, boolean fromThisDevice) {
+    Log.d(TAG, "onIncomingCallAccepted: callId=" + callId + ", fromThisDevice=" + fromThisDevice);
+
+    if (!fromThisDevice) {
+      onCallAnsweredOnOtherDevice();
+      return;
+    }
 
     if (activeCallId == null || !activeCallId.equals(callId)) {
       Log.w(TAG, "Accepted call ID doesn't match active call");
@@ -926,6 +937,52 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
     }
 
     showOrUpdateOngoingNotification("Call with " + callerName);
+  }
+
+  private synchronized void onCallAnsweredOnOtherDevice() {
+    Log.d(TAG, "Call was answered on another device");
+
+    if (!hasActiveCall()) {
+      Log.d(TAG, "No active call, ignoring");
+      return;
+    }
+
+    // Prevent notifyBackendCallEnded() from firing during WebRTC teardown.
+    // The call is still active on the other device.
+    hasNotifiedBackend = true;
+
+    if (callService != null) {
+      callService.stopRingtone();
+    }
+
+    notificationManager.cancel(NOTIFICATION_ID_CALL);
+
+    answeredElsewhere.postValue(true);
+
+    // Disconnect from Telecom CallControlScope
+    CallControlScope scope = activeCallControlScope;
+    if (scope != null) {
+      scope.disconnect(
+          new DisconnectCause(DisconnectCause.REMOTE),
+          new Continuation<CallControlResult>() {
+            @NonNull
+            @Override
+            public CoroutineContext getContext() {
+              return EmptyCoroutineContext.INSTANCE;
+            }
+
+            @Override
+            public void resumeWith(@NonNull Object result) {
+              Log.d(TAG, "Disconnect (answered elsewhere) completed");
+            }
+          });
+    }
+
+    if (callService != null) {
+      callService.endCall();
+    }
+
+    cleanupCall(activeAccId, activeCallId);
   }
 
   private void onOutgoingCallAccepted(int callId, String answerSdp) {
@@ -1135,6 +1192,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
 
   private void resetLiveDataForNewCall() {
     connectionState.postValue(PeerConnection.PeerConnectionState.NEW);
+    answeredElsewhere.postValue(false); // clearLiveData() must not reset answeredElsewhere
     clearLiveData();
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallViewModel.java
@@ -37,6 +37,7 @@ public class CallViewModel extends AndroidViewModel {
   private final LiveData<String> displayName;
   private final LiveData<Icon> displayIcon;
   private final LiveData<Boolean> outgoingCallPlaced;
+  private final LiveData<Boolean> answeredElsewhere;
   private final LiveData<CallEndpointCompat> currentAudioEndpoint;
   private final LiveData<List<CallEndpointCompat>> availableAudioEndpoints;
   private final LiveData<Boolean> isFrontCamera;
@@ -58,6 +59,7 @@ public class CallViewModel extends AndroidViewModel {
     CONNECTING,
     CONNECTED,
     RECONNECTING,
+    ANSWERED_ELSEWHERE,
     ENDED,
     ERROR
   }
@@ -79,6 +81,7 @@ public class CallViewModel extends AndroidViewModel {
     this.displayName = callCoordinator.getDisplayName();
     this.displayIcon = callCoordinator.getDisplayIcon();
     this.outgoingCallPlaced = callCoordinator.getOutgoingCallPlaced();
+    this.answeredElsewhere = callCoordinator.getAnsweredElsewhere();
     this.currentAudioEndpoint = callCoordinator.getCurrentAudioEndpoint();
     this.availableAudioEndpoints = callCoordinator.getAvailableAudioEndpoints();
     this.isFrontCamera = callCoordinator.getIsFrontCamera();
@@ -108,6 +111,10 @@ public class CallViewModel extends AndroidViewModel {
     callState.addSource(
         callCoordinator.getConnectionState(),
         state -> {
+          if (callState.getValue() == CallState.ANSWERED_ELSEWHERE) {
+            return;
+          }
+
           CallState newState = translateConnectionState(state);
 
           if (callState.getValue() != newState) {
@@ -127,6 +134,15 @@ public class CallViewModel extends AndroidViewModel {
             if (callState.getValue() == CallState.CONNECTING) {
               callState.setValue(CallState.RINGING);
             }
+          }
+        });
+
+    callState.addSource(
+        answeredElsewhere,
+        value -> {
+          if (Boolean.TRUE.equals(value)) {
+            hasCallEnded.set(true);
+            callState.setValue(CallState.ANSWERED_ELSEWHERE);
           }
         });
   }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -416,6 +416,7 @@
     <string name="canceled_call">Canceled call</string>
     <string name="missed_call">Missed call</string>
     <string name="already_in_call">Already in a call</string>
+    <string name="call_answered_elsewhere">Call answered on another device</string>
 
     <!-- get confirmations -->
     <!-- confirmation for leaving groups or channels. If a subject is needed, "Are you sure you want to leave the chat?" would work as well -->


### PR DESCRIPTION
Currently, if an incoming call rings on two devices and one device answers the call, the other device will stuck in a wrong state. This PR fixes that.
It also fixes a minor problem with permission check that may cause a crash.

#skip-changelog