### PR TITLE
don't try to upload artifacts for PRs from external contributors

### DIFF
--- a/.github/workflows/preview-apk.yml
+++ b/.github/workflows/preview-apk.yml
@@ -74,12 +74,14 @@ jobs:
 
       - name: Upload APK
         id: upload
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app-preview.apk
           path: 'build/outputs/apk/gplay/debug/*.apk'
 
       - name: Add artifact links to PR
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}


### PR DESCRIPTION
CI is failing at the "Upload APK" step for PRs from external contributors (see https://github.com/deltachat/deltachat-android/pull/4461 for example) 

what matters is that compilation passes etc. so just skip uploading apks in that case