### PR TITLE
prefer 'audio' over 'switch speaker', 

### DIFF
--- a/src/main/res/layout/activity_call.xml
+++ b/src/main/res/layout/activity_call.xml
@@ -307,7 +307,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_volume_up"
-                android:contentDescription="@string/switch_speaker"
+                android:contentDescription="@string/audio"
                 app:tint="@color/calls_button_foreground"
                 app:backgroundTint="@color/calls_button_background"
                 app:fabSize="normal"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -206,8 +206,6 @@
     <string name="camera">Camera</string>
     <!-- As in "start a video recording" or "take a photo"; eg. the description of the "shutter button" in cameras -->
     <string name="capture">Capture</string>
-    <!-- Switch audio output eg. from earphone to front speaker -->
-    <string name="switch_speaker">Switch Speaker</string>
     <!-- Switch eg. from front to back camera -->
     <string name="switch_camera">Switch Camera</string>
     <!-- Toggle camera on/off eg. during an video call -->


### PR DESCRIPTION
'audio' is more correct, others are using that as well, and the translations are there already

see discussion at https://github.com/deltachat/deltachat-android/pull/4416#pullrequestreview-4252074882

to be clear: the string is used as invisible label only

#skip-changelog