### PR TITLE
fix migration while upgrading from 1.10.1 and similar old versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Allow to share location for 24 hours
 * Allow mini-apps to play audio without user interaction
 * Mark chats as unread (long tap a chat and select the corresponding option from the three-dot-menu)
+* Fix process of upgrading from a very old version of the app
 
 ## v2.49.0
 2026-04

--- a/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -191,7 +191,7 @@ public class ApplicationContext extends MultiDexApplication {
               Log.i(TAG, "DcAccounts created");
               rpc = new Rpc(new FFITransport(dcAccounts.getJsonrpcInstance()));
               Log.i(TAG, "Rpc created");
-              AccountManager.getInstance().migrateToDcAccounts(this);
+              AccountManager.getInstance().migrateToDcAccounts(this, dcAccounts);
 
               int[] allAccounts = dcAccounts.getAll();
               Log.i(TAG, "Number of profiles: " + allAccounts.length);

--- a/src/main/java/org/thoughtcrime/securesms/connect/AccountManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/AccountManager.java
@@ -38,7 +38,7 @@ public class AccountManager {
     return self;
   }
 
-  public void migrateToDcAccounts(ApplicationContext context) {
+  public void migrateToDcAccounts(Context context, DcAccounts dcAccounts) {
     try {
       int selectAccountId = 0;
 
@@ -49,8 +49,7 @@ public class AccountManager {
           if (!file.isDirectory()
               && file.getName().startsWith("messenger")
               && file.getName().endsWith(".db")) {
-            int accountId =
-                ApplicationContext.getDcAccounts().migrateAccount(file.getAbsolutePath());
+            int accountId = dcAccounts.migrateAccount(file.getAbsolutePath());
             if (accountId != 0) {
               String selName =
                   PreferenceManager.getDefaultSharedPreferences(context)
@@ -67,7 +66,7 @@ public class AccountManager {
       }
 
       if (selectAccountId != 0) {
-        ApplicationContext.getDcAccounts().selectAccount(selectAccountId);
+        dcAccounts.selectAccount(selectAccountId);
       }
     } catch (Exception e) {
       Log.e(TAG, "Error in migrateToDcAccounts()", e);


### PR DESCRIPTION
the problem was that `AccountManager.migrateToDcAccounts()` was calling `ApplicationContext.getDcAccounts()` internally which would then block on `ensureInitialized()` since `migrateToDcAccounts` is called during initialization process while `isInitialized == false`

this patch just passes `DcAccounts` object directly to `migrateToDcAccounts`

close #4328 