### PR TITLE
remove remainings of is_chatmail usage

### DIFF
--- a/src/main/java/com/b44t/messenger/DcAccounts.java
+++ b/src/main/java/com/b44t/messenger/DcAccounts.java
@@ -74,7 +74,7 @@ public class DcAccounts {
   public boolean isAllChatmail() {
     for (int accountId : getAll()) {
       DcContext dcContext = getAccount(accountId);
-      if (!dcContext.isChatmail()) {
+      if (dcContext.getConfigInt("is_chatmail") == 0) {
         return false;
       }
     }

--- a/src/main/java/com/b44t/messenger/DcContext.java
+++ b/src/main/java/com/b44t/messenger/DcContext.java
@@ -344,10 +344,6 @@ public class DcContext {
     return displayname;
   }
 
-  public boolean isChatmail() {
-    return getConfigInt("is_chatmail") == 1;
-  }
-
   public boolean isMuted() {
     return getConfigInt("is_muted") == 1;
   }

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcContactsLoader.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcContactsLoader.java
@@ -46,7 +46,7 @@ public class DcContactsLoader extends AsyncLoader<DcContactsLoader.Ret> {
     if (query == null && addScanQRLink) {
       additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_QR_INVITE);
     }
-    if (addCreateContactLink && !dcContext.isChatmail()) {
+    if (addCreateContactLink && dcContext.getConfigInt(DcHelper.CONFIG_FORCE_ENCRYPTION) == 0) {
       additional_items =
           Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_CLASSIC_CONTACT);
     }
@@ -54,7 +54,7 @@ public class DcContactsLoader extends AsyncLoader<DcContactsLoader.Ret> {
       additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_GROUP);
       additional_items = Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_BROADCAST);
 
-      if (!dcContext.isChatmail()) {
+      if (dcContext.getConfigInt(DcHelper.CONFIG_FORCE_ENCRYPTION) == 0) {
         additional_items =
             Util.appendInt(additional_items, DcContact.DC_CONTACT_ID_NEW_UNENCRYPTED_GROUP);
       }

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrActivity.java
@@ -18,6 +18,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
+import com.b44t.messenger.DcContext;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.zxing.BinaryBitmap;
@@ -120,10 +121,12 @@ public class QrActivity extends BaseActionBarActivity implements View.OnClickLis
 
   @Override
   public boolean onPrepareOptionsMenu(Menu menu) {
+    DcContext dcContext = DcHelper.getContext(this);
+
     menu.clear();
     getMenuInflater().inflate(R.menu.qr_show, menu);
     menu.findItem(R.id.new_classic_contact)
-        .setVisible(!scanRelay && !DcHelper.getContext(this).isChatmail());
+        .setVisible(!scanRelay && dcContext.getConfigInt(DcHelper.CONFIG_FORCE_ENCRYPTION) == 0);
 
     Util.redMenuItem(menu, R.id.withdraw);
     if (tabLayout.getSelectedTabPosition() == TAB_SCAN) {


### PR DESCRIPTION
instead, force_encryption is checked now,
and this only for option "New Chat -> New Email".

this also fixes the bug that, for classic relays,
by default "force encryption" is set but we still show "new email".

what's left for now is a check for is_chatmail whether fcm is sufficient or not.

counterpart of https://github.com/deltachat/deltachat-ios/pull/3142