### PR TITLE
feat: use message style notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix: avoid crashes in Media preview sometimes
+* Use message style notifications for longer message previews
 
 ## 2.51.0
 2026-05

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -810,11 +810,12 @@ public class NotificationCenter {
     }
   }
 
-  public IconCompat getAvatarIcon(DcContact contact) {
-    return IconCompat.createWithBitmap(getAvatar(new Recipient(context, contact)));
+  public @Nullable IconCompat getAvatarIcon(DcContact contact) {
+    Bitmap avatar = getAvatar(new Recipient(context, contact));
+    return avatar != null ? IconCompat.createWithBitmap(avatar) : null;
   }
 
-  public Bitmap getAvatar(Recipient recipient) {
+  public @Nullable Bitmap getAvatar(Recipient recipient) {
     try {
       Drawable drawable;
       ContactPhoto contactPhoto = recipient.getContactPhoto(context);

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -63,8 +63,18 @@ public class NotificationCenter {
   private volatile long lastAudibleNotification = 0;
   private static final long MIN_AUDIBLE_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(2);
 
-  // Map<accountId, Map<chatId, lines>, contains the last lines of each chat for each account
-  private final HashMap<Integer, HashMap<Integer, LinkedHashMap<Integer, String>>> inboxes =
+  private static class NotifData {
+    final Person sender;
+    final String text;
+
+    NotifData(Person sender, String text) {
+      this.sender = sender;
+      this.text = text;
+    }
+  }
+
+  // notification history of each chat for each account
+  private final HashMap<Integer, HashMap<Integer, LinkedHashMap<Integer, NotifData>>> inboxes =
       new HashMap<>();
 
   public NotificationCenter(Context context) {
@@ -412,27 +422,31 @@ public class NotificationCenter {
           DcMsg dcMsg = dcContext.getMsg(msgId);
           NotificationPrivacyPreference privacy = Prefs.getNotificationPrivacy(context);
 
+          DcContact sender = dcContext.getContact(dcMsg.getFromId());
+          String senderName = dcMsg.getSenderName(sender);
           String shortLine =
               privacy.isDisplayMessage()
                   ? dcMsg.getSummarytext(2000)
                   : context.getString(R.string.notify_new_message);
           String tickerLine = shortLine;
-          if (!dcChat.isMultiUser() && privacy.isDisplayContact()) {
-            tickerLine =
-                dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId())) + ": " + tickerLine;
 
-            if (dcMsg.getOverrideSenderName() != null) {
-              // There is an "overridden" display name on the message, so, we need to prepend the
-              // display name to the message,
-              // i.e. set the shortLine to be the same as the tickerLine.
-              shortLine = tickerLine;
-            }
+          NotifData notifData =
+              new NotifData(
+                  new Person.Builder()
+                      .setName(senderName)
+                      .setIcon(getAvatarIcon(sender))
+                      .setBot(sender.isBot())
+                      .build(),
+                  shortLine);
+
+          if (!dcChat.isMultiUser() && privacy.isDisplayContact()) {
+            tickerLine = senderName + ": " + tickerLine;
           }
 
           DcMsg quotedMsg = dcMsg.getQuotedMsg();
           boolean isMention = dcChat.isMultiUser() && quotedMsg != null && quotedMsg.isOutgoing();
 
-          maybeAddNotification(accountId, dcChat, msgId, shortLine, tickerLine, true, isMention);
+          maybeAddNotification(accountId, dcChat, msgId, notifData, tickerLine, true, isMention);
         });
   }
 
@@ -449,6 +463,7 @@ public class NotificationCenter {
           }
 
           DcContact sender = dcContext.getContact(contactId);
+          String senderName = dcMsg.getSenderName(sender);
           String shortLine =
               context.getString(
                   R.string.reaction_by_other,
@@ -456,8 +471,18 @@ public class NotificationCenter {
                   reaction,
                   dcMsg.getSummarytext(2000));
           DcChat dcChat = dcContext.getChat(dcMsg.getChatId());
+
+          NotifData notifData =
+              new NotifData(
+                  new Person.Builder()
+                      .setName(senderName)
+                      .setIcon(getAvatarIcon(sender))
+                      .setBot(sender.isBot())
+                      .build(),
+                  shortLine);
+
           maybeAddNotification(
-              accountId, dcChat, msgId, shortLine, shortLine, false, dcChat.isMultiUser());
+              accountId, dcChat, msgId, notifData, shortLine, false, dcChat.isMultiUser());
         });
   }
 
@@ -471,6 +496,7 @@ public class NotificationCenter {
 
           DcContext dcContext = context.getDcAccounts().getAccount(accountId);
           DcMsg dcMsg = dcContext.getMsg(msgId);
+          DcChat dcChat = dcContext.getChat(dcMsg.getChatId());
           DcMsg parentMsg;
           if (dcMsg.getType() == DcMsg.DC_MSG_WEBXDC) {
             parentMsg = dcMsg;
@@ -485,9 +511,15 @@ public class NotificationCenter {
           JSONObject info = parentMsg.getWebxdcInfo();
           final String name = JsonUtils.optString(info, "name");
           String shortLine = name.isEmpty() ? text : (name + ": " + text);
-          DcChat dcChat = dcContext.getChat(dcMsg.getChatId());
+          NotifData notifData =
+              new NotifData(
+                  new Person.Builder()
+                      .setIcon(
+                          IconCompat.createWithBitmap(getAvatar(new Recipient(context, dcChat))))
+                      .build(),
+                  shortLine);
           maybeAddNotification(
-              accountId, dcChat, msgId, shortLine, shortLine, false, dcChat.isMultiUser());
+              accountId, dcChat, msgId, notifData, shortLine, false, dcChat.isMultiUser());
         });
   }
 
@@ -496,7 +528,7 @@ public class NotificationCenter {
       int accountId,
       DcChat dcChat,
       int msgId,
-      String shortLine,
+      NotifData notifData,
       String tickerLine,
       boolean playInChatSound,
       boolean isMention) {
@@ -536,20 +568,20 @@ public class NotificationCenter {
     // the user may eg. have chosen a different sound
     String notificationChannel = getNotificationChannel(notificationManager, chatData, dcChat);
 
-    LinkedHashMap<Integer, String> messagesForInbox = null;
+    LinkedHashMap<Integer, NotifData> messagesForInbox = null;
     if (privacy.isDisplayContact() && privacy.isDisplayMessage()) {
       synchronized (inboxes) {
-        HashMap<Integer, LinkedHashMap<Integer, String>> accountInbox = inboxes.get(accountId);
+        HashMap<Integer, LinkedHashMap<Integer, NotifData>> accountInbox = inboxes.get(accountId);
         if (accountInbox == null) {
           accountInbox = new HashMap<>();
           inboxes.put(accountId, accountInbox);
         }
-        LinkedHashMap<Integer, String> messages = accountInbox.get(chatId);
+        LinkedHashMap<Integer, NotifData> messages = accountInbox.get(chatId);
         if (messages == null) {
           messages = new LinkedHashMap<>();
           accountInbox.put(chatId, messages);
         }
-        messages.put(msgId, shortLine);
+        messages.put(msgId, notifData);
         messagesForInbox = new LinkedHashMap<>(messages);
       }
     }
@@ -562,7 +594,7 @@ public class NotificationCenter {
         dcContext,
         dcChat,
         notificationChannel,
-        shortLine,
+        notifData.text,
         tickerLine,
         signal,
         messagesForInbox,
@@ -581,7 +613,7 @@ public class NotificationCenter {
       String contentText,
       String ticker,
       boolean signal,
-      LinkedHashMap<Integer, String> messagesForInbox,
+      LinkedHashMap<Integer, NotifData> messagesForInbox,
       int messageCount,
       boolean includeSummary) {
     try {
@@ -704,16 +736,10 @@ public class NotificationCenter {
           NotificationCompat.MessagingStyle style = new NotificationCompat.MessagingStyle(self);
           style.setGroupConversation(dcChat.isMultiUser());
           style.setConversationTitle(dcChat.getName());
-          for (Map.Entry<Integer, String> msgEntry : messagesForInbox.entrySet()) {
-            DcMsg msg = dcContext.getMsg(msgEntry.getKey());
-            DcContact senderContact = dcContext.getContact(msg.getFromId());
-            Person sender =
-                new Person.Builder()
-                    .setName(msg.getSenderName(senderContact))
-                    .setIcon(getAvatarIcon(senderContact))
-                    .setBot(senderContact.isBot())
-                    .build();
-            style.addMessage(msgEntry.getValue(), msg.getSortTimestamp() * 1000, sender);
+          for (Map.Entry<Integer, NotifData> msgEntry : messagesForInbox.entrySet()) {
+            long timestamp_ms = dcContext.getMsg(msgEntry.getKey()).getSortTimestamp() * 1000;
+            NotifData notifData = msgEntry.getValue();
+            style.addMessage(notifData.text, timestamp_ms, notifData.sender);
           }
           builder.setStyle(style);
         } catch (Exception e) {
@@ -762,7 +788,7 @@ public class NotificationCenter {
 
   @WorkerThread
   private void rebuildNotification(
-      int accountId, int chatId, LinkedHashMap<Integer, String> messages) {
+      int accountId, int chatId, LinkedHashMap<Integer, NotifData> messages) {
     try {
       DcContext dcContext = ApplicationContext.getDcAccounts().getAccount(accountId);
       DcChat dcChat = dcContext.getChat(chatId);
@@ -780,9 +806,9 @@ public class NotificationCenter {
       // Get the latest message ID (last entry in LinkedHashMap)
       Integer latestMsgId = null;
       String lastLine = null;
-      for (Map.Entry<Integer, String> entry : messages.entrySet()) {
+      for (Map.Entry<Integer, NotifData> entry : messages.entrySet()) {
         latestMsgId = entry.getKey();
-        lastLine = entry.getValue();
+        lastLine = entry.getValue().text;
       }
       if (latestMsgId == null || lastLine == null) {
         return;
@@ -855,12 +881,12 @@ public class NotificationCenter {
   public void removeNotification(int accountId, int chatId, int msgId) {
     boolean shouldCancelNotification = false;
     boolean removeSummary = false;
-    LinkedHashMap<Integer, String> remainingMessages = null;
+    LinkedHashMap<Integer, NotifData> remainingMessages = null;
 
     synchronized (inboxes) {
-      HashMap<Integer, LinkedHashMap<Integer, String>> accountInbox = inboxes.get(accountId);
+      HashMap<Integer, LinkedHashMap<Integer, NotifData>> accountInbox = inboxes.get(accountId);
       if (accountInbox != null) {
-        LinkedHashMap<Integer, String> messages = accountInbox.get(chatId);
+        LinkedHashMap<Integer, NotifData> messages = accountInbox.get(chatId);
         if (messages != null) {
           messages.remove(msgId);
 
@@ -893,7 +919,7 @@ public class NotificationCenter {
   public void removeNotifications(int accountId, int chatId) {
     boolean removeSummary;
     synchronized (inboxes) {
-      HashMap<Integer, LinkedHashMap<Integer, String>> accountInbox = inboxes.get(accountId);
+      HashMap<Integer, LinkedHashMap<Integer, NotifData>> accountInbox = inboxes.get(accountId);
       if (accountInbox == null) {
         accountInbox = new HashMap<>();
       }
@@ -919,7 +945,7 @@ public class NotificationCenter {
     NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
     String tag = String.valueOf(accountId);
     synchronized (inboxes) {
-      HashMap<Integer, LinkedHashMap<Integer, String>> accountInbox = inboxes.get(accountId);
+      HashMap<Integer, LinkedHashMap<Integer, NotifData>> accountInbox = inboxes.get(accountId);
       notificationManager.cancel(tag, ID_MSG_SUMMARY);
       if (accountInbox != null) {
         for (Integer chatId : accountInbox.keySet()) {

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -711,6 +711,7 @@ public class NotificationCenter {
                 new Person.Builder()
                     .setName(msg.getSenderName(senderContact))
                     .setIcon(getAvatarIcon(senderContact))
+                    .setBot(senderContact.isBot())
                     .build();
             style.addMessage(msgEntry.getValue(), msg.getSortTimestamp() * 1000, sender);
           }

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.media.AudioAttributes;
 import android.media.RingtoneManager;
@@ -34,6 +35,7 @@ import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcMsg;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.util.HashMap;
@@ -427,15 +429,14 @@ public class NotificationCenter {
 
           DcContact sender = dcContext.getContact(dcMsg.getFromId());
           String senderName = dcMsg.getSenderName(sender);
-          String shortLine =
+          String text =
               privacy.isDisplayMessage()
                   ? dcMsg.getSummarytext(2000)
                   : context.getString(R.string.notify_new_message);
+          String shortLine = text;
           if (dcChat.isMultiUser() && privacy.isDisplayContact()) {
-            shortLine =
-                dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId())) + ": " + shortLine;
+            shortLine = senderName + ": " + text;
           }
-          String tickerLine = shortLine;
 
           NotifData notifData =
               new NotifData(
@@ -443,12 +444,13 @@ public class NotificationCenter {
                       .setName(senderName)
                       .setIcon(getAvatarIcon(sender))
                       .setBot(sender.isBot())
-                      .setKey(dcContext.getAccountId() + "-" + sender.getId())
+                      .setKey(accountId + "-" + sender.getId())
                       .build(),
-                  shortLine);
+                  text);
 
-          if (!dcChat.isMultiUser() && privacy.isDisplayContact()) {
-            tickerLine = senderName + ": " + tickerLine;
+          String tickerLine = text;
+          if (privacy.isDisplayContact()) {
+            tickerLine = senderName + ": " + text;
           }
 
           DcMsg quotedMsg = dcMsg.getQuotedMsg();
@@ -472,7 +474,7 @@ public class NotificationCenter {
 
           DcContact sender = dcContext.getContact(contactId);
           String senderName = dcMsg.getSenderName(sender);
-          String shortLine =
+          String text =
               context.getString(
                   R.string.reaction_by_other,
                   sender.getDisplayName(),
@@ -486,11 +488,12 @@ public class NotificationCenter {
                       .setName(senderName)
                       .setIcon(getAvatarIcon(sender))
                       .setBot(sender.isBot())
+                      .setKey(accountId + "-" + sender.getId())
                       .build(),
-                  shortLine);
+                  text);
 
           maybeAddNotification(
-              accountId, dcChat, msgId, notifData, shortLine, false, dcChat.isMultiUser());
+              accountId, dcChat, msgId, notifData, text, false, dcChat.isMultiUser());
         });
   }
 
@@ -518,11 +521,34 @@ public class NotificationCenter {
 
           JSONObject info = parentMsg.getWebxdcInfo();
           final String name = JsonUtils.optString(info, "name");
-          String shortLine = name.isEmpty() ? text : (name + ": " + text);
-          NotifData notifData =
-              new NotifData(new Person.Builder().setIcon(getAvatarIcon(dcChat)).build(), shortLine);
+          String tickerLine = name.isEmpty() ? text : (name + ": " + text);
+
+          NotifData notifData;
+          if (dcChat.isMultiUser()) {
+            byte[] blob = parentMsg.getWebxdcBlob(JsonUtils.optString(info, "icon"));
+            notifData =
+                new NotifData(
+                    new Person.Builder()
+                        .setName(name)
+                        .setIcon(getAvatarIcon(blob))
+                        .setKey(accountId + "-webxdc-" + msgId)
+                        .build(),
+                    text);
+          } else {
+            DcContact sender = dcContext.getContact(contactId);
+            notifData =
+                new NotifData(
+                    new Person.Builder()
+                        .setName(dcMsg.getSenderName(sender))
+                        .setIcon(getAvatarIcon(sender))
+                        .setBot(sender.isBot())
+                        .setKey(dcContext.getAccountId() + "-" + sender.getId())
+                        .build(),
+                    tickerLine);
+          }
+
           maybeAddNotification(
-              accountId, dcChat, msgId, notifData, shortLine, false, dcChat.isMultiUser());
+              accountId, dcChat, msgId, notifData, tickerLine, false, dcChat.isMultiUser());
         });
   }
 
@@ -572,7 +598,7 @@ public class NotificationCenter {
     String notificationChannel = getNotificationChannel(notificationManager, chatData, dcChat);
 
     LinkedHashMap<Integer, NotifData> messagesForInbox = null;
-    if (privacy.isDisplayContact() && privacy.isDisplayMessage()) {
+    if (privacy.isDisplayContact()) {
       synchronized (inboxes) {
         HashMap<Integer, LinkedHashMap<Integer, NotifData>> accountInbox = inboxes.get(accountId);
         if (accountInbox == null) {
@@ -583,6 +609,9 @@ public class NotificationCenter {
         if (messages == null) {
           messages = new LinkedHashMap<>();
           accountInbox.put(chatId, messages);
+        }
+        if (!privacy.isDisplayMessage()) {
+          messages.clear();
         }
         messages.put(msgId, notifData);
         messagesForInbox = new LinkedHashMap<>(messages);
@@ -728,7 +757,7 @@ public class NotificationCenter {
       }
 
       // Create messaging style
-      if (privacy.isDisplayContact() && privacy.isDisplayMessage() && messagesForInbox != null) {
+      if (privacy.isDisplayContact() && messagesForInbox != null) {
         try {
           Intent viewChatIntent = new Intent(context, ShareActivity.class);
           viewChatIntent.setAction(Intent.ACTION_SEND);
@@ -750,6 +779,7 @@ public class NotificationCenter {
               new Person.Builder()
                   .setName(selfContact.getDisplayName())
                   .setIcon(getAvatarIcon(selfContact))
+                  .setKey(accountId + "-" + selfContact.getId())
                   .build();
           NotificationCompat.MessagingStyle style = new NotificationCompat.MessagingStyle(self);
           if (dcChat.isMultiUser()) {
@@ -855,6 +885,16 @@ public class NotificationCenter {
     } catch (Exception e) {
       Log.e(TAG, "cannot rebuild notification", e);
     }
+  }
+
+  private static @Nullable IconCompat getAvatarIcon(byte[] blob) {
+    if (blob == null) {
+      return null;
+    }
+    ByteArrayInputStream is = new ByteArrayInputStream(blob);
+    BitmapDrawable drawable = (BitmapDrawable) Drawable.createFromStream(is, "icon");
+    Bitmap bitmap = drawable.getBitmap();
+    return IconCompat.createWithBitmap(bitmap);
   }
 
   private @Nullable IconCompat getAvatarIcon(DcChat dcChat) {

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -428,6 +428,10 @@ public class NotificationCenter {
               privacy.isDisplayMessage()
                   ? dcMsg.getSummarytext(2000)
                   : context.getString(R.string.notify_new_message);
+          if (dcChat.isMultiUser() && privacy.isDisplayContact()) {
+            shortLine =
+                dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId())) + ": " + shortLine;
+          }
           String tickerLine = shortLine;
 
           NotifData notifData =

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -26,6 +26,8 @@ import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.Person;
 import androidx.core.app.RemoteInput;
 import androidx.core.app.TaskStackBuilder;
+import androidx.core.content.pm.ShortcutInfoCompat;
+import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
@@ -44,6 +46,7 @@ import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.ShareActivity;
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.preferences.widgets.NotificationPrivacyPreference;
@@ -440,6 +443,7 @@ public class NotificationCenter {
                       .setName(senderName)
                       .setIcon(getAvatarIcon(sender))
                       .setBot(sender.isBot())
+                      .setKey(dcContext.getAccountId() + "-" + sender.getId())
                       .build(),
                   shortLine);
 
@@ -726,6 +730,21 @@ public class NotificationCenter {
       // Create messaging style
       if (privacy.isDisplayContact() && privacy.isDisplayMessage() && messagesForInbox != null) {
         try {
+          Intent viewChatIntent = new Intent(context, ShareActivity.class);
+          viewChatIntent.setAction(Intent.ACTION_SEND);
+          viewChatIntent.putExtra(ShareActivity.EXTRA_ACC_ID, dcContext.getAccountId());
+          viewChatIntent.putExtra(ShareActivity.EXTRA_CHAT_ID, dcChat.getId());
+
+          ShortcutInfoCompat shortcut =
+              new ShortcutInfoCompat.Builder(
+                      context, "chat-" + dcContext.getAccountId() + "-" + dcChat.getId())
+                  .setShortLabel(dcChat.getName())
+                  .setLongLived(true)
+                  .setIntent(viewChatIntent)
+                  .build();
+          ShortcutManagerCompat.pushDynamicShortcut(context, shortcut);
+          builder.setShortcutInfo(shortcut);
+
           DcContact selfContact = dcContext.getContact(DcContact.DC_CONTACT_ID_SELF);
           Person self =
               new Person.Builder()
@@ -733,8 +752,10 @@ public class NotificationCenter {
                   .setIcon(getAvatarIcon(selfContact))
                   .build();
           NotificationCompat.MessagingStyle style = new NotificationCompat.MessagingStyle(self);
-          style.setGroupConversation(dcChat.isMultiUser());
-          style.setConversationTitle(dcChat.getName());
+          if (dcChat.isMultiUser()) {
+            style.setGroupConversation(true);
+            style.setConversationTitle(dcChat.getName());
+          }
           for (Map.Entry<Integer, NotifData> msgEntry : messagesForInbox.entrySet()) {
             long timestamp_ms = dcContext.getMsg(msgEntry.getKey()).getSortTimestamp() * 1000;
             NotifData notifData = msgEntry.getValue();

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -23,8 +23,10 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.core.app.Person;
 import androidx.core.app.RemoteInput;
 import androidx.core.app.TaskStackBuilder;
+import androidx.core.graphics.drawable.IconCompat;
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
@@ -414,10 +416,6 @@ public class NotificationCenter {
               privacy.isDisplayMessage()
                   ? dcMsg.getSummarytext(2000)
                   : context.getString(R.string.notify_new_message);
-          if (dcChat.isMultiUser() && privacy.isDisplayContact()) {
-            shortLine =
-                dcMsg.getSenderName(dcContext.getContact(dcMsg.getFromId())) + ": " + shortLine;
-          }
           String tickerLine = shortLine;
           if (!dcChat.isMultiUser() && privacy.isDisplayContact()) {
             tickerLine =
@@ -643,7 +641,7 @@ public class NotificationCenter {
 
       // Set avatar
       if (privacy.isDisplayContact()) {
-        Bitmap bitmap = getAvatar(dcChat);
+        Bitmap bitmap = getAvatar(new Recipient(context, dcChat));
         if (bitmap != null) {
           builder.setLargeIcon(bitmap);
         }
@@ -694,14 +692,29 @@ public class NotificationCenter {
         }
       }
 
-      // Create inbox style (gets visible if the notification is expanded)
+      // Create messaging style
       if (privacy.isDisplayContact() && privacy.isDisplayMessage() && messagesForInbox != null) {
         try {
-          NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
-          for (String line : messagesForInbox.values()) {
-            inboxStyle.addLine(line);
+          DcContact selfContact = dcContext.getContact(DcContact.DC_CONTACT_ID_SELF);
+          Person self =
+              new Person.Builder()
+                  .setName(selfContact.getDisplayName())
+                  .setIcon(getAvatarIcon(selfContact))
+                  .build();
+          NotificationCompat.MessagingStyle style = new NotificationCompat.MessagingStyle(self);
+          style.setGroupConversation(dcChat.isMultiUser());
+          style.setConversationTitle(dcChat.getName());
+          for (Map.Entry<Integer, String> msgEntry : messagesForInbox.entrySet()) {
+            DcMsg msg = dcContext.getMsg(msgEntry.getKey());
+            DcContact senderContact = dcContext.getContact(msg.getFromId());
+            Person sender =
+                new Person.Builder()
+                    .setName(msg.getSenderName(senderContact))
+                    .setIcon(getAvatarIcon(senderContact))
+                    .build();
+            style.addMessage(msgEntry.getValue(), msg.getSortTimestamp(), sender);
           }
-          builder.setStyle(inboxStyle);
+          builder.setStyle(style);
         } catch (Exception e) {
           Log.w(TAG, e);
         }
@@ -797,8 +810,11 @@ public class NotificationCenter {
     }
   }
 
-  public Bitmap getAvatar(DcChat dcChat) {
-    Recipient recipient = new Recipient(context, dcChat);
+  public IconCompat getAvatarIcon(DcContact contact) {
+    return IconCompat.createWithBitmap(getAvatar(new Recipient(context, contact)));
+  }
+
+  public Bitmap getAvatar(Recipient recipient) {
     try {
       Drawable drawable;
       ContactPhoto contactPhoto = recipient.getContactPhoto(context);

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -512,12 +512,7 @@ public class NotificationCenter {
           final String name = JsonUtils.optString(info, "name");
           String shortLine = name.isEmpty() ? text : (name + ": " + text);
           NotifData notifData =
-              new NotifData(
-                  new Person.Builder()
-                      .setIcon(
-                          IconCompat.createWithBitmap(getAvatar(new Recipient(context, dcChat))))
-                      .build(),
-                  shortLine);
+              new NotifData(new Person.Builder().setIcon(getAvatarIcon(dcChat)).build(), shortLine);
           maybeAddNotification(
               accountId, dcChat, msgId, notifData, shortLine, false, dcChat.isMultiUser());
         });
@@ -673,7 +668,7 @@ public class NotificationCenter {
 
       // Set avatar
       if (privacy.isDisplayContact()) {
-        Bitmap bitmap = getAvatar(new Recipient(context, dcChat));
+        Bitmap bitmap = getAvatar(dcChat);
         if (bitmap != null) {
           builder.setLargeIcon(bitmap);
         }
@@ -837,12 +832,25 @@ public class NotificationCenter {
     }
   }
 
-  public @Nullable IconCompat getAvatarIcon(DcContact contact) {
-    Bitmap avatar = getAvatar(new Recipient(context, contact));
+  private @Nullable IconCompat getAvatarIcon(DcChat dcChat) {
+    Bitmap avatar = getAvatar(dcChat);
     return avatar != null ? IconCompat.createWithBitmap(avatar) : null;
   }
 
-  public @Nullable Bitmap getAvatar(Recipient recipient) {
+  private @Nullable IconCompat getAvatarIcon(DcContact dcContact) {
+    Bitmap avatar = getAvatar(dcContact);
+    return avatar != null ? IconCompat.createWithBitmap(avatar) : null;
+  }
+
+  private @Nullable Bitmap getAvatar(DcChat dcChat) {
+    return getAvatar(new Recipient(context, dcChat));
+  }
+
+  private @Nullable Bitmap getAvatar(DcContact dcContact) {
+    return getAvatar(new Recipient(context, dcContact));
+  }
+
+  private @Nullable Bitmap getAvatar(Recipient recipient) {
     try {
       Drawable drawable;
       ContactPhoto contactPhoto = recipient.getContactPhoto(context);

--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -712,7 +712,7 @@ public class NotificationCenter {
                     .setName(msg.getSenderName(senderContact))
                     .setIcon(getAvatarIcon(senderContact))
                     .build();
-            style.addMessage(msgEntry.getValue(), msg.getSortTimestamp(), sender);
+            style.addMessage(msgEntry.getValue(), msg.getSortTimestamp() * 1000, sender);
           }
           builder.setStyle(style);
         } catch (Exception e) {


### PR DESCRIPTION
With MessagingStyle, Notifications can be expanded to show more text of the message than just a single line.

This feature has been requested in https://support.delta.chat/t/swipe-down-on-notification-to-expand-it/2742