### PR TITLE
fix: missing dep in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
           buildInputs = [
             android-sdk
             pkgs.openjdk17
+            pkgs.perl
             (pkgs.buildPackages.rust-bin.stable."${rust-version}".minimal.override {
               targets = [
                 "armv7-linux-androideabi"


### PR DESCRIPTION
Fixes the following error when building with `ndk-make.sh` in a nix shell:

```
  running cd "/tmp/deltachat-build/aarch64-linux-android/release/build/openssl-sys-7d4a1dbbedb32d08/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="/tmp/android-ndk-root/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar" CC="/tmp/android-ndk-root/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang" RANLIB="/tmp/android-ndk-root/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib" "perl" "./Configure" "--prefix=/tmp/deltachat-build/aarch64-linux-android/release/build/openssl-sys-7d4a1dbbedb32d08/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-shared" "no-module" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-stdio" "linux-aarch64" "-O2" "-DANDROID" "-ffunction-sections" "-fdata-sections" "-fPIC" "-fno-unwind-tables" "-fno-exceptions" "-fno-asynchronous-unwind-tables" "-fomit-frame-pointer" "-fvisibility=hidden"
  cargo:warning=configuring OpenSSL build: 'perl' reported failure with exit status: 2
  cargo:warning=openssl-src: failed to build OpenSSL from source

  --- stderr
  Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC entries checked: /usr/local/lib64/perl5/5.42 /usr/local/share/perl5/5.42 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./Configure line 15.
  BEGIN failed--compilation aborted at ./Configure line 15.



  Error configuring OpenSSL build:
      'perl' reported failure with exit status: 2
      Command failed: cd "/tmp/deltachat-build/aarch64-linux-android/release/build/openssl-sys-7d4a1dbbedb32d08/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="/tmp/android-ndk-root/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar" CC="/tmp/android-ndk-root/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang" RANLIB="/tmp/android-ndk-root/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib" "perl" "./Configure" "--prefix=/tmp/deltachat-build/aarch64-linux-android/release/build/openssl-sys-7d4a1dbbedb32d08/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-shared" "no-module" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-stdio" "linux-aarch64" "-O2" "-DANDROID" "-ffunction-sections" "-fdata-sections" "-fPIC" "-fno-unwind-tables" "-fno-exceptions" "-fno-asynchronous-unwind-tables" "-fomit-frame-pointer" "-fvisibility=hidden"
```