### PR TITLE
change default visibility of scroll_to_bottom_button to invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix: properly hide draft attachment during in-chat search
 * Fix: close mini-apps and chats if they are deleted
 * Fix: cancel in-chat search when back is pressed, instead of directly returning to chatlist
+* Fix: "go to bottom" floating button not appearing sometimes when user jumped to message
 
 ## v2.53.0
 2026-06

--- a/src/main/res/layout/conversation_fragment.xml
+++ b/src/main/res/layout/conversation_fragment.xml
@@ -53,7 +53,7 @@
 
     <ImageButton
         android:id="@+id/scroll_to_bottom_button"
-        android:visibility="gone"
+        android:visibility="invisible"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="10dp"


### PR DESCRIPTION
close #4502

it seems the problem was because a race condition the animation being triggered when the view had zero size or something like that, I was a bit throwing spaghetti into the wall here but setting the visibility to invisible so it is size is calculated sooner seems to fix the problem