### PR TITLE
allow to select multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Delta Chat Android Changelog
 
+## Unreleased
+
+* Allow to select multiple files for sending
+
 ## v2.53.0
 2026-06
 

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -441,32 +441,19 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           else mediaType = MediaType.IMAGE;
           setMedia(singleUri, mediaType);
         } else {
-          final ClipData multipleUris = data.getClipData();
-          if (multipleUris != null) {
-            final int uriCount = multipleUris.getItemCount();
-            if (uriCount > 0) {
-              ArrayList<Uri> uriList = new ArrayList<>(uriCount);
-              for (int i = 0; i < uriCount; i++) {
-                uriList.add(multipleUris.getItemAt(i).getUri());
-              }
-              askSendingFiles(
-                  uriList,
-                  () -> {
-                    Util.runOnAnyBackgroundThread(
-                        () -> {
-                          SendRelayedMessageUtil.sendMultipleMsgs(this, chatId, uriList, null);
-                        });
-                  });
-            }
-          }
+          sendMultipleMsgs(data);
         }
         break;
 
       case PICK_DOCUMENT:
-        final String docMimeType = MediaUtil.getMimeType(this, data.getData());
-        final MediaType docMediaType =
-            MediaUtil.isAudioType(docMimeType) ? MediaType.AUDIO : MediaType.DOCUMENT;
-        setMedia(data.getData(), docMediaType);
+        if (data.getData() != null) { // single Uri
+          final String docMimeType = MediaUtil.getMimeType(this, data.getData());
+          final MediaType docMediaType =
+              MediaUtil.isAudioType(docMimeType) ? MediaType.AUDIO : MediaType.DOCUMENT;
+          setMedia(data.getData(), docMediaType);
+        } else {
+          sendMultipleMsgs(data);
+        }
         break;
 
       case PICK_WEBXDC:
@@ -506,6 +493,25 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       case ScribbleActivity.SCRIBBLE_REQUEST_CODE:
         setMedia(data.getData(), MediaType.IMAGE);
         break;
+    }
+  }
+
+  private void sendMultipleMsgs(Intent data) {
+    final ClipData multipleUris = data.getClipData();
+    if (multipleUris != null) {
+      final int uriCount = multipleUris.getItemCount();
+      if (uriCount > 0) {
+        ArrayList<Uri> uriList = new ArrayList<>(uriCount);
+        for (int i = 0; i < uriCount; i++) {
+          uriList.add(multipleUris.getItemAt(i).getUri());
+        }
+        askSendingFiles(
+            uriList,
+            () -> {
+              Util.runOnAnyBackgroundThread(
+                  () -> SendRelayedMessageUtil.sendMultipleMsgs(this, chatId, uriList, null));
+            });
+      }
     }
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WelcomeActivity.java
@@ -212,7 +212,12 @@ public class WelcomeActivity extends BaseActionBarActivity
               File imexDir = DcHelper.getImexDir();
               if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 AttachmentManager.selectMediaType(
-                    this, "application/x-tar", null, PICK_BACKUP, StorageUtil.getDownloadUri());
+                    this,
+                    "application/x-tar",
+                    null,
+                    PICK_BACKUP,
+                    StorageUtil.getDownloadUri(),
+                    false);
               } else {
                 final String backupFile = dcContext.imexHasBackup(imexDir.getAbsolutePath());
                 if (backupFile != null) {

--- a/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -445,7 +445,7 @@ public class AttachmentManager {
   }
 
   public static void selectDocument(Activity activity, int requestCode) {
-    selectMediaType(activity, "*/*", null, requestCode);
+    selectMediaType(activity, "*/*", null, requestCode, null, true);
   }
 
   public static void selectWebxdc(Activity activity, int requestCode) {
@@ -483,7 +483,7 @@ public class AttachmentManager {
         .ifNecessary()
         .withPermanentDenialDialog(
             activity.getString(R.string.perm_explain_access_to_storage_denied))
-        .onAllGranted(() -> selectMediaType(activity, "image/*", null, requestCode))
+        .onAllGranted(() -> selectMediaType(activity, "image/*", null, requestCode, null, false))
         .execute();
   }
 
@@ -606,20 +606,6 @@ public class AttachmentManager {
               }
             })
         .execute();
-  }
-
-  public static void selectMediaType(
-      Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode) {
-    selectMediaType(activity, type, extraMimeType, requestCode, null, false);
-  }
-
-  public static void selectMediaType(
-      Activity activity,
-      @NonNull String type,
-      @Nullable String[] extraMimeType,
-      int requestCode,
-      @Nullable Uri initialUri) {
-    selectMediaType(activity, type, extraMimeType, requestCode, initialUri, false);
   }
 
   public static void selectMediaType(


### PR DESCRIPTION
some users have asked me for this here and there, and also happens quite often to myself when I want to send images as files to avoid compression, have to do it one-by-one 


also made the "allow multi-selection" flag more explicit than implicit and removed the unnecessary overridden variants 