### PR TITLE
Hide webxdc attach button for channels

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1116,6 +1116,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (chatId == DcChat.DC_CHAT_NO_CHAT)
       throw new IllegalStateException("can't display a conversation for no chat.");
     dcChat = DcHelper.getContext(context).getChat(chatId);
+    attachmentTypeSelector = null;
     recipient = new Recipient(this, dcChat);
     glideRequests = GlideApp.with(this);
 

--- a/src/main/java/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
@@ -92,6 +92,10 @@ public class AttachmentTypeSelector extends PopupWindow {
       ViewUtil.findById(layout, R.id.location_linear_layout).setVisibility(View.GONE);
     }
 
+    if (DcHelper.getContext(context).getChat(chatId).isOutBroadcast()) {
+      ViewUtil.findById(layout, R.id.webxdc_linear_layout).setVisibility(View.GONE);
+    }
+
     setLocationButtonImage(context);
 
     setContentView(layout);

--- a/src/main/res/layout/attachment_type_selector.xml
+++ b/src/main/res/layout/attachment_type_selector.xml
@@ -203,6 +203,7 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/webxdc_linear_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"


### PR DESCRIPTION
Closes #4398

I didn't re-arrange the buttons because I want to keep the changes minimal

<img width="540" height="1212" alt="Screenshot_20260504_165929" src="https://github.com/user-attachments/assets/d46a8cb9-54a9-4fa7-8789-f7a5281fb90c" />

#skip-changelog