### PR TITLE
Remove usages of `class.getSimpleName()`

### DIFF
--- a/src/androidTest/java/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
+++ b/src/androidTest/java/com/b44t/messenger/uibenchmarks/EnterChatsBenchmark.java
@@ -39,7 +39,7 @@ public class EnterChatsBenchmark {
   // PLEASE BACKUP YOUR ACCOUNT BEFORE RUNNING THIS!
   // ==============================================================================================
 
-  private static final String TAG = EnterChatsBenchmark.class.getSimpleName();
+  private static final String TAG = "EnterChatsBenchmark";
 
   @Rule
   public ActivityScenarioRule<ConversationListActivity> activityRule =

--- a/src/foss/java/org/thoughtcrime/securesms/geolocation/LocationSourceFactory.java
+++ b/src/foss/java/org/thoughtcrime/securesms/geolocation/LocationSourceFactory.java
@@ -6,7 +6,7 @@ import android.util.Log;
 /** Non-GMS, always uses the platform LocationManager. */
 public final class LocationSourceFactory {
 
-  private static final String TAG = LocationSourceFactory.class.getSimpleName();
+  private static final String TAG = "LocationSourceFactory";
 
   private LocationSourceFactory() {}
 

--- a/src/gplay/java/org/thoughtcrime/securesms/geolocation/GmsLocationSource.java
+++ b/src/gplay/java/org/thoughtcrime/securesms/geolocation/GmsLocationSource.java
@@ -14,7 +14,7 @@ import com.google.android.gms.location.Priority;
 
 public class GmsLocationSource implements LocationSource {
 
-  private static final String TAG = GmsLocationSource.class.getSimpleName();
+  private static final String TAG = "GmsLocationSource";
   private static final long UPDATE_INTERVAL_MS = 3_000;
   private static final long FASTEST_INTERVAL_MS = 1_000;
 

--- a/src/gplay/java/org/thoughtcrime/securesms/geolocation/LocationSourceFactory.java
+++ b/src/gplay/java/org/thoughtcrime/securesms/geolocation/LocationSourceFactory.java
@@ -11,7 +11,7 @@ import com.google.android.gms.common.GoogleApiAvailability;
  */
 public final class LocationSourceFactory {
 
-  private static final String TAG = LocationSourceFactory.class.getSimpleName();
+  private static final String TAG = "LocationSourceFactory";
 
   private LocationSourceFactory() {}
 

--- a/src/gplay/java/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
+++ b/src/gplay/java/org/thoughtcrime/securesms/notifications/FcmReceiveService.java
@@ -17,7 +17,7 @@ import org.thoughtcrime.securesms.service.FetchForegroundService;
 import org.thoughtcrime.securesms.util.Util;
 
 public class FcmReceiveService extends FirebaseMessagingService {
-  private static final String TAG = FcmReceiveService.class.getSimpleName();
+  private static final String TAG = "FcmReceiveService";
   private static final Object INIT_LOCK = new Object();
   private static boolean initialized;
   private static volatile boolean triedRegistering;

--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -59,7 +59,6 @@ public class DcMsg {
   public static final int DC_VIDEOCHATTYPE_UNKNOWN = 0;
   public static final int DC_VIDEOCHATTYPE_BASICWEBRTC = 1;
 
-  private static final String TAG = "DcMsg";
 
   public DcMsg(DcContext context, int viewtype) {
     msgCPtr = context.createMsgCPtr(viewtype);

--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -59,7 +59,6 @@ public class DcMsg {
   public static final int DC_VIDEOCHATTYPE_UNKNOWN = 0;
   public static final int DC_VIDEOCHATTYPE_BASICWEBRTC = 1;
 
-
   public DcMsg(DcContext context, int viewtype) {
     msgCPtr = context.createMsgCPtr(viewtype);
   }

--- a/src/main/java/com/b44t/messenger/DcMsg.java
+++ b/src/main/java/com/b44t/messenger/DcMsg.java
@@ -59,7 +59,7 @@ public class DcMsg {
   public static final int DC_VIDEOCHATTYPE_UNKNOWN = 0;
   public static final int DC_VIDEOCHATTYPE_BASICWEBRTC = 1;
 
-  private static final String TAG = DcMsg.class.getSimpleName();
+  private static final String TAG = "DcMsg";
 
   public DcMsg(DcContext context, int viewtype) {
     msgCPtr = context.createMsgCPtr(viewtype);

--- a/src/main/java/org/thoughtcrime/securesms/AllMediaActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/AllMediaActivity.java
@@ -35,7 +35,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class AllMediaActivity extends PassphraseRequiredActionBarActivity
     implements DcEventCenter.DcEventDelegate {
-  private static final String TAG = AllMediaActivity.class.getSimpleName();
+  private static final String TAG = "AllMediaActivity";
 
   public static final String CHAT_ID_EXTRA = "chat_id";
   public static final String CONTACT_ID_EXTRA = "contact_id";

--- a/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -50,7 +50,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.webxdc.WebxdcGarbageCollectionWorker;
 
 public class ApplicationContext extends MultiDexApplication {
-  private static final String TAG = ApplicationContext.class.getSimpleName();
+  private static final String TAG = "ApplicationContext";
   private static final Object initLock = new Object();
   private static volatile boolean isInitialized = false;
 

--- a/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -20,7 +20,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public abstract class BaseActionBarActivity extends AppCompatActivity {
 
-  private static final String TAG = BaseActionBarActivity.class.getSimpleName();
+  private static final String TAG = "BaseActionBarActivity";
   protected DynamicTheme dynamicTheme = new DynamicTheme();
 
   protected void onPreCreate() {

--- a/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
@@ -47,7 +47,7 @@ import org.thoughtcrime.securesms.util.task.SnackbarAsyncTask;
 import org.thoughtcrime.securesms.util.views.ProgressDialog;
 
 public abstract class BaseConversationListFragment extends Fragment implements ActionMode.Callback {
-  private static final String TAG = BaseConversationListFragment.class.getSimpleName();
+  private static final String TAG = "BaseConversationListFragment";
   protected ActionMode actionMode;
   protected PulsingFloatingActionButton fab;
 

--- a/src/main/java/org/thoughtcrime/securesms/ContactSelectionActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ContactSelectionActivity.java
@@ -29,7 +29,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
  */
 public abstract class ContactSelectionActivity extends PassphraseRequiredActionBarActivity
     implements ContactSelectionListFragment.OnContactSelectedListener {
-  private static final String TAG = ContactSelectionActivity.class.getSimpleName();
+  private static final String TAG = "ContactSelectionActivity";
 
   protected ContactSelectionListFragment contactsFragment;
 

--- a/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -67,7 +67,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
  */
 public class ContactSelectionListFragment extends Fragment
     implements LoaderManager.LoaderCallbacks<DcContactsLoader.Ret>, DcEventCenter.DcEventDelegate {
-  private static final String TAG = ContactSelectionListFragment.class.getSimpleName();
+  private static final String TAG = "ContactSelectionListFragment";
 
   public static final String MULTI_SELECT = "multi_select";
   public static final String SELECT_UNENCRYPTED_EXTRA = "select_unencrypted_extra";

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -149,7 +149,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         InputPanel.Listener,
         InputPanel.MediaListener,
         AudioView.OnActionListener {
-  private static final String TAG = ConversationActivity.class.getSimpleName();
+  private static final String TAG = "ConversationActivity";
 
   public static final String ACCOUNT_ID_EXTRA = "account_id";
   public static final String CHAT_ID_EXTRA = "chat_id";

--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -79,7 +79,7 @@ import org.thoughtcrime.securesms.util.views.ConversationAdaptiveActionsToolbar;
 
 @SuppressLint("StaticFieldLeak")
 public class ConversationFragment extends MessageSelectorFragment {
-  private static final String TAG = ConversationFragment.class.getSimpleName();
+  private static final String TAG = "ConversationFragment";
 
   private static final int SCROLL_ANIMATION_THRESHOLD = 50;
 

--- a/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
@@ -85,7 +85,7 @@ import org.thoughtcrime.securesms.util.views.Stub;
  * @author Moxie Marlinspike
  */
 public class ConversationItem extends BaseConversationItem {
-  private static final String TAG = ConversationItem.class.getSimpleName();
+  private static final String TAG = "ConversationItem";
 
   private static final Rect SWIPE_RECT = new Rect();
 

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -89,7 +89,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class ConversationListActivity extends PassphraseRequiredActionBarActivity
     implements ConversationListFragment.ConversationSelectedListener {
-  private static final String TAG = ConversationListActivity.class.getSimpleName();
+  private static final String TAG = "ConversationListActivity";
   private static final String OPENPGP4FPR = "openpgp4fpr";
   private static final String NDK_ARCH_WARNED = "ndk_arch_warned";
   public static final String CLEAR_NOTIFICATIONS = "clear_notifications";

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -56,7 +56,7 @@ public class ConversationListFragment extends BaseConversationListFragment
   public static final String ARCHIVE = "archive";
   public static final String RELOAD_LIST = "reload_list";
 
-  private static final String TAG = ConversationListFragment.class.getSimpleName();
+  private static final String TAG = "ConversationListFragment";
 
   private RecyclerView list;
   private View emptyState;

--- a/src/main/java/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -42,7 +42,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 @SuppressLint("StaticFieldLeak")
 public class CreateProfileActivity extends BaseActionBarActivity {
 
-  private static final String TAG = CreateProfileActivity.class.getSimpleName();
+  private static final String TAG = "CreateProfileActivity";
 
   private static final int REQUEST_CODE_AVATAR = 1;
 

--- a/src/main/java/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
+++ b/src/main/java/org/thoughtcrime/securesms/EphemeralMessagesDialog.java
@@ -15,7 +15,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class EphemeralMessagesDialog {
 
-  private static final String TAG = EphemeralMessagesDialog.class.getSimpleName();
+  private static final String TAG = "EphemeralMessagesDialog";
 
   public static void show(
       final Context context,

--- a/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -46,7 +46,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     implements ItemClickListener {
 
-  private static final String TAG = GroupCreateActivity.class.getSimpleName();
+  private static final String TAG = "GroupCreateActivity";
   public static final String EDIT_GROUP_CHAT_ID = "edit_group_chat_id";
   public static final String CREATE_BROADCAST = "create_broadcast";
   public static final String UNENCRYPTED = "unencrypted";

--- a/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/InstantOnboardingActivity.java
@@ -63,7 +63,7 @@ import org.thoughtcrime.securesms.util.views.ProgressDialog;
 public class InstantOnboardingActivity extends BaseActionBarActivity
     implements DcEventCenter.DcEventDelegate {
 
-  private static final String TAG = InstantOnboardingActivity.class.getSimpleName();
+  private static final String TAG = "InstantOnboardingActivity";
   private static final String DCACCOUNT = "dcaccount";
   private static final String DCLOGIN = "dclogin";
   private static final String INSTANCES_URL = "https://chatmail.at/relays";

--- a/src/main/java/org/thoughtcrime/securesms/LogViewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/LogViewActivity.java
@@ -18,7 +18,7 @@ import org.thoughtcrime.securesms.util.FileProviderUtil;
 
 public class LogViewActivity extends BaseActionBarActivity {
 
-  private static final String TAG = LogViewActivity.class.getSimpleName();
+  private static final String TAG = "LogViewActivity";
 
   LogViewFragment logViewFragment;
 

--- a/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -69,7 +69,7 @@ import org.thoughtcrime.securesms.util.Util;
 public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     implements RecipientModifiedListener, LoaderManager.LoaderCallbacks<DcMediaGalleryElement> {
 
-  private static final String TAG = MediaPreviewActivity.class.getSimpleName();
+  private static final String TAG = "MediaPreviewActivity";
 
   public static final String ACTIVITY_TITLE_EXTRA = "activity_title";
   public static final String EDIT_AVATAR_CHAT_ID = "avatar_for_chat_id";

--- a/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -41,7 +41,7 @@ import org.thoughtcrime.securesms.qr.QrCodeHandler;
  */
 public class NewConversationActivity extends ContactSelectionActivity {
 
-  private static final String TAG = NewConversationActivity.class.getSimpleName();
+  private static final String TAG = "NewConversationActivity";
 
   @Override
   public void onCreate(Bundle bundle, boolean ready) {

--- a/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -7,7 +7,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.service.GenericForegroundService;
 
 public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarActivity {
-  private static final String TAG = PassphraseRequiredActionBarActivity.class.getSimpleName();
+  private static final String TAG = "PassphraseRequiredActionBarActivity";
 
   @Override
   protected final void onCreate(Bundle savedInstanceState) {

--- a/src/main/java/org/thoughtcrime/securesms/ProfileAdapter.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileAdapter.java
@@ -30,7 +30,7 @@ import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.Util;
 
 public class ProfileAdapter extends RecyclerView.Adapter {
-  private static final String TAG = ProfileAdapter.class.getSimpleName();
+  private static final String TAG = "ProfileAdapter";
 
   public static final int ITEM_AVATAR = 10;
   public static final int ITEM_DIVIDER = 20;

--- a/src/main/java/org/thoughtcrime/securesms/ProfileFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ProfileFragment.java
@@ -38,7 +38,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 public class ProfileFragment extends Fragment
     implements ProfileAdapter.ItemClickListener, DcEventCenter.DcEventDelegate {
 
-  private static final String TAG = ProfileFragment.class.getSimpleName();
+  private static final String TAG = "ProfileFragment";
   public static final String CHAT_ID_EXTRA = "chat_id";
   public static final String CONTACT_ID_EXTRA = "contact_id";
 

--- a/src/main/java/org/thoughtcrime/securesms/ResolveMediaTask.java
+++ b/src/main/java/org/thoughtcrime/securesms/ResolveMediaTask.java
@@ -17,7 +17,7 @@ import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 
 public class ResolveMediaTask extends AsyncTask<Uri, Void, Uri> {
 
-  private static final String TAG = ResolveMediaTask.class.getSimpleName();
+  private static final String TAG = "ResolveMediaTask";
 
   interface OnMediaResolvedListener {
     void onMediaResolved(Uri uri);

--- a/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ShareActivity.java
@@ -47,7 +47,7 @@ import org.thoughtcrime.securesms.util.ShareUtil;
  */
 public class ShareActivity extends PassphraseRequiredActionBarActivity
     implements ResolveMediaTask.OnMediaResolvedListener {
-  private static final String TAG = ShareActivity.class.getSimpleName();
+  private static final String TAG = "ShareActivity";
 
   public static final String EXTRA_ACC_ID = "acc_id";
   public static final String EXTRA_CHAT_ID = "chat_id";

--- a/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
@@ -32,7 +32,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class WebViewActivity extends PassphraseRequiredActionBarActivity
     implements SearchView.OnQueryTextListener, WebView.FindListener {
-  private static final String TAG = WebViewActivity.class.getSimpleName();
+  private static final String TAG = "WebViewActivity";
   // Regex to extract the host from a URL for IDN conversion.
   private static final Pattern URL_PATTERN =
       Pattern.compile("^((?:[a-zA-Z0-9]+://)?)([^/?#]+)(.*)$");

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -58,7 +58,7 @@ import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.Util;
 
 public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcEventDelegate {
-  private static final String TAG = WebxdcActivity.class.getSimpleName();
+  private static final String TAG = "WebxdcActivity";
   private static final String EXTRA_ACCOUNT_ID = "accountId";
   private static final String EXTRA_APP_MSG_ID = "appMessageId";
   private static final String EXTRA_HIDE_ACTION_BAR = "hideActionBar";

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcStoreActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcStoreActivity.java
@@ -30,7 +30,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class WebxdcStoreActivity extends PassphraseRequiredActionBarActivity {
-  private static final String TAG = WebxdcStoreActivity.class.getSimpleName();
+  private static final String TAG = "WebxdcStoreActivity";
 
   private DcContext dcContext;
   private Rpc rpc;

--- a/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -49,7 +49,7 @@ public class WelcomeActivity extends BaseActionBarActivity
     implements DcEventCenter.DcEventDelegate {
   public static final String BACKUP_QR_EXTRA = "backup_qr_extra";
   public static final int PICK_BACKUP = 20574;
-  private static final String TAG = WelcomeActivity.class.getSimpleName();
+  private static final String TAG = "WelcomeActivity";
   public static final String TMP_BACKUP_FILE = "tmp-backup-file";
 
   private ProgressDialog progressDialog = null;

--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListFragment.java
@@ -41,7 +41,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class AccountSelectionListFragment extends DialogFragment
     implements DcEventCenter.DcEventDelegate {
-  private static final String TAG = AccountSelectionListFragment.class.getSimpleName();
+  private static final String TAG = "AccountSelectionListFragment";
   private static final String ARG_SELECT_ONLY = "select_only";
   private RecyclerView recyclerView;
   private AccountSelectionListAdapter adapter;

--- a/src/main/java/org/thoughtcrime/securesms/audio/AudioCodec.java
+++ b/src/main/java/org/thoughtcrime/securesms/audio/AudioCodec.java
@@ -15,7 +15,7 @@ import org.thoughtcrime.securesms.util.Prefs;
 
 public class AudioCodec {
 
-  private static final String TAG = AudioCodec.class.getSimpleName();
+  private static final String TAG = "AudioCodec";
 
   private static final int SAMPLE_RATE = 44100;
   private static final int CHANNELS = 1;
@@ -191,7 +191,7 @@ public class AudioCodec {
                 setFinished();
               }
             },
-            AudioCodec.class.getSimpleName())
+            "AudioCodec")
         .start();
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
+++ b/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
@@ -18,7 +18,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class AudioRecorder {
 
-  private static final String TAG = AudioRecorder.class.getSimpleName();
+  private static final String TAG = "AudioRecorder";
 
   private static final ExecutorService executor = ThreadUtil.newDynamicSingleThreadedExecutor();
 

--- a/src/main/java/org/thoughtcrime/securesms/calls/AudioDevicePickerDialog.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/AudioDevicePickerDialog.java
@@ -20,7 +20,7 @@ import org.thoughtcrime.securesms.R;
 /** Bottom sheet dialog for selecting audio output device */
 @RequiresApi(Build.VERSION_CODES.O)
 public class AudioDevicePickerDialog extends BottomSheetDialog {
-  private static final String TAG = AudioDevicePickerDialog.class.getSimpleName();
+  private static final String TAG = "AudioDevicePickerDialog";
 
   public interface OnDeviceSelectedListener {
     void onDeviceSelected(CallEndpointCompat endpoint);

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
@@ -51,7 +51,7 @@ import org.webrtc.VideoTrack;
 @RequiresApi(api = Build.VERSION_CODES.O)
 public class CallActivity extends AppCompatActivity {
 
-  private static final String TAG = CallActivity.class.getSimpleName();
+  private static final String TAG = "CallActivity";
   private static final int MIC_PERMISSION_REQUEST_CODE = 1001;
   private static final int CAMERA_PERMISSION_REQUEST_CODE = 1002;
 

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
@@ -63,7 +63,7 @@ import org.webrtc.VideoTrack;
 
 @RequiresApi(api = Build.VERSION_CODES.O)
 public class CallCoordinator implements DcEventCenter.DcEventDelegate {
-  private static final String TAG = CallCoordinator.class.getSimpleName();
+  private static final String TAG = "CallCoordinator";
 
   // Notification channels
   private static final String CHANNEL_ID_INCOMING = "voip_incoming_calls";

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallService.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallService.java
@@ -33,7 +33,7 @@ import org.webrtc.VideoTrack;
 @RequiresApi(api = Build.VERSION_CODES.O)
 public class CallService extends Service implements WebRTCClient.Callbacks {
 
-  private static final String TAG = CallService.class.getSimpleName();
+  private static final String TAG = "CallService";
 
   private final IBinder binder = new LocalBinder();
 

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallUtil.java
@@ -21,7 +21,7 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.BitmapUtil;
 
 public class CallUtil {
-  private static final String TAG = CallUtil.class.getSimpleName();
+  private static final String TAG = "CallUtil";
 
   @RequiresApi(api = Build.VERSION_CODES.O)
   public static void startAudioCall(Context context, int chatId) {

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallViewModel.java
@@ -20,7 +20,7 @@ import org.webrtc.VideoTrack;
 @RequiresApi(api = Build.VERSION_CODES.O)
 public class CallViewModel extends AndroidViewModel {
 
-  private static final String TAG = CallViewModel.class.getSimpleName();
+  private static final String TAG = "CallViewModel";
 
   private final CallCoordinator callCoordinator;
 

--- a/src/main/java/org/thoughtcrime/securesms/calls/MediaStreamManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/MediaStreamManager.java
@@ -24,7 +24,7 @@ import org.webrtc.VideoTrack;
 
 public class MediaStreamManager {
 
-  private static final String TAG = MediaStreamManager.class.getSimpleName();
+  private static final String TAG = "MediaStreamManager";
   private static final String STREAM_ID = "local_stream";
   private static final String AUDIO_TRACK_ID = "audio_track";
   private static final String VIDEO_TRACK_ID = "video_track";

--- a/src/main/java/org/thoughtcrime/securesms/components/CallItemView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/CallItemView.java
@@ -15,7 +15,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.DateUtils;
 
 public class CallItemView extends FrameLayout {
-  private static final String TAG = CallItemView.class.getSimpleName();
+  private static final String TAG = "CallItemView";
 
   private final @NonNull ImageView icon;
   private final @NonNull TextView title;

--- a/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
@@ -43,7 +43,7 @@ public class InputPanel extends ConstraintLayout
         KeyboardAwareLinearLayout.OnKeyboardShownListener,
         MediaKeyboard.MediaKeyboardListener {
 
-  private static final String TAG = InputPanel.class.getSimpleName();
+  private static final String TAG = "InputPanel";
 
   private static final int FADE_TIME = 150;
 

--- a/src/main/java/org/thoughtcrime/securesms/components/KeyboardAwareLinearLayout.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/KeyboardAwareLinearLayout.java
@@ -38,7 +38,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
  * been opened and what its height would be.
  */
 public class KeyboardAwareLinearLayout extends LinearLayoutCompat {
-  private static final String TAG = KeyboardAwareLinearLayout.class.getSimpleName();
+  private static final String TAG = "KeyboardAwareLinearLayout";
 
   private static final long KEYBOARD_DEBOUNCE = 150;
 

--- a/src/main/java/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/QuoteView.java
@@ -35,7 +35,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class QuoteView extends FrameLayout implements RecipientForeverObserver {
 
-  private static final String TAG = QuoteView.class.getSimpleName();
+  private static final String TAG = "QuoteView";
 
   private static final int MESSAGE_TYPE_PREVIEW = 0;
 

--- a/src/main/java/org/thoughtcrime/securesms/components/ScaleStableImageView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/ScaleStableImageView.java
@@ -30,7 +30,7 @@ public class ScaleStableImageView extends AppCompatImageView
     implements KeyboardAwareLinearLayout.OnKeyboardShownListener,
         KeyboardAwareLinearLayout.OnKeyboardHiddenListener {
 
-  private static final String TAG = ScaleStableImageView.class.getSimpleName();
+  private static final String TAG = "ScaleStableImageView";
 
   private Drawable defaultDrawable;
   private Drawable currentDrawable;

--- a/src/main/java/org/thoughtcrime/securesms/components/SearchToolbar.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/SearchToolbar.java
@@ -22,7 +22,7 @@ import org.thoughtcrime.securesms.animation.AnimationCompleteListener;
 
 public class SearchToolbar extends LinearLayout {
 
-  private static final String TAG = SearchToolbar.class.getSimpleName();
+  private static final String TAG = "SearchToolbar";
   private float x, y;
   private MenuItem searchItem;
   private EditText searchText;

--- a/src/main/java/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -30,7 +30,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class ThumbnailView extends FrameLayout {
 
-  private static final String TAG = ThumbnailView.class.getSimpleName();
+  private static final String TAG = "ThumbnailView";
   private static final int WIDTH = 0;
   private static final int HEIGHT = 1;
   private static final int MIN_WIDTH = 0;

--- a/src/main/java/org/thoughtcrime/securesms/components/VcardView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/VcardView.java
@@ -17,7 +17,7 @@ import org.thoughtcrime.securesms.mms.VcardSlide;
 import org.thoughtcrime.securesms.recipients.Recipient;
 
 public class VcardView extends FrameLayout {
-  private static final String TAG = VcardView.class.getSimpleName();
+  private static final String TAG = "VcardView";
 
   private final @NonNull AvatarView avatar;
   private final @NonNull TextView name;

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class AudioPlaybackViewModel extends ViewModel {
-  private static final String TAG = AudioPlaybackViewModel.class.getSimpleName();
+  private static final String TAG = "AudioPlaybackViewModel";
 
   private static final int NON_MESSAGE_AUDIO_MSG_ID =
       0; // Audios not attached to a message doesn't have message id.

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -23,7 +23,7 @@ import org.thoughtcrime.securesms.util.DateUtils;
 
 public class AudioView extends FrameLayout {
 
-  private static final String TAG = AudioView.class.getSimpleName();
+  private static final String TAG = "AudioView";
 
   private final @NonNull ImageView playPauseButton;
   private final AnimatedVectorDrawableCompat playToPauseDrawable;

--- a/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboard.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboard.java
@@ -22,7 +22,7 @@ import org.thoughtcrime.securesms.util.ResUtil;
 public class MediaKeyboard extends LinearLayout
     implements InputView, Consumer<EmojiViewItem>, StickerPickerView.StickerPickerListener {
 
-  private static final String TAG = MediaKeyboard.class.getSimpleName();
+  private static final String TAG = "MediaKeyboard";
 
   @Nullable private MediaKeyboardListener keyboardListener;
   private EmojiPickerView emojiPicker;

--- a/src/main/java/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -23,7 +23,7 @@ import org.thoughtcrime.securesms.util.Prefs;
 
 @SuppressLint("BatteryLife")
 public class DozeReminder {
-  private static final String TAG = DozeReminder.class.getSimpleName();
+  private static final String TAG = "DozeReminder";
 
   public static boolean isEligible(Context context) {
     if (context == null) {

--- a/src/main/java/org/thoughtcrime/securesms/components/viewpager/HackyViewPager.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/viewpager/HackyViewPager.java
@@ -19,7 +19,7 @@ import androidx.viewpager.widget.ViewPager;
  */
 public class HackyViewPager extends ViewPager {
 
-  private static final String TAG = HackyViewPager.class.getSimpleName();
+  private static final String TAG = "HackyViewPager";
 
   public HackyViewPager(Context context) {
     super(context);

--- a/src/main/java/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -18,7 +18,7 @@ import org.thoughtcrime.securesms.accounts.AccountSelectionListFragment;
 
 public class AccountManager {
 
-  private static final String TAG = AccountManager.class.getSimpleName();
+  private static final String TAG = "AccountManager";
   private static final String LAST_ACCOUNT_ID = "last_account_id";
   private static AccountManager self;
 

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java
@@ -14,7 +14,7 @@ import org.thoughtcrime.securesms.service.FetchForegroundService;
 import org.thoughtcrime.securesms.util.Util;
 
 public class DcEventCenter {
-  private static final String TAG = DcEventCenter.class.getSimpleName();
+  private static final String TAG = "DcEventCenter";
   private @NonNull final Hashtable<Integer, ArrayList<DcEventDelegate>> currentAccountObservers =
       new Hashtable<>();
   private @NonNull final Hashtable<Integer, ArrayList<DcEventDelegate>> multiAccountObservers =

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -42,7 +42,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class DcHelper {
 
-  private static final String TAG = DcHelper.class.getSimpleName();
+  private static final String TAG = "DcHelper";
 
   public static final String CONFIG_CONFIGURED_ADDRESS = "configured_addr";
   public static final String CONFIG_DISPLAY_NAME = "displayname";

--- a/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
@@ -40,7 +40,7 @@ import org.thoughtcrime.securesms.util.Util;
  */
 public class DirectShareUtil {
 
-  private static final String TAG = DirectShareUtil.class.getSimpleName();
+  private static final String TAG = "DirectShareUtil";
   private static final String SHORTCUT_CATEGORY = "android.shortcut.conversation";
 
   public static void clearShortcut(@NonNull Context context, int chatId) {

--- a/src/main/java/org/thoughtcrime/securesms/connect/KeepAliveService.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/KeepAliveService.java
@@ -21,7 +21,7 @@ import org.thoughtcrime.securesms.util.Prefs;
 
 public class KeepAliveService extends Service {
 
-  private static final String TAG = KeepAliveService.class.getSimpleName();
+  private static final String TAG = "KeepAliveService";
 
   static KeepAliveService s_this = null;
 

--- a/src/main/java/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/NetworkStateReceiver.java
@@ -10,7 +10,7 @@ import android.util.Log;
 
 public class NetworkStateReceiver extends BroadcastReceiver {
 
-  private static final String TAG = NetworkStateReceiver.class.getSimpleName();
+  private static final String TAG = "NetworkStateReceiver";
   private int debugConnectedCount;
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/main/java/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.thoughtcrime.securesms.ContactSelectionListFragment;
 import org.thoughtcrime.securesms.util.Hash;
 import org.thoughtcrime.securesms.util.Prefs;
 

--- a/src/main/java/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/main/java/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -37,7 +37,7 @@ import org.thoughtcrime.securesms.util.Prefs;
  * @author Moxie Marlinspike
  */
 public class ContactAccessor {
-  private static final String TAG = ContactSelectionListFragment.class.getSimpleName();
+  private static final String TAG = "ContactSelectionListFragment";
 
   private static final int CONTACT_CURSOR_NAME = 0;
 

--- a/src/main/java/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/main/java/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -36,7 +36,7 @@ import org.thoughtcrime.securesms.util.Prefs;
  * @author Moxie Marlinspike
  */
 public class ContactAccessor {
-  private static final String TAG = "ContactSelectionListFragment";
+  private static final String TAG = "ContactAccessor";
 
   private static final int CONTACT_CURSOR_NAME = 0;
 

--- a/src/main/java/org/thoughtcrime/securesms/database/loaders/PagingMediaLoader.java
+++ b/src/main/java/org/thoughtcrime/securesms/database/loaders/PagingMediaLoader.java
@@ -12,7 +12,7 @@ import org.thoughtcrime.securesms.util.AsyncLoader;
 
 public class PagingMediaLoader extends AsyncLoader<DcMediaGalleryElement> {
 
-  private static final String TAG = PagingMediaLoader.class.getSimpleName();
+  private static final String TAG = "PagingMediaLoader";
 
   private final DcMsg msg;
   private final boolean leftIsRecent;

--- a/src/main/java/org/thoughtcrime/securesms/geolocation/LocationStreamingService.java
+++ b/src/main/java/org/thoughtcrime/securesms/geolocation/LocationStreamingService.java
@@ -23,7 +23,7 @@ import org.thoughtcrime.securesms.connect.DcHelper;
 
 public class LocationStreamingService extends Service {
 
-  private static final String TAG = LocationStreamingService.class.getSimpleName();
+  private static final String TAG = "LocationStreamingService";
   private static final String ACTION_STOP = "org.thoughtcrime.securesms.geolocation.STOP_STREAMING";
   private static final int NOTIFICATION_ID = 8801;
   private static final String CHANNEL_ID = "location_streaming";

--- a/src/main/java/org/thoughtcrime/securesms/geolocation/PlatformLocationSource.java
+++ b/src/main/java/org/thoughtcrime/securesms/geolocation/PlatformLocationSource.java
@@ -15,7 +15,7 @@ import java.util.concurrent.Executor;
 
 public class PlatformLocationSource implements LocationSource {
 
-  private static final String TAG = PlatformLocationSource.class.getSimpleName();
+  private static final String TAG = "PlatformLocationSource";
   private static final long UPDATE_INTERVAL_MS = 0;
 
   private LocationManager locationManager;

--- a/src/main/java/org/thoughtcrime/securesms/jobmanager/JobConsumer.java
+++ b/src/main/java/org/thoughtcrime/securesms/jobmanager/JobConsumer.java
@@ -19,7 +19,7 @@ import androidx.annotation.NonNull;
 
 class JobConsumer extends Thread {
 
-  private static final String TAG = JobConsumer.class.getSimpleName();
+  private static final String TAG = "JobConsumer";
 
   enum JobResult {
     SUCCESS,

--- a/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -75,7 +75,7 @@ import org.thoughtcrime.securesms.util.views.Stub;
 
 public class AttachmentManager {
 
-  private static final String TAG = AttachmentManager.class.getSimpleName();
+  private static final String TAG = "AttachmentManager";
 
   private final @NonNull Context context;
   private final @NonNull Stub<View> attachmentViewStub;

--- a/src/main/java/org/thoughtcrime/securesms/mms/DecryptableStreamLocalUriFetcher.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/DecryptableStreamLocalUriFetcher.java
@@ -11,7 +11,7 @@ import java.io.InputStream;
 
 class DecryptableStreamLocalUriFetcher extends StreamLocalUriFetcher {
 
-  private static final String TAG = DecryptableStreamLocalUriFetcher.class.getSimpleName();
+  private static final String TAG = "DecryptableStreamLocalUriFetcher";
 
   private final Context context;
 

--- a/src/main/java/org/thoughtcrime/securesms/notifications/InChatSounds.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/InChatSounds.java
@@ -7,7 +7,7 @@ import android.util.Log;
 import org.thoughtcrime.securesms.R;
 
 public class InChatSounds {
-  private static final String TAG = InChatSounds.class.getSimpleName();
+  private static final String TAG = "InChatSounds";
   private static volatile InChatSounds instance;
 
   private SoundPool soundPool = null;

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -54,7 +54,7 @@ import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 public class NotificationCenter {
-  private static final String TAG = NotificationCenter.class.getSimpleName();
+  private static final String TAG = "NotificationCenter";
   @NonNull private final ApplicationContext context;
   private volatile ChatData visibleChat = null;
   private volatile Pair<Integer, Integer> visibleWebxdc = null;

--- a/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -33,7 +33,7 @@ import org.thoughtcrime.securesms.util.Util;
 /** Get the response text from the Wearable Device and sends an message as a reply */
 public class RemoteReplyReceiver extends BroadcastReceiver {
 
-  public static final String TAG = RemoteReplyReceiver.class.getSimpleName();
+  public static final String TAG = "RemoteReplyReceiver";
   public static final String REPLY_ACTION = "org.thoughtcrime.securesms.notifications.WEAR_REPLY";
   public static final String ACCOUNT_ID_EXTRA = "account_id";
   public static final String CHAT_ID_EXTRA = "chat_id";

--- a/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -45,7 +45,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment
     implements DcEventCenter.DcEventDelegate {
-  private static final String TAG = AdvancedPreferenceFragment.class.getSimpleName();
+  private static final String TAG = "AdvancedPreferenceFragment";
 
   private ListPreference showEmails;
   CheckBoxPreference selfReportingCheckbox;

--- a/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -34,7 +34,7 @@ import org.thoughtcrime.securesms.util.Prefs;
 public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragment
     implements Preference.OnPreferenceChangeListener {
 
-  private static final String TAG = NotificationsPreferenceFragment.class.getSimpleName();
+  private static final String TAG = "NotificationsPreferenceFragment";
 
   private CheckBoxPreference ignoreBattery;
   private CheckBoxPreference notificationsEnabled;

--- a/src/main/java/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
+++ b/src/main/java/org/thoughtcrime/securesms/providers/PersistentBlobProvider.java
@@ -24,7 +24,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class PersistentBlobProvider {
 
-  private static final String TAG = PersistentBlobProvider.class.getSimpleName();
+  private static final String TAG = "PersistentBlobProvider";
 
   private static final String URI_STRING = "content://org.thoughtcrime.securesms/capture-new";
   public static final Uri CONTENT_URI = Uri.parse(URI_STRING);

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupProviderFragment.java
@@ -26,7 +26,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class BackupProviderFragment extends Fragment implements DcEventCenter.DcEventDelegate {
 
-  private static final String TAG = BackupProviderFragment.class.getSimpleName();
+  private static final String TAG = "BackupProviderFragment";
 
   private DcContext dcContext;
   private DcBackupProvider dcBackupProvider;

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupReceiverFragment.java
@@ -19,7 +19,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class BackupReceiverFragment extends Fragment implements DcEventCenter.DcEventDelegate {
 
-  private static final String TAG = BackupProviderFragment.class.getSimpleName();
+  private static final String TAG = "BackupProviderFragment";
 
   private DcContext dcContext;
   private TextView statusLine;

--- a/src/main/java/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/BackupTransferActivity.java
@@ -27,7 +27,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class BackupTransferActivity extends BaseActionBarActivity {
 
-  private static final String TAG = BackupTransferActivity.class.getSimpleName();
+  private static final String TAG = "BackupTransferActivity";
 
   public enum TransferMode {
     INVALID(0),

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
@@ -40,7 +40,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class QrActivity extends BaseActionBarActivity implements View.OnClickListener {
 
-  private static final String TAG = QrActivity.class.getSimpleName();
+  private static final String TAG = "QrActivity";
   public static final String EXTRA_SCAN_RELAY = "scan_relay";
 
   private static final int REQUEST_CODE_IMAGE = 46243;

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -26,7 +26,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.views.ProgressDialog;
 
 public class QrCodeHandler {
-  private static final String TAG = QrCodeHandler.class.getSimpleName();
+  private static final String TAG = "QrCodeHandler";
 
   public static int SECUREJOIN_SOURCE_EXTERNAL_LINK = 1;
   public static int SECUREJOIN_SOURCE_INTERNAL_LINK = 2;

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrScanFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrScanFragment.java
@@ -19,7 +19,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class QrScanFragment extends Fragment {
 
-  private static final String TAG = QrScanFragment.class.getSimpleName();
+  private static final String TAG = "QrScanFragment";
 
   private CompoundBarcodeView barcodeScannerView;
   private MyCaptureManager capture;

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrShowFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrShowFragment.java
@@ -30,7 +30,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class QrShowFragment extends Fragment implements DcEventCenter.DcEventDelegate {
 
-  private static final String TAG = QrShowFragment.class.getSimpleName();
+  private static final String TAG = "QrShowFragment";
   public static final int WHITE = 0xFFFFFFFF;
   private static final int BLACK = 0xFF000000;
   private static final int WIDTH = 400;

--- a/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsDetailsFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsDetailsFragment.java
@@ -31,7 +31,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class ReactionsDetailsFragment extends DialogFragment
     implements DcEventCenter.DcEventDelegate {
-  private static final String TAG = ReactionsDetailsFragment.class.getSimpleName();
+  private static final String TAG = "ReactionsDetailsFragment";
   private static final String ARG_MSG_ID = "msg_id";
 
   private RecyclerView recyclerView;

--- a/src/main/java/org/thoughtcrime/securesms/relay/EditRelayActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/relay/EditRelayActivity.java
@@ -56,7 +56,7 @@ public class EditRelayActivity extends BaseActionBarActivity
     PORT,
   }
 
-  private static final String TAG = EditRelayActivity.class.getSimpleName();
+  private static final String TAG = "EditRelayActivity";
   public static final String EXTRA_ADDR = "extra_addr";
 
   private TextInputEditText emailInput;

--- a/src/main/java/org/thoughtcrime/securesms/relay/RelayListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/relay/RelayListActivity.java
@@ -37,7 +37,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 public class RelayListActivity extends BaseActionBarActivity
     implements RelayListAdapter.OnRelayClickListener, DcEventCenter.DcEventDelegate {
 
-  private static final String TAG = RelayListActivity.class.getSimpleName();
+  private static final String TAG = "RelayListActivity";
   public static final String EXTRA_QR_DATA = "qr_data";
 
   private RelayListAdapter adapter;

--- a/src/main/java/org/thoughtcrime/securesms/scribbles/ImageEditorFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/scribbles/ImageEditorFragment.java
@@ -37,7 +37,7 @@ import org.thoughtcrime.securesms.util.Util;
 public final class ImageEditorFragment extends Fragment
     implements ImageEditorHud.EventListener, VerticalSlideColorPicker.OnColorChangeListener {
 
-  private static final String TAG = ImageEditorFragment.class.getSimpleName();
+  private static final String TAG = "ImageEditorFragment";
 
   private static final String KEY_IMAGE_URI = "image_uri";
 

--- a/src/main/java/org/thoughtcrime/securesms/scribbles/StickerSelectActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/scribbles/StickerSelectActivity.java
@@ -29,7 +29,7 @@ import org.thoughtcrime.securesms.R;
 public class StickerSelectActivity extends FragmentActivity
     implements StickerSelectFragment.StickerSelectionListener {
 
-  private static final String TAG = StickerSelectActivity.class.getSimpleName();
+  private static final String TAG = "StickerSelectActivity";
 
   public static final String EXTRA_STICKER_FILE = "extra_sticker_file";
 

--- a/src/main/java/org/thoughtcrime/securesms/scribbles/UriGlideRenderer.java
+++ b/src/main/java/org/thoughtcrime/securesms/scribbles/UriGlideRenderer.java
@@ -40,7 +40,7 @@ import org.thoughtcrime.securesms.util.BitmapUtil;
  */
 final class UriGlideRenderer implements Renderer {
 
-  private static final String TAG = UriGlideRenderer.class.getSimpleName();
+  private static final String TAG = "UriGlideRenderer";
 
   private static final int PREVIEW_DIMENSION_LIMIT = 2048;
   private static final int MAX_BLUR_DIMENSION = 300;

--- a/src/main/java/org/thoughtcrime/securesms/search/SearchViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/search/SearchViewModel.java
@@ -15,7 +15,7 @@ import org.thoughtcrime.securesms.search.model.SearchResult;
 import org.thoughtcrime.securesms.util.Util;
 
 class SearchViewModel extends ViewModel {
-  private static final String TAG = SearchViewModel.class.getSimpleName();
+  private static final String TAG = "SearchViewModel";
   private final ObservingLiveData searchResult;
   private String lastQuery;
   private final DcContext dcContext;

--- a/src/main/java/org/thoughtcrime/securesms/service/AudioPlaybackService.java
+++ b/src/main/java/org/thoughtcrime/securesms/service/AudioPlaybackService.java
@@ -22,7 +22,7 @@ import org.thoughtcrime.securesms.ConversationListActivity;
 
 public class AudioPlaybackService extends MediaSessionService {
 
-  private static final String TAG = AudioPlaybackService.class.getSimpleName();
+  private static final String TAG = "AudioPlaybackService";
 
   private ExoPlayer player;
   private MediaSession session;

--- a/src/main/java/org/thoughtcrime/securesms/service/FetchForegroundService.java
+++ b/src/main/java/org/thoughtcrime/securesms/service/FetchForegroundService.java
@@ -16,7 +16,7 @@ import org.thoughtcrime.securesms.notifications.NotificationCenter;
 import org.thoughtcrime.securesms.util.Util;
 
 public final class FetchForegroundService extends Service {
-  private static final String TAG = FetchForegroundService.class.getSimpleName();
+  private static final String TAG = "FetchForegroundService";
   private static final Object SERVICE_LOCK = new Object();
   private static final Object STOP_NOTIFIER = new Object();
   private static volatile boolean fetchingSynchronously = false;

--- a/src/main/java/org/thoughtcrime/securesms/service/GenericForegroundService.java
+++ b/src/main/java/org/thoughtcrime/securesms/service/GenericForegroundService.java
@@ -28,7 +28,7 @@ import org.thoughtcrime.securesms.util.IntentUtils;
 
 public final class GenericForegroundService extends Service {
 
-  private static final String TAG = GenericForegroundService.class.getSimpleName();
+  private static final String TAG = "GenericForegroundService";
 
   private final IBinder binder = new LocalBinder();
 

--- a/src/main/java/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -26,7 +26,7 @@ import javax.microedition.khronos.egl.EGLDisplay;
 
 public class BitmapUtil {
 
-  private static final String TAG = BitmapUtil.class.getSimpleName();
+  private static final String TAG = "BitmapUtil";
 
   @WorkerThread
   public static Bitmap createScaledBitmap(Bitmap bitmap, int maxWidth, int maxHeight) {

--- a/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -35,7 +35,7 @@ import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 
 public class MediaUtil {
 
-  private static final String TAG = MediaUtil.class.getSimpleName();
+  private static final String TAG = "MediaUtil";
 
   public static final String IMAGE_WEBP = "image/webp";
   public static final String IMAGE_JPEG = "image/jpeg";

--- a/src/main/java/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Prefs.java
@@ -22,7 +22,7 @@ import org.thoughtcrime.securesms.preferences.widgets.NotificationPrivacyPrefere
 
 public class Prefs {
 
-  private static final String TAG = Prefs.class.getSimpleName();
+  private static final String TAG = "Prefs";
 
   public static final String RELIABLE_SERVICE_PREF = "pref_reliable_service";
   public static final String DISABLE_PASSPHRASE_PREF = "pref_disable_passphrase";

--- a/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -34,7 +34,7 @@ import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 
 public class SaveAttachmentTask
     extends ProgressDialogAsyncTask<SaveAttachmentTask.Attachment, Void, Pair<Integer, Uri>> {
-  private static final String TAG = SaveAttachmentTask.class.getSimpleName();
+  private static final String TAG = "SaveAttachmentTask";
 
   static final int SUCCESS = 0;
   private static final int FAILURE = 1;

--- a/src/main/java/org/thoughtcrime/securesms/util/Util.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Util.java
@@ -58,7 +58,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.ComposeText;
 
 public class Util {
-  private static final String TAG = Util.class.getSimpleName();
+  private static final String TAG = "Util";
   public static final String INVITE_DOMAIN = "i.delta.chat";
 
   public static final Handler handler = new Handler(Looper.getMainLooper());

--- a/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -50,7 +50,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.views.Stub;
 
 public class ViewUtil {
-  private static final String TAG = ViewUtil.class.getSimpleName();
+  private static final String TAG = "ViewUtil";
 
   @SuppressWarnings("deprecation")
   public static void setBackground(final @NonNull View v, final @Nullable Drawable drawable) {

--- a/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
+++ b/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
@@ -26,7 +26,7 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class VideoRecoder {
 
-  private static final String TAG = VideoRecoder.class.getSimpleName();
+  private static final String TAG = "VideoRecoder";
 
   private static final String MIME_TYPE = "video/avc";
   private final boolean cancelCurrentVideoConversion = false;

--- a/src/main/java/org/thoughtcrime/securesms/webrtc/WebRTCClient.java
+++ b/src/main/java/org/thoughtcrime/securesms/webrtc/WebRTCClient.java
@@ -44,7 +44,7 @@ import org.webrtc.VideoTrack;
 @RequiresApi(Build.VERSION_CODES.M)
 public class WebRTCClient {
 
-  private static final String TAG = WebRTCClient.class.getSimpleName();
+  private static final String TAG = "WebRTCClient";
 
   private static final int DC_ID_ICE_TRICKLING = 1;
   private static final int DC_ID_MUTED_STATE = 3;

--- a/src/main/java/org/thoughtcrime/securesms/webxdc/WebxdcGarbageCollectionWorker.java
+++ b/src/main/java/org/thoughtcrime/securesms/webxdc/WebxdcGarbageCollectionWorker.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 import org.thoughtcrime.securesms.connect.DcHelper;
 
 public class WebxdcGarbageCollectionWorker extends ListenableWorker {
-  private static final String TAG = WebxdcGarbageCollectionWorker.class.getSimpleName();
+  private static final String TAG = "WebxdcGarbageCollectionWorker";
   private Context context;
 
   public WebxdcGarbageCollectionWorker(Context context, WorkerParameters params) {


### PR DESCRIPTION
Currently all TAGs in classes are generated at runtime using `class.getSimpleName()`. This causes problems on release builds because the class names are obfuscated by ProGuard, thus resulting in log lines like these:

```
03-11 22:08:19.022 15827 15827 🔵 j       : startSession: sessionId=[0]
03-11 22:08:19.064 15827 15827 🔵 f       : omitting devices =[]
03-11 22:08:19.066 15827 15827 🔵 p       : getAvailableStartingCallEndpoints: awaitClose
03-11 22:08:19.066 15827 15827 🔵 j       : endSession: sessionId=[0]
03-11 22:08:19.090 15827 15827 🔵 f       : omitting devices =[(type=[18], name=[Pixel 5]),(type=[24], name=[Pixel 5])
```

where j, f, p shall be actual class names.

Retrace does not handle this automatically.

#skip-changelog