### PR TITLE
allow to share location for 24 hours, remove 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Better incoming call system integration
 * Calls are not experimental anymore and don't need to be manually enabled
 * Display a permanent notification when doing location streaming and get rid of dangerous "Access Location in Background" permission
+* Allow to share location for 24 hours
 * Allow mini-apps to play audio without user interaction
 * Mark chats as unread (long tap a chat and select the corresponding option from the three-dot-menu)
 

--- a/src/main/java/org/thoughtcrime/securesms/ShareLocationDialog.java
+++ b/src/main/java/org/thoughtcrime/securesms/ShareLocationDialog.java
@@ -18,19 +18,19 @@ public class ShareLocationDialog {
           switch (which) {
             default:
             case 0:
-              shareLocationUnit = 5 * 60;
-              break;
-            case 1:
               shareLocationUnit = 30 * 60;
               break;
-            case 2:
+            case 1:
               shareLocationUnit = 60 * 60;
               break;
-            case 3:
+            case 2:
               shareLocationUnit = 2 * 60 * 60;
               break;
-            case 4:
+            case 3:
               shareLocationUnit = 6 * 60 * 60;
+              break;
+            case 4:
+              shareLocationUnit = 24 * 60 * 60;
               break;
           }
 

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -121,11 +121,10 @@
     </string-array>
 
     <string-array name="share_location_durations">
-        <item>@string/share_location_for_5_minutes</item>
         <item>@string/share_location_for_30_minutes</item>
         <item>@string/share_location_for_one_hour</item>
         <item>@string/share_location_for_two_hours</item>
-        <item>@string/share_location_for_six_hours</item>
+        <item>@string/share_location_for_24_hours</item>
     </string-array>
 
     <string-array name="recipient_vibrate_entries">

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -124,6 +124,7 @@
         <item>@string/share_location_for_30_minutes</item>
         <item>@string/share_location_for_one_hour</item>
         <item>@string/share_location_for_two_hours</item>
+        <item>@string/share_location_for_six_hours</item>
         <item>@string/share_location_for_24_hours</item>
     </string-array>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -380,11 +380,14 @@
     <string name="mute_for_seven_days">Mute for 7 days</string>
     <string name="mute_forever">Mute forever</string>
 
+    <!-- deprecated -->
     <string name="share_location_for_5_minutes">For 5 minutes</string>
+
     <string name="share_location_for_30_minutes">For 30 minutes</string>
     <string name="share_location_for_one_hour">For 1 hour</string>
     <string name="share_location_for_two_hours">For 2 hours</string>
     <string name="share_location_for_six_hours">For 6 hours</string>
+    <string name="share_location_for_24_hours">For 24 hours</string>
 
     <plurals name="ask_send_following_n_files_to">
         <item quantity="one">Send the following file to %s?</item>


### PR DESCRIPTION
now with the permanent notification is harder to forget you are streaming location so add 24 hours since some people have requested this (ex. people doing long bike trips)
 
5 minutes option is too short and we might not even get gps location in that time, so better remove it, people can always manually disable at any time, and more easily from the notification now