### PR TITLE
Save audio draft on interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Fix: avoid crashes in Media preview sometimes
+* Fix: Incorrect total time when attaching audio files as draft
+* Fix: Audio files in draft showing total time from wrong file
+* Voice recording will be automatically saved as draft when interrupted 
 
 ## 2.51.0
 2026-05

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -494,6 +494,11 @@
             android:foregroundServiceType="camera|microphone|phoneCall" />
 
         <receiver
+            android:name=".calls.CallActionReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
+        <receiver
             android:name=".notifications.MarkReadReceiver"
             android:enabled="true"
             android:exported="false">

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -384,7 +384,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   protected void onPause() {
     super.onPause();
 
-    processComposeControls(ACTION_SAVE_DRAFT);
+    if (inputPanel.isRecording() && inputPanel.getRecordingDuration() > 1000) {
+      saveRecording();
+    } else {
+      processComposeControls(ACTION_SAVE_DRAFT);
+    }
 
     DcHelper.getNotificationCenter(this).clearVisibleChat();
     if (isFinishing()) overridePendingTransition(R.anim.fade_scale_in, R.anim.slide_to_right);
@@ -961,6 +965,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         setMedia(draft, MediaType.GIF).addListener(listener);
         break;
       case DcMsg.DC_MSG_AUDIO:
+      case DcMsg.DC_MSG_VOICE:
         setMedia(draft, MediaType.AUDIO).addListener(listener);
         break;
       case DcMsg.DC_MSG_VIDEO:
@@ -1661,6 +1666,56 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       }
       return false;
     }
+  }
+
+  private void saveRecording() {
+    inputPanel.resetRecordingUI();
+    getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+    final int thisChatId = chatId;
+    final Optional<QuoteModel> quote = inputPanel.getQuote();
+
+    ListenableFuture<Pair<Uri, Long>> future = audioRecorder.stopRecording();
+    future.addListener(
+        new ListenableFuture.Listener<Pair<Uri, Long>>() {
+          @Override
+          public void onSuccess(final @NonNull Pair<Uri, Long> result) {
+            Util.runOnAnyBackgroundThread(
+                () -> {
+                  try {
+                    DcContext dcContext = DcHelper.getContext(context);
+                    String path =
+                        DcHelper.copyToBlobdir(
+                            ConversationActivity.this, result.first, "voice", ".m4a");
+
+                    DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_VOICE);
+                    msg.setFileAndDeduplicate(path, null, null);
+                    if (quote.isPresent()) {
+                      msg.setQuote(quote.get().getQuotedMsg());
+                    }
+                    dcContext.setDraft(thisChatId, msg);
+                  } catch (Exception e) {
+                    Log.e(TAG, "Failed to save voice as draft", e);
+                  } finally {
+                    PersistentBlobProvider.getInstance()
+                        .delete(ConversationActivity.this, result.first);
+                  }
+
+                  runOnUiThread(
+                      () -> {
+                        if (chatId == thisChatId && !isFinishing() && !isDestroyed()) {
+                          initializeDraft();
+                          updateToggleButtonState();
+                        }
+                      });
+                });
+          }
+
+          @Override
+          public void onFailure(ExecutionException e) {
+            Log.w(TAG, "Failed to stop recording", e);
+          }
+        });
   }
 
   private class AttachButtonListener implements OnClickListener {

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -714,7 +714,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       extras.putInt(ConversationListFragment.RELOAD_LIST, 1);
     }
 
-    playbackViewModel.stopNonMessageAudioPlayback();
+    if (attachmentManager.isAttachmentPresent()) {
+      SlideDeck slideDeck = attachmentManager.buildSlideDeck();
+      int audioDraftId = slideDeck.getAudioDraftId();
+      if (audioDraftId != 0) {
+        playbackViewModel.stop(audioDraftId);
+      }
+    }
 
     boolean archived = getIntent().getBooleanExtra(FROM_ARCHIVED_CHATS_EXTRA, false);
     Intent intent =
@@ -1259,9 +1265,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       inputPanel.clearQuote();
     }
 
-    // Stop draft audio playback regardless, since it is unlikely
-    // we will need background playback for drafts
-    playbackViewModel.stopNonMessageAudioPlayback();
+    // Stop draft audio playback
+    if (slideDeck != null) {
+      int audioDraftId = slideDeck.getAudioDraftId();
+      if (audioDraftId != 0) {
+        playbackViewModel.stop(audioDraftId);
+      }
+    }
 
     DcContext dcContext = DcHelper.getContext(context);
     final int currentChatId = dcChat.getId();

--- a/src/main/java/org/thoughtcrime/securesms/attachments/Attachment.java
+++ b/src/main/java/org/thoughtcrime/securesms/attachments/Attachment.java
@@ -4,15 +4,10 @@ import android.content.Context;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import org.thoughtcrime.securesms.connect.DcHelper;
-import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.util.MediaUtil;
-import org.thoughtcrime.securesms.util.Util;
 
 public abstract class Attachment {
 
@@ -116,14 +111,7 @@ public abstract class Attachment {
           filename = filename.substring(0, i);
         }
       }
-      String path = DcHelper.getBlobdirFile(DcHelper.getContext(context), filename, ext);
-
-      // copy content to this file
-      InputStream inputStream = PartAuthority.getAttachmentStream(context, getDataUri());
-      OutputStream outputStream = new FileOutputStream(path);
-      Util.copy(inputStream, outputStream);
-
-      return path;
+      return DcHelper.copyToBlobdir(context, getDataUri(), filename, ext);
     } catch (Exception e) {
       e.printStackTrace();
       return null;

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallActionReceiver.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallActionReceiver.java
@@ -1,0 +1,27 @@
+package org.thoughtcrime.securesms.calls;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.util.Log;
+import androidx.annotation.RequiresApi;
+
+@RequiresApi(api = Build.VERSION_CODES.O)
+public class CallActionReceiver extends BroadcastReceiver {
+  private static final String TAG = "CallActionReceiver";
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    if (intent == null) return;
+
+    String action = intent.getAction();
+    Log.d(TAG, "Received action: " + action);
+
+    if (CallActivity.ACTION_DECLINE_CALL.equals(action)) {
+      CallCoordinator.getInstance(context).declineCall();
+    } else if (CallActivity.ACTION_HANGUP_CALL.equals(action)) {
+      CallCoordinator.getInstance(context).hangUp();
+    }
+  }
+}

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
@@ -1464,12 +1464,11 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
             PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     // Decline intent
-    Intent declineIntent = new Intent(this.appContext, CallActivity.class);
+    Intent declineIntent = new Intent(this.appContext, CallActionReceiver.class);
     declineIntent.setAction(CallActivity.ACTION_DECLINE_CALL);
-    declineIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     PendingIntent declinePendingIntent =
-        PendingIntent.getActivity(
+        PendingIntent.getBroadcast(
             this.appContext,
             1,
             declineIntent,
@@ -1538,12 +1537,11 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
     Intent activityIntent = new Intent(this.appContext, CallActivity.class);
     activityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
-    Intent hangupIntent = new Intent(this.appContext, CallActivity.class);
+    Intent hangupIntent = new Intent(this.appContext, CallActionReceiver.class);
     hangupIntent.setAction(CallActivity.ACTION_HANGUP_CALL);
-    hangupIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     PendingIntent hangupPendingIntent =
-        PendingIntent.getActivity(
+        PendingIntent.getBroadcast(
             this.appContext,
             3,
             hangupIntent,

--- a/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
@@ -332,6 +332,31 @@ public class InputPanel extends ConstraintLayout
     }
   }
 
+  public boolean isRecording() {
+    return microphoneRecorderView.isRecording();
+  }
+
+  public long getRecordingDuration() {
+    return recordTime.getElapsedTime();
+  }
+
+  public void resetRecordingUI() {
+    microphoneRecorderView.resetState();
+    recordLockCancel.setVisibility(View.GONE);
+    recordTime.hide();
+    slideToCancel.hide();
+
+    emojiToggle.setVisibility(View.VISIBLE);
+    emojiToggle.setAlpha(1f);
+    composeText.setVisibility(View.VISIBLE);
+    composeText.setAlpha(1f);
+    quickCameraToggle.setVisibility(View.VISIBLE);
+    quickCameraToggle.setAlpha(1f);
+    quickAudioToggle.setVisibility(View.VISIBLE);
+    quickAudioToggle.setAlpha(1f);
+    buttonToggle.setAlpha(1f);
+  }
+
   public interface Listener {
     void onRecorderStarted();
 
@@ -424,10 +449,10 @@ public class InputPanel extends ConstraintLayout
     }
 
     public long hide() {
-      long elapsedtime = System.currentTimeMillis() - startTime.get();
+      long elapsedTime = getElapsedTime();
       this.startTime.set(0);
       ViewUtil.fadeOut(this.recordTimeView, FADE_TIME, View.INVISIBLE);
-      return elapsedtime;
+      return elapsedTime;
     }
 
     @Override
@@ -438,6 +463,11 @@ public class InputPanel extends ConstraintLayout
         recordTimeView.setText(formatElapsedTime(elapsedTime));
         Util.runOnMainDelayed(this, UPDATE_EVERY_MS);
       }
+    }
+
+    public long getElapsedTime() {
+      long start = startTime.get();
+      return start > 0 ? System.currentTimeMillis() - start : 0;
     }
 
     private String formatElapsedTime(long ms) {

--- a/src/main/java/org/thoughtcrime/securesms/components/MicrophoneRecorderView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/MicrophoneRecorderView.java
@@ -287,4 +287,15 @@ public final class MicrophoneRecorderView extends FrameLayout implements View.On
           .start();
     }
   }
+
+  public boolean isRecording() {
+    return state != State.NOT_RUNNING;
+  }
+
+  public void resetState() {
+    if (state != State.NOT_RUNNING) {
+      state = State.NOT_RUNNING;
+      hideUi();
+    }
+  }
 }

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
@@ -27,9 +27,6 @@ import java.util.concurrent.Executors;
 public class AudioPlaybackViewModel extends ViewModel {
   private static final String TAG = "AudioPlaybackViewModel";
 
-  private static final int NON_MESSAGE_AUDIO_MSG_ID =
-      0; // Audios not attached to a message doesn't have message id.
-
   private final MutableLiveData<AudioPlaybackState> playbackState;
 
   private final MutableLiveData<Map<Integer, Long>> durations =
@@ -203,10 +200,6 @@ public class AudioPlaybackViewModel extends ViewModel {
     if (mediaController == null) return false;
     MediaItem current = mediaController.getCurrentMediaItem();
     return current != null && String.valueOf(msgId).equals(current.mediaId);
-  }
-
-  public void stopNonMessageAudioPlayback() {
-    stopByIds(NON_MESSAGE_AUDIO_MSG_ID);
   }
 
   // A special method for deleting message, where we only use message Ids

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
@@ -34,6 +34,7 @@ public class AudioPlaybackViewModel extends ViewModel {
 
   private final MutableLiveData<Map<Integer, Long>> durations =
       new MutableLiveData<>(new HashMap<>());
+  private final Map<Integer, Uri> durationUris = new HashMap<>();
   private final Set<Integer> extractionInProgress = new HashSet<>();
   private final ExecutorService extractionExecutor = Executors.newFixedThreadPool(2);
 
@@ -115,7 +116,17 @@ public class AudioPlaybackViewModel extends ViewModel {
     // Check cache
     Map<Integer, Long> currentDurations = durations.getValue();
     if (currentDurations != null && currentDurations.containsKey(msgId)) {
-      return;
+      Uri cachedUri = durationUris.get(msgId);
+      if (audioUri.equals(cachedUri)) {
+        return;
+      }
+      Map<Integer, Long> updated = new HashMap<>(currentDurations);
+      updated.remove(msgId);
+      durations.setValue(updated);
+      durationUris.remove(msgId);
+      synchronized (extractionInProgress) {
+        extractionInProgress.remove(msgId);
+      }
     }
 
     // Check extracting
@@ -136,6 +147,7 @@ public class AudioPlaybackViewModel extends ViewModel {
                 Map<Integer, Long> updatedDurations = new HashMap<>(durations.getValue());
                 updatedDurations.put(msgId, duration);
                 durations.setValue(updatedDurations);
+                durationUris.put(msgId, audioUri);
               });
 
           synchronized (extractionInProgress) {
@@ -386,6 +398,7 @@ public class AudioPlaybackViewModel extends ViewModel {
   protected void onCleared() {
     stopUpdateProgress();
     extractionExecutor.shutdown();
+    durationUris.clear();
     super.onCleared();
   }
 }

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -109,7 +109,10 @@ public class AudioView extends FrameLayout {
 
           AudioPlaybackState state = viewModel.getPlaybackState().getValue();
 
-          if (state != null && msgId == state.getMsgId()) {
+          if (state != null
+              && msgId == state.getMsgId()
+              && (state.getStatus() == AudioPlaybackState.PlaybackStatus.PLAYING
+                  || state.getStatus() == AudioPlaybackState.PlaybackStatus.PAUSED)) {
             // Same audio
             if (state.getStatus() == AudioPlaybackState.PlaybackStatus.PLAYING) {
               viewModel.pause(msgId);
@@ -194,14 +197,17 @@ public class AudioView extends FrameLayout {
 
     seekBar.setEnabled(true);
 
+    this.progress = 0;
+    this.duration = 0;
+
+    viewModel.ensureDurationLoaded(getContext(), msgId, audioUri);
+
     // Get duration
     Map<Integer, Long> durations = viewModel.getDurations().getValue();
     if (durations != null && durations.containsKey(msgId)) {
       this.duration = Math.toIntExact(durations.get(msgId));
-      updateTimestampsAndSeekBar();
-    } else {
-      viewModel.ensureDurationLoaded(getContext(), msgId, audioUri);
     }
+    updateTimestampsAndSeekBar();
 
     if (audio.asAttachment().isVoiceNote() || !audio.getFileName().isPresent()) {
       title.setVisibility(View.GONE);
@@ -340,16 +346,18 @@ public class AudioView extends FrameLayout {
   private void onDurationsChanged(Map<Integer, Long> durations) {
     AudioPlaybackState state = viewModel.getPlaybackState().getValue();
 
-    // When there is no playback happening, msgId can be -1
-    if (state != null && msgId >= 0 && msgId == state.getMsgId()) {
+    if (state != null
+        && msgId >= 0
+        && msgId == state.getMsgId()
+        && (state.getStatus() == AudioPlaybackState.PlaybackStatus.PLAYING
+            || state.getStatus() == AudioPlaybackState.PlaybackStatus.PAUSED)) {
       return;
     }
 
     Long duration = durations.get(msgId);
-    if (duration != null && seekBar.getMax() <= 100) {
+    if (duration != null) {
       this.duration = Math.toIntExact(duration);
       updateTimestampsAndSeekBar();
-      seekBar.setMax(this.duration);
     }
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -23,6 +23,10 @@ import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcLot;
 import com.b44t.messenger.DcMsg;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Date;
 import java.util.HashMap;
 import org.thoughtcrime.securesms.ApplicationContext;
@@ -31,6 +35,7 @@ import org.thoughtcrime.securesms.LocalHelpActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.ShareActivity;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
+import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.notifications.NotificationCenter;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.qr.QrActivity;
@@ -416,6 +421,15 @@ public class DcHelper {
       filename = filename.substring(0, point);
     }
     return getBlobdirFile(dcContext, filename, ext);
+  }
+
+  public static String copyToBlobdir(Context context, Uri uri, String filename, String ext)
+      throws IOException {
+    String path = getBlobdirFile(getContext(context), filename, ext);
+    InputStream inputStream = PartAuthority.getAttachmentStream(context, uri);
+    OutputStream outputStream = new FileOutputStream(path);
+    Util.copy(inputStream, outputStream);
+    return path;
   }
 
   @NonNull

--- a/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -725,13 +725,31 @@ public class AttachmentManager {
         mimeType = "application/octet-stream";
       }
 
+      DcContext dcContext = DcHelper.getContext(context);
+
       switch (this) {
         case IMAGE:
           return new ImageSlide(context, uri, fileName, dataSize, width, height);
         case GIF:
           return new GifSlide(context, uri, fileName, dataSize, width, height);
         case AUDIO:
-          return new AudioSlide(context, uri, dataSize, false, fileName);
+          DcMsg audioMsg = new DcMsg(dcContext, DcMsg.DC_MSG_AUDIO);
+          Attachment audioAttachment =
+              new UriAttachment(
+                  uri,
+                  null,
+                  mimeType,
+                  AttachmentDatabase.TRANSFER_PROGRESS_STARTED,
+                  dataSize,
+                  0,
+                  0,
+                  fileName,
+                  null,
+                  false);
+          String audioPath = audioAttachment.getRealPath(context);
+          audioMsg.setFileAndDeduplicate(audioPath, fileName, mimeType);
+          dcContext.setDraft(chatId, audioMsg);
+          return new AudioSlide(context, audioMsg);
         case VIDEO:
           return new VideoSlide(context, uri, fileName, dataSize);
         case DOCUMENT:
@@ -739,7 +757,6 @@ public class AttachmentManager {
           // draft
           // is set. Therefore we need to create a DcMsg already now.
           if (fileName != null && fileName.endsWith(".xdc")) {
-            DcContext dcContext = DcHelper.getContext(context);
             DcMsg msg = new DcMsg(dcContext, DcMsg.DC_MSG_WEBXDC);
             Attachment attachment =
                 new UriAttachment(

--- a/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -17,14 +17,12 @@
 package org.thoughtcrime.securesms.mms;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
@@ -69,6 +67,7 @@ import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.scribbles.ScribbleActivity;
 import org.thoughtcrime.securesms.util.MediaUtil;
+import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.guava.Optional;
 import org.thoughtcrime.securesms.util.views.Stub;
@@ -221,7 +220,6 @@ public class AttachmentManager {
   }
   */
 
-  @SuppressLint("StaticFieldLeak")
   public ListenableFuture<Boolean> setMedia(
       @NonNull final GlideRequests glideRequests,
       @NonNull final Uri uri,
@@ -235,158 +233,106 @@ public class AttachmentManager {
 
     final SettableFuture<Boolean> result = new SettableFuture<>();
 
-    new AsyncTask<Void, Void, Slide>() {
-      @Override
-      protected void onPreExecute() {
-        thumbnail.clear(glideRequests);
-        setAttachmentPresent(true);
-      }
+    thumbnail.clear(glideRequests);
+    setAttachmentPresent(true);
 
-      @Override
-      protected @Nullable Slide doInBackground(Void... params) {
-        try {
-          if (msg != null && msg.getType() == DcMsg.DC_MSG_WEBXDC) {
-            return new DocumentSlide(context, msg);
-          } else if (PartAuthority.isLocalUri(uri)) {
-            return getManuallyCalculatedSlideInfo(uri, width, height, msg);
-          } else {
-            Slide result = getContentResolverSlideInfo(uri, width, height, chatId);
-
-            if (result == null) return getManuallyCalculatedSlideInfo(uri, width, height, msg);
-            else return result;
-          }
-        } catch (IOException e) {
-          Log.w(TAG, e);
-          return null;
-        }
-      }
-
-      @Override
-      protected void onPostExecute(@Nullable final Slide slide) {
-        if (slide == null) {
-          setAttachmentPresent(false);
-          result.set(false);
-        } else if (slide.getFileSize() > 1024 * 1024 * 1024) {
-          // this is only a rough check, videos and images may be recoded
-          // and the core checks more carefully later.
-          setAttachmentPresent(false);
-          Log.w(TAG, "File too large.");
-          Toast.makeText(slide.context, "File too large.", Toast.LENGTH_LONG).show();
-          result.set(false);
-        } else {
-          setSlide(slide);
-          setAttachmentPresent(true);
-
-          if (slide.hasAudio()) {
-            audioView.setPlaybackViewModel(playbackViewModel);
-            audioView.setAudio((AudioSlide) slide);
-            removableMediaView.display(audioView, false);
-            removableMediaView.addRemoveClickListener(
-                v -> {
-                  playbackViewModel.stop(audioView.getMsgId());
-                });
-            result.set(true);
-          } else if (slide.isVcard()) {
-            vcardView.setVcard(glideRequests, (VcardSlide) slide, DcHelper.getRpc(context));
-            removableMediaView.display(vcardView, false);
-          } else if (slide.hasDocument()) {
-            if (slide.isWebxdcDocument()) {
-              DcMsg instance =
-                  msg != null ? msg : DcHelper.getContext(context).getMsg(slide.dcMsgId);
-              webxdcView.setWebxdc(instance, context.getString(R.string.webxdc_draft_hint));
-              webxdcView.setWebxdcClickListener(
-                  (v, s) -> {
-                    WebxdcActivity.openWebxdcActivity(context, instance);
-                  });
-              removableMediaView.display(webxdcView, false);
+    Util.runOnBackground(
+        () -> {
+          Slide slide = null;
+          try {
+            if (msg != null && msg.getType() == DcMsg.DC_MSG_WEBXDC) {
+              slide = new DocumentSlide(context, msg);
+            } else if (msg != null
+                && (msg.getType() == DcMsg.DC_MSG_AUDIO || msg.getType() == DcMsg.DC_MSG_VOICE)) {
+              slide = new AudioSlide(context, msg);
+            } else if (PartAuthority.isLocalUri(uri)) {
+              slide = getManuallyCalculatedSlideInfo(uri, width, height, msg, mediaType, chatId);
             } else {
-              documentView.setDocument((DocumentSlide) slide);
-              removableMediaView.display(documentView, false);
+              slide = getContentResolverSlideInfo(uri, width, height, chatId, mediaType);
+              if (slide == null) {
+                slide = getManuallyCalculatedSlideInfo(uri, width, height, msg, mediaType, chatId);
+              }
             }
-            result.set(true);
-          } else {
-            Attachment attachment = slide.asAttachment();
-            result.deferTo(
-                thumbnail.setImageResource(
-                    glideRequests, slide, attachment.getWidth(), attachment.getHeight()));
-            removableMediaView.display(thumbnail, mediaType == MediaType.IMAGE);
+          } catch (IOException e) {
+            Log.w(TAG, e);
           }
 
-          attachmentListener.onAttachmentChanged();
-        }
-      }
+          final Slide finalSlide = slide;
+          Util.runOnMain(
+              () -> {
+                if (finalSlide == null) {
+                  setAttachmentPresent(false);
+                  result.set(false);
+                } else if (finalSlide.getFileSize() > 1024 * 1024 * 1024) {
+                  // this is only a rough check, videos and images may be recoded
+                  // and the core checks more carefully later.
+                  setAttachmentPresent(false);
+                  Log.w(TAG, "File too large.");
+                  Toast.makeText(finalSlide.context, "File too large.", Toast.LENGTH_LONG).show();
+                  result.set(false);
+                } else {
+                  setSlide(finalSlide);
+                  setAttachmentPresent(true);
 
-      private @Nullable Slide getContentResolverSlideInfo(
-          Uri uri, int width, int height, int chatId) {
+                  if (finalSlide.hasAudio()) {
+                    audioView.setPlaybackViewModel(playbackViewModel);
+                    audioView.setAudio((AudioSlide) finalSlide);
+                    removableMediaView.display(audioView, false);
+                    removableMediaView.addRemoveClickListener(
+                        v -> playbackViewModel.stop(audioView.getMsgId()));
+                    result.set(true);
+                  } else if (finalSlide.isVcard()) {
+                    vcardView.setVcard(
+                        glideRequests, (VcardSlide) finalSlide, DcHelper.getRpc(context));
+                    removableMediaView.display(vcardView, false);
+                  } else if (finalSlide.hasDocument()) {
+                    if (finalSlide.isWebxdcDocument()) {
+                      DcMsg instance =
+                          msg != null
+                              ? msg
+                              : DcHelper.getContext(context).getMsg(finalSlide.dcMsgId);
+                      webxdcView.setWebxdc(instance, context.getString(R.string.webxdc_draft_hint));
+                      webxdcView.setWebxdcClickListener(
+                          (v, s) -> WebxdcActivity.openWebxdcActivity(context, instance));
+                      removableMediaView.display(webxdcView, false);
+                    } else {
+                      documentView.setDocument((DocumentSlide) finalSlide);
+                      removableMediaView.display(documentView, false);
+                    }
+                    result.set(true);
+                  } else {
+                    Attachment attachment = finalSlide.asAttachment();
+                    result.deferTo(
+                        thumbnail.setImageResource(
+                            glideRequests,
+                            finalSlide,
+                            attachment.getWidth(),
+                            attachment.getHeight()));
+                    removableMediaView.display(thumbnail, mediaType == MediaType.IMAGE);
+                  }
 
-        long start = System.currentTimeMillis();
-        try (Cursor cursor = context.getContentResolver().query(uri, null, null, null, null)) {
+                  attachmentListener.onAttachmentChanged();
+                }
+              });
+        });
 
-          if (cursor != null && cursor.moveToFirst()) {
-            String fileName =
-                cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME));
-            long fileSize = cursor.getLong(cursor.getColumnIndexOrThrow(OpenableColumns.SIZE));
-            String mimeType = context.getContentResolver().getType(uri);
+    return result;
+  }
 
-            if (width == 0 || height == 0) {
-              Pair<Integer, Integer> dimens = MediaUtil.getDimensions(context, mimeType, uri);
-              width = dimens.first;
-              height = dimens.second;
-            }
-
-            Log.w(
-                TAG,
-                "remote slide with size "
-                    + fileSize
-                    + " took "
-                    + (System.currentTimeMillis() - start)
-                    + "ms");
-            return mediaType.createSlide(
-                context, uri, fileName, mimeType, fileSize, width, height, chatId);
-          }
-        }
-
-        return null;
-      }
-
-      private @NonNull Slide getManuallyCalculatedSlideInfo(
-          Uri uri, int width, int height, @Nullable DcMsg msg) throws IOException {
-        long start = System.currentTimeMillis();
-        Long mediaSize = null;
-        String fileName = null;
-        String mimeType = null;
-
-        if (msg != null) {
-          fileName = msg.getFilename();
-          mimeType = msg.getFilemime();
-        }
-
-        if (PartAuthority.isLocalUri(uri)) {
-          mediaSize = PartAuthority.getAttachmentSize(context, uri);
-          if (fileName == null) fileName = PartAuthority.getAttachmentFileName(context, uri);
-          if (mimeType == null) mimeType = PartAuthority.getAttachmentContentType(context, uri);
-        }
-
-        if (mediaSize == null) {
-          mediaSize = MediaUtil.getMediaSize(context, uri);
-        }
-
-        if (mimeType == null) {
-          mimeType = MediaUtil.getMimeType(context, uri);
-        }
+  private @Nullable Slide getContentResolverSlideInfo(
+      Uri uri, int width, int height, int chatId, MediaType mediaType) {
+    long start = System.currentTimeMillis();
+    try (Cursor cursor = context.getContentResolver().query(uri, null, null, null, null)) {
+      if (cursor != null && cursor.moveToFirst()) {
+        String fileName =
+            cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME));
+        long mediaSize = cursor.getLong(cursor.getColumnIndexOrThrow(OpenableColumns.SIZE));
+        String mimeType = context.getContentResolver().getType(uri);
 
         if (width == 0 || height == 0) {
           Pair<Integer, Integer> dimens = MediaUtil.getDimensions(context, mimeType, uri);
           width = dimens.first;
           height = dimens.second;
-        }
-
-        if (fileName == null) {
-          try {
-            fileName = new File(uri.getPath()).getName();
-          } catch (Exception e) {
-            Log.w(TAG, "Could not get file name from uri: " + e);
-          }
         }
 
         Log.w(
@@ -399,9 +345,61 @@ public class AttachmentManager {
         return mediaType.createSlide(
             context, uri, fileName, mimeType, mediaSize, width, height, chatId);
       }
-    }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
 
-    return result;
+    return null;
+  }
+
+  private @NonNull Slide getManuallyCalculatedSlideInfo(
+      Uri uri, int width, int height, @Nullable DcMsg msg, MediaType mediaType, int chatId)
+      throws IOException {
+    long start = System.currentTimeMillis();
+    Long mediaSize = null;
+    String fileName = null;
+    String mimeType = null;
+
+    if (msg != null) {
+      fileName = msg.getFilename();
+      mimeType = msg.getFilemime();
+    }
+
+    if (PartAuthority.isLocalUri(uri)) {
+      mediaSize = PartAuthority.getAttachmentSize(context, uri);
+      if (fileName == null) fileName = PartAuthority.getAttachmentFileName(context, uri);
+      if (mimeType == null) mimeType = PartAuthority.getAttachmentContentType(context, uri);
+    }
+
+    if (mediaSize == null) {
+      mediaSize = MediaUtil.getMediaSize(context, uri);
+    }
+
+    if (mimeType == null) {
+      mimeType = MediaUtil.getMimeType(context, uri);
+    }
+
+    if (width == 0 || height == 0) {
+      Pair<Integer, Integer> dimens = MediaUtil.getDimensions(context, mimeType, uri);
+      width = dimens.first;
+      height = dimens.second;
+    }
+
+    if (fileName == null) {
+      try {
+        fileName = new File(uri.getPath()).getName();
+      } catch (Exception e) {
+        Log.w(TAG, "Could not get file name from uri: " + e);
+      }
+    }
+
+    Log.w(
+        TAG,
+        "local slide with size "
+            + mediaSize
+            + " took "
+            + (System.currentTimeMillis() - start)
+            + "ms");
+    return mediaType.createSlide(
+        context, uri, fileName, mimeType, mediaSize, width, height, chatId);
   }
 
   // should be called when the attachment manager comes into view again.

--- a/src/main/java/org/thoughtcrime/securesms/mms/SlideDeck.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/SlideDeck.java
@@ -78,4 +78,13 @@ public class SlideDeck {
     }
     return 0;
   }
+
+  public int getAudioDraftId() {
+    for (Slide slide : slides) {
+      if (slide.hasAudio() && slide.dcMsgId != 0) {
+        return slide.dcMsgId;
+      }
+    }
+    return 0;
+  }
 }


### PR DESCRIPTION
- Also fixes pre-existing bugs while attaching audio files as draft.
- When rejecting a call from notification, it no longer goes through activity (no black screen for a split second)
- Removed the deprecated `AsyncTask` in [AttachmentManager.java‎](https://github.com/deltachat/deltachat-android/pull/4460/changes#diff-610e8defba98a716becd78e3122eba4380fb7144eb464bc501204f372ce15459)
- Audio attachments are now saved properly like other file attachments when in a draft

Fixes #4437