### PR TITLE
fix: edit avatar btn: Group Name and Image -> Edit

### DIFF
--- a/src/main/res/menu/media_preview.xml
+++ b/src/main/res/menu/media_preview.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/media_preview__edit"
-        android:title="@string/menu_group_name_and_image"
+        android:title="@string/global_menu_edit_desktop"
         android:icon="@drawable/ic_create_white_24dp"
         app:showAsAction="always" />
     <item

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -288,7 +288,7 @@
     <string name="menu_send">Send</string>
     <string name="menu_toggle_keyboard">Toggle Emoji Keyboard</string>
     <string name="menu_edit_group">Edit Group</string>
-    <!-- deprecated: "Edit Group" dialog usually also contains the "Group Description" field -->
+    <!-- deprecated: "Edit Group" dialog usually also contains the "Group Description" field, use global_menu_edit_desktop instead -->
     <string name="menu_group_name_and_image">Group Name and Image</string>
     <string name="menu_show_global_map">All Locations</string>
     <string name="menu_archive_chat">Archive Chat</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -288,6 +288,7 @@
     <string name="menu_send">Send</string>
     <string name="menu_toggle_keyboard">Toggle Emoji Keyboard</string>
     <string name="menu_edit_group">Edit Group</string>
+    <!-- deprecated: "Edit Group" dialog usually also contains the "Group Description" field -->
     <string name="menu_group_name_and_image">Group Name and Image</string>
     <string name="menu_show_global_map">All Locations</string>
     <string name="menu_archive_chat">Archive Chat</string>


### PR DESCRIPTION
Since recently there is also "description"
in the "Edit Group" / "Edit Channel" dialog,
so the string is pretty much unapplicable anymore.

There is also an MR to remove its usage from Desktop:
https://github.com/deltachat/deltachat-desktop/pull/6484.
On iOS looks like it's already unused.

TODO:
- [x] Do the regular string removal procedure, unless it's enough to just remove it from the .xml files here.
- [ ] Assess the overall idea of this MR.

