### PR TITLE
update NDK version in CI workflows

### DIFF
--- a/.github/workflows/cache-core.yml
+++ b/.github/workflows/cache-core.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
         id: setup-ndk
         with:
-          ndk-version: r27
+          ndk-version: "r29"
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/preview-apk.yml
+++ b/.github/workflows/preview-apk.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
         id: setup-ndk
         with:
-          ndk-version: r27
+          ndk-version: "r29"
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:


### PR DESCRIPTION
wanted to update to 30, but it seems that is not "stable release" yet, latest stable release at https://developer.android.com/ndk/downloads/revision_history is r29