### PR TITLE
shorten shortcut for 'Mark as Read'

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
+++ b/src/main/java/org/thoughtcrime/securesms/notifications/NotificationCenter.java
@@ -720,7 +720,7 @@ public class NotificationCenter {
 
           NotificationCompat.Action markAsReadAction =
               new NotificationCompat.Action(
-                  R.drawable.check, context.getString(R.string.mark_as_read_short), markReadIntent);
+                  R.drawable.check, context.getString(R.string.mark_as_read), markReadIntent);
 
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             NotificationCompat.Action replyAction =

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <!-- Used as an menu entry or button -->
     <string name="mark_as_read">Mark as Read</string>
     <!-- Used beside an icon with very few space. Shortest text for "Mark as being read". In english, this could be "Read" (past tense of "to read"), in german, this could be "Gelesen". -->
-    <string name="mark_as_read_short">Mark Read</string>
+    <string name="mark_as_read_short">Read</string>
     <!-- Used as an menu entry or button -->
     <string name="mark_as_unread">Mark as Unread</string>
     <!-- Used beside an icon with very few space. Shortest text for "Mark as being unread". In english, this could be "Unread" (past tense of "to unread"), in german, this could be "Ungelesen". -->


### PR DESCRIPTION
all of WhatsApp/Signal/Telegram use 'Read' (past tense) for the shortcut of 'Mark as Read', we also give that as an example in the translators hint.

this works, as there is enough context,
eg. the chat is long-tapped or swiped.

beside consistency, more reasons to follow that path:

- LiquidGlass has larger buttons, it looks better to stay short here

- while 'Mark Read' is short enough, it results in translations being to long - the shorter source, differing more from 'Mark as Read', should encourage translators to stay shorter

- surely UI should and do work also with longer texts, but it looks better to be short and on point

the string is mainly used by iOS, for android it is used in the notification, where we switch to the longer form, that is very similar to what we had before (but i would be fine with both)

once merged, we should call `./scripts/tx-update-changed-sources.sh` 