### PR TITLE
feat: simplify location streaming wording

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/geolocation/LocationStreamingService.java
+++ b/src/main/java/org/thoughtcrime/securesms/geolocation/LocationStreamingService.java
@@ -188,9 +188,9 @@ public class LocationStreamingService extends Service {
       NotificationChannel channel =
           new NotificationChannel(
               CHANNEL_ID,
-              getString(R.string.location_streaming_notification_title),
+              getString(R.string.pref_on_demand_location_streaming),
               NotificationManager.IMPORTANCE_LOW);
-      channel.setDescription(getString(R.string.location_streaming_channel_desc));
+      channel.setDescription("Channel for Location Streaming");
       channel.setShowBadge(false);
       NotificationManager nm = getSystemService(NotificationManager.class);
       if (nm != null) nm.createNotificationChannel(channel);
@@ -209,7 +209,7 @@ public class LocationStreamingService extends Service {
         PendingIntent.getService(this, 1, stopIntent, PendingIntent.FLAG_IMMUTABLE);
 
     return new NotificationCompat.Builder(this, CHANNEL_ID)
-        .setContentTitle(getString(R.string.location_streaming_notification_title))
+        .setContentTitle(getString(R.string.pref_on_demand_location_streaming))
         .setContentText(getString(R.string.location_streaming_notification_text))
         .setSmallIcon(R.drawable.ic_location_on_white_24dp)
         .setOngoing(true)

--- a/src/main/java/org/thoughtcrime/securesms/geolocation/LocationStreamingService.java
+++ b/src/main/java/org/thoughtcrime/securesms/geolocation/LocationStreamingService.java
@@ -190,7 +190,6 @@ public class LocationStreamingService extends Service {
               CHANNEL_ID,
               getString(R.string.pref_on_demand_location_streaming),
               NotificationManager.IMPORTANCE_LOW);
-      channel.setDescription("Channel for Location Streaming");
       channel.setShowBadge(false);
       NotificationManager nm = getSystemService(NotificationManager.class);
       if (nm != null) nm.createNotificationChannel(channel);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -834,7 +834,7 @@
     <string name="pref_show_emails_all">All</string>
     <string name="pref_experimental_features">Experimental Features</string>
     <string name="pref_experimental_features_explain">These features may be unstable and may be changed or removed</string>
-    <string name="pref_on_demand_location_streaming">On-demand Location Streaming</string>
+    <string name="pref_on_demand_location_streaming">Location Streaming</string>
     <string name="pref_background_default">Default image</string>
     <string name="pref_background_default_color">Default color</string>
     <string name="pref_background_custom_image">Custom image</string>
@@ -1076,8 +1076,6 @@
     <string name="n_messages_in_m_chats">%1$d messages in %2$d chats</string>
 
     <!-- location streaming -->
-    <string name="location_streaming_channel_desc">Channel for On-demand Location Streaming</string>
-    <string name="location_streaming_notification_title">Location Streaming</string>
     <string name="location_streaming_notification_text">You are sharing your location</string>
     <string name="location_rationale">To share your live location with chat members, allow Delta Chat to use your location data.\n\nTo make live location work gaplessly, location data is used even when the app is closed or not in use.</string>
 


### PR DESCRIPTION
as an outcome of some recent discussions, this PR renames "On-demand Location Streaming" to only "Location Streaming". the "on demand" was added that time to not confuse ppl - but that was done without any data, and now, ppl _are_ actually confused by that :) also, it makes the things a heavy wording.

moreover, this PR removes some double titles - @wchen342 in general, we do not double strings unless we have hints that it really needed; this is esp. true for experimental features, where also english is fine. we accept sometimes weird translation keys as a drawback.

for the channel description: for more important descriptions, we do not have translations - most ppl never see them, they are hard to translate without context - also, the current one does not make sense to give to translators: title "Channel: Location Streaming" with description "Channel for Location Streaming" - then we can also just strike it (but not sure if a channel can have _no_ description)

both are to remove load from translators - and also from us, as we do not have to deal with questions.

#skip-changelog

once merged, we need to call `./scripts/tx-update-changed-sources.sh`