### PR TITLE
feat: better wording for "Media Quality" option

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -748,7 +748,7 @@
     <string name="pref_outgoing_media_quality">Outgoing Media Quality</string>
     <string name="pref_outgoing_media_quality_hint">To send original quality, attach media as a \"File\". This uses significantly more data for you and your recipients.</string>
     <string name="pref_outgoing_balanced">Balanced</string>
-    <string name="pref_outgoing_worse">Worse quality, small size</string>
+    <string name="pref_outgoing_worse">Worse quality, save data</string>
     <string name="pref_vibrate">Vibrate</string>
     <string name="pref_screen_security">Screen Security</string>
     <!-- Translators: Must indicate that there is no guarantee as the system may not honor our request. -->


### PR DESCRIPTION
this changes "Worse quality, small size" to "Worse quality, save data".

this makes it more clearer, what the advantage of that option is.

also, the recently added hint about sending as original also speaks about "data" (https://github.com/deltachat/deltachat-android/pull/4259) which is more known to the average user, knowing that of "mobile data" etc.

came over that when thinking about https://github.com/chatmail/core/issues/8167 - this wording change, however, makes sense whatever we do there :)

#skip-changelog as this is a minor change