### PR TITLE
Prevent app launch from creating multiple WelcomeActivity on top of each other

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -30,6 +30,7 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
 
     if (!DcHelper.isConfigured(getApplicationContext())) {
       Intent intent = new Intent(this, WelcomeActivity.class);
+      intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
       startActivity(intent);
       super.onCreate(savedInstanceState);
       finish();


### PR DESCRIPTION
See #4339 for details.

Fixes #4339

#skip-changelog