### PR TITLE
actually explain what the 'calls notification' option does

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -767,7 +767,7 @@
     <!-- Title for the "Calls" notification setting. This is a plural noun, not a verb. -->
     <string name="pref_calls">Calls</string>
     <!-- Details about what the "Calls" notification setting does -->
-    <string name="pref_calls_explain">Show call screen on incoming calls</string>
+    <string name="pref_calls_explain">Show call screen for accepted contacts</string>
     <string name="pref_notifications_show">Show</string>
     <string name="pref_notifications_priority">Priority</string>
     <string name="pref_notifications_explain">Enable system notifications for new messages</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -61,7 +61,9 @@
     <string name="media">Media</string>
     <string name="apps_and_media">Apps &amp; Media</string>
     <string name="profile">Profile</string>
+    <!-- deprecated -->
     <string name="all_profiles">All Profiles</string>
+    <!-- deprecated -->
     <string name="current_profile">Current Profile</string>
     <string name="main_menu">Main Menu</string>
     <string name="start_chat">Start Chat</string>
@@ -772,6 +774,7 @@
     <string name="pref_notifications_priority">Priority</string>
     <string name="pref_notifications_explain">Enable system notifications for new messages</string>
     <string name="pref_show_notification_content">Show message content in notification</string>
+    <!-- deprecated -->
     <string name="pref_show_notification_content_explain">Shows sender and first words of the message in notifications</string>
     <string name="pref_led_color">LED Color</string>
     <string name="pref_sound">Sound</string>


### PR DESCRIPTION
this PR changes the wording of the "Calls" subtitle, explaining, what it actually does.

this still respects previous discussions, that the option should be regarded about the "ringing" screen - even if disabled, normal notification may arrive (as anyway for every "hello!")

<img width="320" src="https://github.com/user-attachments/assets/c8968a9a-3d1f-4876-ab9c-790805e0d7c7" />

#skip-changelog

once merged, we need to call `./scripts/tx-update-changed-sources.sh`