### PR TITLE
avoid NPE in MediaView.set()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat Android Changelog
 
+## Unreleased
+
+* Fix: avoid crashes in Media preview sometimes
+
 ## 2.51.0
 2026-05
 

--- a/src/main/java/org/thoughtcrime/securesms/components/MediaView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/MediaView.java
@@ -57,7 +57,7 @@ public class MediaView extends FrameLayout {
       long size,
       boolean autoplay)
       throws IOException {
-    mediaType = mediaType == null? "null" : mediaType;
+    mediaType = mediaType == null ? "null" : mediaType;
     if (mediaType.startsWith("image/")) {
       imageView.setVisibility(View.VISIBLE);
       if (videoView.resolved()) videoView.get().setVisibility(View.GONE);

--- a/src/main/java/org/thoughtcrime/securesms/components/MediaView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/MediaView.java
@@ -53,10 +53,11 @@ public class MediaView extends FrameLayout {
       @NonNull Window window,
       @NonNull Uri source,
       @Nullable String fileName,
-      @NonNull String mediaType,
+      @Nullable String mediaType,
       long size,
       boolean autoplay)
       throws IOException {
+    mediaType = mediaType == null? "null" : mediaType;
     if (mediaType.startsWith("image/")) {
       imageView.setVisibility(View.VISIBLE);
       if (videoView.resolved()) videoView.get().setVisibility(View.GONE);


### PR DESCRIPTION
instead throw IOException as it is already expected for invalid media types

close #4457