### PR TITLE
feat: add playback speed toggle for audio messages

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
@@ -235,6 +235,12 @@ public class AudioPlaybackViewModel extends ViewModel {
     this.isUserSeeking = isUserSeeking;
   }
 
+  public void setPlaybackSpeed(float speed) {
+    if (mediaController != null) {
+      mediaController.setPlaybackSpeed(speed);
+    }
+  }
+
   // Private methods
   private void setupPlayerListener() {
     if (mediaController == null) return;

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
@@ -31,6 +31,7 @@ public class AudioPlaybackViewModel extends ViewModel {
       0; // Audios not attached to a message doesn't have message id.
 
   private final MutableLiveData<AudioPlaybackState> playbackState;
+  private final MutableLiveData<Float> playbackSpeed = new MutableLiveData<>(1f);
 
   private final MutableLiveData<Map<Integer, Long>> durations =
       new MutableLiveData<>(new HashMap<>());
@@ -52,6 +53,10 @@ public class AudioPlaybackViewModel extends ViewModel {
     return playbackState;
   }
 
+  public LiveData<Float> getPlaybackSpeed() {
+    return playbackSpeed;
+  }
+
   public void setMediaController(@Nullable MediaController controller) {
     if (this.mediaController != null && playerListener != null) {
       this.mediaController.removeListener(playerListener);
@@ -59,8 +64,14 @@ public class AudioPlaybackViewModel extends ViewModel {
     playerListener = null;
 
     this.mediaController = controller;
-    if (mediaController != null && mediaController.isPlaying()) {
-      startUpdateProgress();
+    if (mediaController != null) {
+      Float speed = playbackSpeed.getValue();
+      if (speed != null && speed != 1f) {
+        mediaController.setPlaybackSpeed(speed);
+      }
+      if (mediaController.isPlaying()) {
+        startUpdateProgress();
+      }
     }
     updateCurrentState(true);
     setupPlayerListener();
@@ -235,14 +246,8 @@ public class AudioPlaybackViewModel extends ViewModel {
     this.isUserSeeking = isUserSeeking;
   }
 
-  private int playbackSpeedIndex = 0;
-
-  public int getPlaybackSpeedIndex() {
-    return playbackSpeedIndex;
-  }
-
-  public void setPlaybackSpeed(float speed, int speedIndex) {
-    playbackSpeedIndex = speedIndex;
+  public void setPlaybackSpeed(float speed) {
+    playbackSpeed.setValue(speed);
     if (mediaController != null) {
       mediaController.setPlaybackSpeed(speed);
     }

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
@@ -235,7 +235,14 @@ public class AudioPlaybackViewModel extends ViewModel {
     this.isUserSeeking = isUserSeeking;
   }
 
-  public void setPlaybackSpeed(float speed) {
+  private int playbackSpeedIndex = 0;
+
+  public int getPlaybackSpeedIndex() {
+    return playbackSpeedIndex;
+  }
+
+  public void setPlaybackSpeed(float speed, int speedIndex) {
+    playbackSpeedIndex = speedIndex;
     if (mediaController != null) {
       mediaController.setPlaybackSpeed(speed);
     }

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.lifecycle.Observer;
+import androidx.preference.PreferenceManager;
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat;
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat;
 import java.util.Map;
@@ -24,6 +25,9 @@ import org.thoughtcrime.securesms.util.DateUtils;
 public class AudioView extends FrameLayout {
 
   private static final String TAG = "AudioView";
+  private static final String PREF_SPEED_INDEX = "pref_audio_playback_speed_index";
+  private static final float[] SPEEDS = {1f, 1.5f, 2f};
+  private static final String[] SPEED_LABELS = {"1×", "1.5×", "2×"};
 
   private final @NonNull ImageView playPauseButton;
   private final AnimatedVectorDrawableCompat playToPauseDrawable;
@@ -34,9 +38,11 @@ public class AudioView extends FrameLayout {
   private final @NonNull SeekBar seekBar;
   private final @NonNull TextView timestamp;
   private final @NonNull TextView title;
+  private final @NonNull TextView speedButton;
   private final @NonNull View mask;
   private OnActionListener listener;
 
+  private int speedIndex = 0;
   private int msgId = -1;
   private Uri audioUri;
   private int progress;
@@ -62,7 +68,12 @@ public class AudioView extends FrameLayout {
     this.seekBar = findViewById(R.id.seek);
     this.timestamp = findViewById(R.id.timestamp);
     this.title = findViewById(R.id.title);
+    this.speedButton = findViewById(R.id.audio_speed_button);
     this.mask = findViewById(R.id.interception_mask);
+
+    this.speedIndex =
+        PreferenceManager.getDefaultSharedPreferences(context).getInt(PREF_SPEED_INDEX, 0);
+    this.speedButton.setText(SPEED_LABELS[speedIndex]);
 
     updateTimestampsAndSeekBar();
 
@@ -124,6 +135,19 @@ public class AudioView extends FrameLayout {
 
           if (listener != null) {
             listener.onPlayPauseButtonClicked(v);
+          }
+        });
+
+    speedButton.setOnClickListener(
+        v -> {
+          speedIndex = (speedIndex + 1) % SPEEDS.length;
+          speedButton.setText(SPEED_LABELS[speedIndex]);
+          PreferenceManager.getDefaultSharedPreferences(getContext())
+              .edit()
+              .putInt(PREF_SPEED_INDEX, speedIndex)
+              .apply();
+          if (viewModel != null) {
+            viewModel.setPlaybackSpeed(SPEEDS[speedIndex]);
           }
         });
 
@@ -191,6 +215,9 @@ public class AudioView extends FrameLayout {
     msgId = audio.getDcMsgId();
     audioUri = audio.getUri();
     playPauseButton.setImageDrawable(playDrawable);
+    if (viewModel != null) {
+      viewModel.setPlaybackSpeed(SPEEDS[speedIndex]);
+    }
 
     seekBar.setEnabled(true);
 

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -14,7 +14,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.lifecycle.Observer;
-import androidx.preference.PreferenceManager;
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat;
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat;
 import java.util.Map;
@@ -25,7 +24,6 @@ import org.thoughtcrime.securesms.util.DateUtils;
 public class AudioView extends FrameLayout {
 
   private static final String TAG = "AudioView";
-  private static final String PREF_SPEED_INDEX = "pref_audio_playback_speed_index";
   private static final float[] SPEEDS = {1f, 1.5f, 2f};
   private static final String[] SPEED_LABELS = {"1×", "1.5×", "2×"};
 
@@ -43,6 +41,7 @@ public class AudioView extends FrameLayout {
   private OnActionListener listener;
 
   private int speedIndex = 0;
+  private boolean isActiveMessage = false;
   private int msgId = -1;
   private Uri audioUri;
   private int progress;
@@ -71,9 +70,7 @@ public class AudioView extends FrameLayout {
     this.speedButton = findViewById(R.id.audio_speed_button);
     this.mask = findViewById(R.id.interception_mask);
 
-    this.speedIndex =
-        PreferenceManager.getDefaultSharedPreferences(context).getInt(PREF_SPEED_INDEX, 0);
-    this.speedButton.setText(SPEED_LABELS[speedIndex]);
+    this.speedButton.setText(SPEED_LABELS[0]);
 
     updateTimestampsAndSeekBar();
 
@@ -142,10 +139,6 @@ public class AudioView extends FrameLayout {
         v -> {
           speedIndex = (speedIndex + 1) % SPEEDS.length;
           speedButton.setText(SPEED_LABELS[speedIndex]);
-          PreferenceManager.getDefaultSharedPreferences(getContext())
-              .edit()
-              .putInt(PREF_SPEED_INDEX, speedIndex)
-              .apply();
           if (viewModel != null) {
             viewModel.setPlaybackSpeed(SPEEDS[speedIndex]);
           }
@@ -215,9 +208,6 @@ public class AudioView extends FrameLayout {
     msgId = audio.getDcMsgId();
     audioUri = audio.getUri();
     playPauseButton.setImageDrawable(playDrawable);
-    if (viewModel != null) {
-      viewModel.setPlaybackSpeed(SPEEDS[speedIndex]);
-    }
 
     seekBar.setEnabled(true);
 
@@ -331,18 +321,28 @@ public class AudioView extends FrameLayout {
   private void onPlaybackStateChanged(AudioPlaybackState state) {
     if (audioUri == null || state == null) return;
 
-    // Check if this state is about this message
     boolean isThisMessage = msgId == state.getMsgId();
 
     if (isThisMessage) {
+      if (!isActiveMessage) {
+        // Just became active — reset speed to 1x
+        speedIndex = 0;
+        speedButton.setText(SPEED_LABELS[0]);
+        if (viewModel != null) {
+          viewModel.setPlaybackSpeed(1f);
+        }
+      }
+      speedButton.setVisibility(View.VISIBLE);
       updateUIForPlaybackState(state);
     } else {
+      speedButton.setVisibility(View.GONE);
       togglePlayPause(false);
 
       // Also clear progress to avoid confusion
       this.progress = 0;
       updateTimestampsAndSeekBar();
     }
+    isActiveMessage = isThisMessage;
   }
 
   private void updateUIForPlaybackState(AudioPlaybackState state) {

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -140,7 +140,7 @@ public class AudioView extends FrameLayout {
           speedIndex = (speedIndex + 1) % SPEEDS.length;
           speedButton.setText(SPEED_LABELS[speedIndex]);
           if (viewModel != null) {
-            viewModel.setPlaybackSpeed(SPEEDS[speedIndex]);
+            viewModel.setPlaybackSpeed(SPEEDS[speedIndex], speedIndex);
           }
         });
 
@@ -325,12 +325,8 @@ public class AudioView extends FrameLayout {
 
     if (isThisMessage) {
       if (!isActiveMessage) {
-        // Just became active — reset speed to 1x
-        speedIndex = 0;
-        speedButton.setText(SPEED_LABELS[0]);
-        if (viewModel != null) {
-          viewModel.setPlaybackSpeed(1f);
-        }
+        speedIndex = viewModel != null ? viewModel.getPlaybackSpeedIndex() : 0;
+        speedButton.setText(SPEED_LABELS[speedIndex]);
       }
       speedButton.setVisibility(View.VISIBLE);
       updateUIForPlaybackState(state);

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -41,7 +41,6 @@ public class AudioView extends FrameLayout {
   private OnActionListener listener;
 
   private int speedIndex = 0;
-  private boolean isActiveMessage = false;
   private int msgId = -1;
   private Uri audioUri;
   private int progress;
@@ -49,6 +48,7 @@ public class AudioView extends FrameLayout {
   private AudioPlaybackViewModel viewModel;
   private final Observer<AudioPlaybackState> stateObserver = this::onPlaybackStateChanged;
   private final Observer<Map<Integer, Long>> durationObserver = this::onDurationsChanged;
+  private final Observer<Float> speedObserver = this::onPlaybackSpeedChanged;
   private boolean isPlaying;
 
   public AudioView(Context context) {
@@ -107,6 +107,9 @@ public class AudioView extends FrameLayout {
 
       viewModel.getDurations().removeObserver(durationObserver);
       viewModel.getDurations().observeForever(durationObserver);
+
+      viewModel.getPlaybackSpeed().removeObserver(speedObserver);
+      viewModel.getPlaybackSpeed().observeForever(speedObserver);
     }
 
     playPauseButton.setOnClickListener(
@@ -138,9 +141,8 @@ public class AudioView extends FrameLayout {
     speedButton.setOnClickListener(
         v -> {
           speedIndex = (speedIndex + 1) % SPEEDS.length;
-          speedButton.setText(SPEED_LABELS[speedIndex]);
           if (viewModel != null) {
-            viewModel.setPlaybackSpeed(SPEEDS[speedIndex], speedIndex);
+            viewModel.setPlaybackSpeed(SPEEDS[speedIndex]);
           }
         });
 
@@ -179,6 +181,7 @@ public class AudioView extends FrameLayout {
     if (viewModel != null) {
       viewModel.getPlaybackState().removeObserver(stateObserver);
       viewModel.getDurations().removeObserver(durationObserver);
+      viewModel.getPlaybackSpeed().removeObserver(speedObserver);
     }
     if (playToPauseDrawable != null) {
       playToPauseDrawable.clearAnimationCallbacks();
@@ -193,6 +196,7 @@ public class AudioView extends FrameLayout {
     if (this.viewModel != null) {
       this.viewModel.getPlaybackState().removeObserver(stateObserver);
       this.viewModel.getDurations().removeObserver(durationObserver);
+      this.viewModel.getPlaybackSpeed().removeObserver(speedObserver);
     }
 
     // ViewModel is used directly for simplicity, since there is no reuse yet
@@ -201,6 +205,7 @@ public class AudioView extends FrameLayout {
     if (viewModel != null) {
       viewModel.getPlaybackState().observeForever(stateObserver);
       viewModel.getDurations().observeForever(durationObserver);
+      viewModel.getPlaybackSpeed().observeForever(speedObserver);
     }
   }
 
@@ -323,22 +328,17 @@ public class AudioView extends FrameLayout {
 
     boolean isThisMessage = msgId == state.getMsgId();
 
+    speedButton.setVisibility(isThisMessage ? View.VISIBLE : View.GONE);
+
     if (isThisMessage) {
-      if (!isActiveMessage) {
-        speedIndex = viewModel != null ? viewModel.getPlaybackSpeedIndex() : 0;
-        speedButton.setText(SPEED_LABELS[speedIndex]);
-      }
-      speedButton.setVisibility(View.VISIBLE);
       updateUIForPlaybackState(state);
     } else {
-      speedButton.setVisibility(View.GONE);
       togglePlayPause(false);
 
       // Also clear progress to avoid confusion
       this.progress = 0;
       updateTimestampsAndSeekBar();
     }
-    isActiveMessage = isThisMessage;
   }
 
   private void updateUIForPlaybackState(AudioPlaybackState state) {
@@ -358,6 +358,17 @@ public class AudioView extends FrameLayout {
         // No special handling yet
         break;
     }
+  }
+
+  private void onPlaybackSpeedChanged(Float speed) {
+    if (speed == null) return;
+    for (int i = 0; i < SPEEDS.length; i++) {
+      if (Math.abs(SPEEDS[i] - speed) < 0.01f) {
+        speedIndex = i;
+        break;
+      }
+    }
+    speedButton.setText(SPEED_LABELS[speedIndex]);
   }
 
   private void onDurationsChanged(Map<Integer, Long> durations) {

--- a/src/main/res/layout/audio_view.xml
+++ b/src/main/res/layout/audio_view.xml
@@ -77,6 +77,7 @@
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:textColor="@color/audio_icon"
                         style="@style/Signal.Text.Caption"
+                        android:visibility="gone"
                         android:contentDescription="@string/playback_speed" />
 
                     <TextView

--- a/src/main/res/layout/audio_view.xml
+++ b/src/main/res/layout/audio_view.xml
@@ -64,6 +64,22 @@
                         android:visibility="visible" />
 
                     <TextView
+                        android:id="@+id/audio_speed_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="4dp"
+                        android:text="1×"
+                        android:textSize="12sp"
+                        android:textStyle="bold"
+                        android:padding="4dp"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:textColor="@color/audio_icon"
+                        style="@style/Signal.Text.Caption"
+                        android:contentDescription="@string/playback_speed" />
+
+                    <TextView
                         android:id="@+id/title"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -334,6 +334,7 @@
     <string name="accept">Accept</string>
     <string name="menu_play">Play</string>
     <string name="menu_pause">Pause</string>
+    <string name="playback_speed">Playback speed</string>
     <string name="menu_scroll_to_bottom">Scroll to the Bottom</string>
     <string name="menu_scroll_to_top">Scroll to the Top</string>
     <string name="menu_help">Help</string>


### PR DESCRIPTION
This PR adds a playback speed toggle button to the audio player UI, allowing users to switch between 1×, 1.5×, and 2× speeds.

How it works:
- The button appears only on the currently active (playing or paused) audio message — not on every message in the chat
- Speed is stored in the ViewModel and persists across tracks within the same session
- When switching to a new audio message, the previously selected speed is preserved
- Uses ExoPlayer's native setPlaybackSpeed() — no extra dependencies

How it looks in a chat:
<img width="1080" height="2063" alt="img-2026-05-13-17-36-23" src="https://github.com/user-attachments/assets/a69e07de-7453-4200-9eee-a4ef93ed951d" />


Tested on Android 16 (OnePlus 12).

Future idea: It would be great to add a persistent playback panel at the top of the chat (similar to Telegram's), showing which message is currently playing and providing speed/pause controls regardless of scroll position. This became more relevant now that audio messages auto-advance to the next one — if you leave the chat, it's not obvious where the sound is coming from. The speed button could be moved there as well. Happy to open a separate PR
for this if there's interest.