### PR TITLE
fix warning string, make reuse of new explicit button strings

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -307,8 +307,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
 
   private boolean showGroupNameEmptyToast(String groupName) {
     if (groupName == null) {
-      Toast.makeText(this, getString(R.string.group_please_enter_group_name), Toast.LENGTH_LONG)
-          .show();
+      Toast.makeText(this, getString(R.string.please_enter_chat_name), Toast.LENGTH_LONG).show();
       return true;
     }
     return false;

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -363,20 +363,24 @@ public class QrCodeHandler {
       SecurejoinSource source,
       SecurejoinUiPath uipath) {
     String msg;
+    int positiveButton;
     switch (qrParsed.getState()) {
       case DcContext.DC_QR_ASK_VERIFYGROUP:
         msg = activity.getString(R.string.qrscan_ask_join_group, qrParsed.getText1());
+        positiveButton = R.string.join_group;
         break;
       case DcContext.DC_QR_ASK_JOIN_BROADCAST:
         msg = activity.getString(R.string.qrscan_ask_join_channel, qrParsed.getText1());
+        positiveButton = R.string.join_channel;
         break;
       default:
         msg = activity.getString(R.string.ask_start_chat_with, name);
+        positiveButton = R.string.ok;
         break;
     }
     builder.setMessage(msg);
     builder.setPositiveButton(
-        android.R.string.ok,
+        positiveButton,
         (dialogInterface, i) -> {
           secureJoinByQr(qrRawString, source, uipath);
         });


### PR DESCRIPTION
this PR makes use of some more explicit strings introduced at https://github.com/deltachat/deltachat-android/pull/4372 and fixes an warning message (in a channel it says you shall enter a group name)

## before/after joining message

<img width="320" src="https://github.com/user-attachments/assets/b9d3c946-d766-4413-963c-6cc6d4e78c62" /> <img width="320" src="https://github.com/user-attachments/assets/94d01905-9d49-4aa5-8c83-128315f88498" />

## before/after name warning

<img width="320" src="https://github.com/user-attachments/assets/89a4fe08-a5fa-4bf0-b5c6-652cb15e39e2" /> <img width="320" src="https://github.com/user-attachments/assets/de9c99a8-635f-439d-b199-1c1ae583116d" />


