### PR TITLE
Add fallback for getExternalCacheDir() in case primary storage is SD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix file sharing to certain apps (e.g. Material Files, etc.)
 * Fix problem with calls when microphone permission is not granted
+* Fix taking pictures and videos in devices with SD cards
 * Remove proxy toggle from profile editing to avoid confusion
 
 ## v2.48.0

--- a/src/main/java/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
+++ b/src/main/java/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
@@ -208,7 +208,6 @@ public class PersistentBlobProvider {
         return getFile(context, ContentUris.parseId(uri)).delete();
     }
 
-    //noinspection SimplifiableIfStatement
     if (isExternalBlobUri(context, uri)) {
       return new File(uri.getPath()).delete();
     }
@@ -287,6 +286,20 @@ public class PersistentBlobProvider {
 
   private static @NonNull File getExternalDir(Context context) throws IOException {
     File externalDir = context.getExternalCacheDir();
+
+    if (externalDir != null) {
+      try {
+        FileProviderUtil.getUriFor(context, new File(externalDir, "test"));
+      } catch (IllegalArgumentException e) {
+        Log.w(
+            TAG,
+            "External cache dir not resolvable by FileProvider, "
+                + "falling back to internal cache",
+            e);
+        externalDir = null;
+      }
+    }
+
     if (externalDir == null) {
       externalDir = context.getCacheDir();
     }

--- a/src/main/res/xml/file_provider_paths.xml
+++ b/src/main/res/xml/file_provider_paths.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
+    <cache-path
+        name="cache"
+        path="." />
+
     <external-cache-path
         name="external_cache"
         path="." />


### PR DESCRIPTION
The way external cache is used right now is probably not entirely correct. If I read the document correctly, for sensitive information we shall use internal storage. In any case, this shall fix the immediate crash.

Fixes #4350