### PR TITLE
open map if user clicks the "Location streaming enabled by Foo/you" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Mark chats as unread (long tap a chat and select the corresponding option from the three-dot-menu)
 * Fix process of upgrading from a very old version of the app
 * Show more recent added stickers at the top of the sticker picker
+* Allow to open map if user clicks "Location streaming enabled" system message
 
 ## v2.49.0
 2026-04

--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -926,6 +926,8 @@ public class ConversationFragment extends MessageSelectorFragment {
           WebxdcActivity.openWebxdcActivity(
               getContext(), messageRecord.getParent(), messageRecord.getWebxdcHref());
         }
+      } else if (messageRecord.getInfoType() == DcMsg.DC_INFO_LOCATIONSTREAMING_ENABLED) {
+        WebxdcActivity.openMaps(getContext(), (int) chatId);
       } else if (messageRecord.getInfoType() == DcMsg.DC_INFO_CHAT_DESCRIPTION_CHANGED) {
         Intent intent = new Intent(getContext(), ProfileActivity.class);
         intent.putExtra(ProfileActivity.CHAT_ID_EXTRA, (int) chatId);


### PR DESCRIPTION
currently clicking such info messages does nothing, which is particularly bad if the receiver side doesn't have location streaming enabled (because there is no way to access the map then)
