### PR TITLE
Fix debouncing in chatlist and search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add new webxdc.isAppSender and webxdc.isBroadcast APIs for mini-apps
 * Fix: Location streaming now works correctly with multiple accounts
+* Fix debouncing in chatlist and search
 
 ## v2.50.0
 2026-05

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -240,9 +240,9 @@ public class ConversationListFragment extends BaseConversationListFragment
 
   public void loadChatlistAsync() {
     synchronized (loadChatlistLock) {
-      needsAnotherLoad = true;
       if (inLoadChatlist) {
         Log.i(TAG, "chatlist loading debounced");
+        needsAnotherLoad = true;
         return;
       }
       inLoadChatlist = true;

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -251,6 +251,9 @@ public class ConversationListFragment extends BaseConversationListFragment
     Util.runOnAnyBackgroundThread(
         () -> {
           while (true) {
+            Log.i(TAG, "executing debounced chatlist loading");
+            loadChatlist();
+
             synchronized (loadChatlistLock) {
               if (!needsAnotherLoad) {
                 inLoadChatlist = false;
@@ -259,8 +262,6 @@ public class ConversationListFragment extends BaseConversationListFragment
               needsAnotherLoad = false;
             }
 
-            Log.i(TAG, "executing debounced chatlist loading");
-            loadChatlist();
             Util.sleep(100);
           }
         });

--- a/src/main/java/org/thoughtcrime/securesms/search/SearchViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/search/SearchViewModel.java
@@ -22,6 +22,7 @@ class SearchViewModel extends ViewModel {
   private final Context appContext;
   private final DcContext dcContext;
   private boolean forwarding = false;
+  private final Object bgSearchLock = new Object();
   private boolean inBgSearch;
   private boolean needsAnotherBgSearch;
 
@@ -45,27 +46,29 @@ class SearchViewModel extends ViewModel {
   }
 
   public void updateQuery() {
-    if (inBgSearch) {
+    synchronized (bgSearchLock) {
       needsAnotherBgSearch = true;
-      Log.i(TAG, "... search call debounced");
-    } else {
+      if (inBgSearch) {
+        Log.i(TAG, "... search call debounced");
+        return;
+      }
       inBgSearch = true;
-      Util.runOnBackground(
-          () -> {
-            Util.sleep(100);
-            needsAnotherBgSearch = false;
-            queryAndCallback(lastQuery, searchResult::postValue);
-
-            while (needsAnotherBgSearch) {
-              Util.sleep(100);
-              needsAnotherBgSearch = false;
-              Log.i(TAG, "... executing debounced search call");
-              queryAndCallback(lastQuery, searchResult::postValue);
-            }
-
-            inBgSearch = false;
-          });
     }
+    Util.runOnBackground(
+        () -> {
+          while (true) {
+            Log.i(TAG, "... executing debounced search call");
+            queryAndCallback(lastQuery, searchResult::postValue);
+            synchronized (bgSearchLock) {
+              if (!needsAnotherBgSearch) {
+                inBgSearch = false;
+                return;
+              }
+              needsAnotherBgSearch = false;
+            }
+            Util.sleep(100);
+          }
+        });
   }
 
   private void queryAndCallback(@NonNull String query, @NonNull SearchViewModel.Callback callback) {

--- a/src/main/java/org/thoughtcrime/securesms/search/SearchViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/search/SearchViewModel.java
@@ -47,9 +47,9 @@ class SearchViewModel extends ViewModel {
 
   public void updateQuery() {
     synchronized (bgSearchLock) {
-      needsAnotherBgSearch = true;
       if (inBgSearch) {
         Log.i(TAG, "... search call debounced");
+        needsAnotherBgSearch = true;
         return;
       }
       inBgSearch = true;


### PR DESCRIPTION
Reset inLoadChatlist only right before exit
in loadChatlistAsync().
Otherwise if loadChatlistAsync() is called
while the loop is running loadChatlist() or Util.sleep(100),
loadChatlistAsync() will see inLoadChatlist=false,
set needsAnotherLoad=true and start a second loop.
This way it is possible to spawn any number of background loops
running loadChatlist() simultaneously
so no debouncing actually happened.

Debouncing in SearchViewModel.updateQuery()
is fixed similarly by copying the code structure from loadChatlistAsync().
Previously it did not even have the lock.

Seems to be introduced in https://github.com/deltachat/deltachat-android/pull/2001