### PR TITLE
feat: tweak forward confirmation

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -843,8 +843,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (dcChat.isSelfTalk()) {
       SendRelayedMessageUtil.immediatelyRelay(this, chatId);
     } else {
+      int messageIds [] = ShareUtil.getForwardedMessageIDs(this);
+      int messageCount = messageIds == null ? 0 : messageIds.length;
       new AlertDialog.Builder(this)
-          .setMessage(getString(R.string.ask_forward, dcChat.getName()))
+          .setMessage(getResources().getQuantityString(R.plurals.ask_forward_messages, messageCount, messageCount, dcChat.getName()))
           .setPositiveButton(
               R.string.ok,
               (dialogInterface, i) -> {

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -198,7 +198,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private final boolean isSecureText = true;
   private boolean isDefaultSms = true;
   private boolean isSecurityInitialized = false;
-  private boolean successfulForwardingAttempt = false;
   private boolean isEditing = false;
   private boolean switchedProfile = false;
 
@@ -844,20 +843,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (dcChat.isSelfTalk()) {
       SendRelayedMessageUtil.immediatelyRelay(this, chatId);
     } else {
-      String name = dcChat.getName();
-      if (!dcChat.isMultiUser()) {
-        int[] contactIds = dcContext.getChatContacts(chatId);
-        if (contactIds.length == 1 || contactIds.length == 2) {
-          name = dcContext.getContact(contactIds[0]).getDisplayName();
-        }
-      }
       new AlertDialog.Builder(this)
-          .setMessage(getString(R.string.ask_forward, name))
+          .setMessage(getString(R.string.ask_forward, dcChat.getName()))
           .setPositiveButton(
               R.string.ok,
               (dialogInterface, i) -> {
                 SendRelayedMessageUtil.immediatelyRelay(this, chatId);
-                successfulForwardingAttempt = true;
               })
           .setNegativeButton(R.string.cancel, (dialogInterface, i) -> finish())
           .setOnCancelListener(dialog -> finish())

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -848,7 +848,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       new AlertDialog.Builder(this)
           .setMessage(getResources().getQuantityString(R.plurals.ask_forward_messages, messageCount, messageCount, dcChat.getName()))
           .setPositiveButton(
-              R.string.ok,
+              R.string.forward,
               (dialogInterface, i) -> {
                 SendRelayedMessageUtil.immediatelyRelay(this, chatId);
               })

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -843,10 +843,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (dcChat.isSelfTalk()) {
       SendRelayedMessageUtil.immediatelyRelay(this, chatId);
     } else {
-      int messageIds [] = ShareUtil.getForwardedMessageIDs(this);
+      int messageIds[] = ShareUtil.getForwardedMessageIDs(this);
       int messageCount = messageIds == null ? 0 : messageIds.length;
       new AlertDialog.Builder(this)
-          .setMessage(getResources().getQuantityString(R.plurals.ask_forward_messages, messageCount, messageCount, dcChat.getName()))
+          .setMessage(
+              getResources()
+                  .getQuantityString(
+                      R.plurals.ask_forward_messages, messageCount, messageCount, dcChat.getName()))
           .setPositiveButton(
               R.string.forward,
               (dialogInterface, i) -> {

--- a/src/main/java/org/thoughtcrime/securesms/util/ShareUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/ShareUtil.java
@@ -66,7 +66,7 @@ public class ShareUtil {
     }
   }
 
-  static int[] getForwardedMessageIDs(Activity activity) {
+  public static int[] getForwardedMessageIDs(Activity activity) {
     try {
       return activity.getIntent().getIntArrayExtra(FORWARDED_MESSAGE_IDS);
     } catch (NullPointerException npe) {

--- a/src/main/java/org/thoughtcrime/securesms/util/ShareUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/ShareUtil.java
@@ -174,8 +174,4 @@ public class ShareUtil {
   public static void setSharedTitle(Intent composeIntent, String text) {
     composeIntent.putExtra(SHARED_TITLE, text);
   }
-
-  public static void setDirectSharing(Intent composeIntent, int chatId) {
-    composeIntent.putExtra(DIRECT_SHARING_CHAT_ID, chatId);
-  }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -458,6 +458,12 @@
         <item quantity="one">Delete %d message?</item>
         <item quantity="other">Delete %d messages?</item>
     </plurals>
+    <!-- First placeholder gets replaced by the number of messages to forward. Second placeholder gets replaced by the name of the destination chat -->
+    <plurals name="ask_forward_messages">
+        <item quantity="one">Forward message to %2$s?</item>
+        <item quantity="other">Forward %1$d messages to %2$s?</item>
+    </plurals>
+    <!-- deprecated, use ask_forward_messages -->
     <string name="ask_forward">Forward messages to %1$s?</string>
     <string name="ask_forward_multiple">Forward messages to %1$d chats?</string>
     <string name="ask_export_attachment">Exporting attachments will allow other apps on your device to access them.\n\nContinue?</string>


### PR DESCRIPTION
the string to show the impact of forwarding clearer is mostly needed on desktop, where you can more easily select many messages accidentally. see discussions at https://github.com/deltachat/deltachat-desktop/issues/2892#issuecomment-4422987687

however, it makes sense on other OS as well, and we show the impact also at other places. and is nicer, to have correct plural form here, in case you forward only one message.

## before (confirmation is always the same)

<img width="320" src="https://github.com/user-attachments/assets/8e7fa210-dc04-4e29-8805-8fe2e1c2dafe" />
<img width="320" src="https://github.com/user-attachments/assets/5a294dd1-727f-436a-b733-5a89b92a1c7f" />


## after (impact is shown, better singular/plural, clearer button)

<img width="320" src="https://github.com/user-attachments/assets/65c290ef-0330-4c3a-8ede-af75eb6df5ec" /> <img width="320" src="https://github.com/user-attachments/assets/b0b6baed-363e-43e8-a574-747872c8db77" />

#skip-changelog as this is a minor ui change only


