### PR TITLE
Use notification channel settings for ringtone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix: close mini-apps and chats if they are deleted
 * Fix: cancel in-chat search when back is pressed, instead of directly returning to chatlist
 * Fix: "go to bottom" floating button not appearing sometimes when user jumped to message
+* Fix: incoming call ringtone now respects user's notification channel sound setting instead of the system default
 
 ## v2.53.0
 2026-06

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
@@ -15,6 +15,9 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Icon;
+import android.media.AudioAttributes;
+import android.media.AudioManager;
+import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
@@ -69,7 +72,8 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
   private static final String TAG = "CallCoordinator";
 
   // Notification channels
-  private static final String CHANNEL_ID_INCOMING = "voip_incoming_calls";
+  private static final String CHANNEL_ID_INCOMING_OLD = "voip_incoming_calls";
+  static final String CHANNEL_ID_INCOMING_V2 = "voip_incoming_calls_v2";
   private static final String CHANNEL_ID_ONGOING = "voip_ongoing_calls";
   private static final String CHANNEL_ID_MISSED = "voip_missed_calls";
   private static final int NOTIFICATION_ID_CALL = 1001;
@@ -170,11 +174,22 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
   }
 
   private void createNotificationChannels() {
+    notificationManager.deleteNotificationChannel(CHANNEL_ID_INCOMING_OLD);
+
+    Uri ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE);
+    AudioAttributes ringtoneAttributes =
+        new AudioAttributes.Builder()
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+            .setLegacyStreamType(AudioManager.STREAM_RING)
+            .build();
+
     NotificationChannel incomingChannel =
         new NotificationChannel(
-            CHANNEL_ID_INCOMING, "Incoming Calls", NotificationManager.IMPORTANCE_HIGH);
+            CHANNEL_ID_INCOMING_V2, "Incoming Calls", NotificationManager.IMPORTANCE_HIGH);
     incomingChannel.setDescription("Notifications for incoming DeltaChat calls");
-    incomingChannel.setSound(null, null);
+    incomingChannel.setSound(ringtoneUri, ringtoneAttributes);
+    incomingChannel.enableVibration(true);
 
     NotificationChannel ongoingChannel =
         new NotificationChannel(
@@ -268,9 +283,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
               // Initialize call
               callService.initializeCall();
 
-              if (isIncomingCall) {
-                callService.startIncomingRingtone();
-              } else {
+              if (!isIncomingCall) {
                 mainHandler.removeCallbacks(outgoingRingtoneRunnable);
                 mainHandler.postDelayed(outgoingRingtoneRunnable, 1500);
               }
@@ -603,12 +616,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
     appContext.startActivity(intent);
 
-    // CallStyle is always on top, so it will overlap
-    // Downside is once notification is dismissed and user backs out,
-    // the only way to get back to the call is to click on the message again.
-    notificationManager.cancel(NOTIFICATION_ID_CALL);
-
-    Log.d(TAG, "Answering call: " + callId);
+    Log.d(TAG, "Showing incoming call screen: " + callId);
   }
 
   public synchronized void declineCall() {
@@ -1476,7 +1484,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
           new Person.Builder().setName(callerName).setIcon(callerIcon).setImportant(true).build();
 
       builder =
-          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING)
+          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING_V2)
               .setSmallIcon(R.drawable.icon_notification)
               .setContentTitle("Incoming call")
               .setContentText("Incoming call from " + callerName)
@@ -1491,7 +1499,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
     } else {
       // Android 8-12: Notification with actions
       builder =
-          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING)
+          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING_V2)
               .setSmallIcon(R.drawable.icon_notification)
               .setContentTitle("Incoming call")
               .setContentText("Incoming call from " + callerName)
@@ -1513,7 +1521,9 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
                       .build());
     }
 
-    notificationManager.notify(NOTIFICATION_ID_CALL, builder.build());
+    Notification notification = builder.build();
+    notification.flags |= Notification.FLAG_INSISTENT;
+    notificationManager.notify(NOTIFICATION_ID_CALL, notification);
   }
 
   private void showMissedCallNotification(int accId, int chatId, boolean wasVideoCall) {

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallCoordinator.java
@@ -72,8 +72,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
   private static final String TAG = "CallCoordinator";
 
   // Notification channels
-  private static final String CHANNEL_ID_INCOMING_OLD = "voip_incoming_calls";
-  static final String CHANNEL_ID_INCOMING_V2 = "voip_incoming_calls_v2";
+  private static final String CHANNEL_ID_INCOMING = "voip_incoming_calls_v2";
   private static final String CHANNEL_ID_ONGOING = "voip_ongoing_calls";
   private static final String CHANNEL_ID_MISSED = "voip_missed_calls";
   private static final int NOTIFICATION_ID_CALL = 1001;
@@ -174,7 +173,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
   }
 
   private void createNotificationChannels() {
-    notificationManager.deleteNotificationChannel(CHANNEL_ID_INCOMING_OLD);
+    notificationManager.deleteNotificationChannel("voip_incoming_calls");
 
     Uri ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE);
     AudioAttributes ringtoneAttributes =
@@ -186,7 +185,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
 
     NotificationChannel incomingChannel =
         new NotificationChannel(
-            CHANNEL_ID_INCOMING_V2, "Incoming Calls", NotificationManager.IMPORTANCE_HIGH);
+            CHANNEL_ID_INCOMING, "Incoming Calls", NotificationManager.IMPORTANCE_HIGH);
     incomingChannel.setDescription("Notifications for incoming DeltaChat calls");
     incomingChannel.setSound(ringtoneUri, ringtoneAttributes);
     incomingChannel.enableVibration(true);
@@ -1484,7 +1483,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
           new Person.Builder().setName(callerName).setIcon(callerIcon).setImportant(true).build();
 
       builder =
-          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING_V2)
+          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING)
               .setSmallIcon(R.drawable.icon_notification)
               .setContentTitle("Incoming call")
               .setContentText("Incoming call from " + callerName)
@@ -1499,7 +1498,7 @@ public class CallCoordinator implements DcEventCenter.DcEventDelegate {
     } else {
       // Android 8-12: Notification with actions
       builder =
-          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING_V2)
+          new Notification.Builder(this.appContext, CHANNEL_ID_INCOMING)
               .setSmallIcon(R.drawable.icon_notification)
               .setContentTitle("Incoming call")
               .setContentText("Incoming call from " + callerName)

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallService.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallService.java
@@ -8,10 +8,7 @@ import android.content.pm.ServiceInfo;
 import android.media.AudioAttributes;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
-import android.media.Ringtone;
-import android.media.RingtoneManager;
 import android.media.ToneGenerator;
-import android.net.Uri;
 import android.os.Binder;
 import android.os.Build;
 import android.os.Handler;
@@ -45,11 +42,9 @@ public class CallService extends Service implements WebRTCClient.Callbacks {
   private MediaStreamManager mediaStreamManager;
 
   // Ringtone Resources
-  private Ringtone ringtone;
   private AudioManager audioManager;
   private AudioFocusRequest audioFocusRequest;
   private ToneGenerator toneGenerator;
-  private Runnable toneLoopRunnable;
 
   private CallCoordinator callCoordinator;
 
@@ -185,61 +180,6 @@ public class CallService extends Service implements WebRTCClient.Callbacks {
 
   // Ringtone Management
 
-  public void startIncomingRingtone() {
-    Log.d(TAG, "startIncomingRingtone");
-
-    if (ringtone != null && ringtone.isPlaying()) {
-      Log.d(TAG, "Ringtone already playing");
-      return;
-    }
-
-    try {
-      // Get system default ringtone URI
-      Uri ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE);
-
-      if (ringtoneUri == null) {
-        Log.w(TAG, "No default ringtone available");
-        return;
-      }
-
-      ringtone = RingtoneManager.getRingtone(getApplicationContext(), ringtoneUri);
-
-      if (ringtone == null) {
-        Log.e(TAG, "Failed to create Ringtone from URI: " + ringtoneUri);
-        return;
-      }
-
-      AudioAttributes audioAttributes =
-          new AudioAttributes.Builder()
-              .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-              .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-              .setLegacyStreamType(AudioManager.STREAM_RING)
-              .build();
-
-      ringtone.setAudioAttributes(audioAttributes);
-
-      // Request audio focus
-      audioFocusRequest =
-          new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
-              .setAudioAttributes(audioAttributes)
-              .setWillPauseWhenDucked(false)
-              .build();
-
-      int result = audioManager.requestAudioFocus(audioFocusRequest);
-      if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-        Log.w(TAG, "Audio focus not granted");
-      }
-
-      ringtone.play();
-      Log.d(TAG, "Ringtone started playing");
-
-    } catch (Exception e) {
-      Log.e(TAG, "Failed to start ringtone", e);
-      // Clean up on error
-      stopRingtone();
-    }
-  }
-
   public void startOutgoingRingtone() {
     Log.d(TAG, "startOutgoingRingtone");
 
@@ -298,18 +238,6 @@ public class CallService extends Service implements WebRTCClient.Callbacks {
         Log.e(TAG, "Error stopping ToneGenerator", e);
       }
       toneGenerator = null;
-    }
-
-    if (ringtone != null) {
-      try {
-        if (ringtone.isPlaying()) {
-          ringtone.stop();
-          Log.d(TAG, "Ringtone stopped");
-        }
-      } catch (Exception e) {
-        Log.e(TAG, "Error stopping ringtone", e);
-      }
-      ringtone = null;
     }
 
     if (audioFocusRequest != null && audioManager != null) {


### PR DESCRIPTION
So that incoming call sound loop correct and can be customized by users.

For new users this works automatically. For existing installations, there may be a left over channel in their settings, but if one didn't change anything there then no actions are needed.

Fixes #4513