### PR TITLE
webxdc drafts: show state in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add notifications for missed calls
 * Video call preview now accurately shows what is sent to remote
 * Enhance display of messages with long links
+* Show in title if an app is still in draft mode
 * Fix: properly hide draft attachment during in-chat search
 * Fix: close mini-apps and chats if they are deleted
 * Fix: cancel in-chat search when back is pressed, instead of directly returning to chatlist

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -528,8 +528,15 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   }
 
   private void updateTitleAndMenu(WebxdcMessageInfo info, DcChat chat) {
-    final String docName = TextUtils.isEmpty(info.document) ? info.name : info.document;
-    getSupportActionBar().setTitle(docName + " – " + chat.getName());
+    final String title;
+    if (dcAppMsg.getState() == DcMsg.DC_STATE_OUT_DRAFT) {
+      title = getString(R.string.draft);
+    } else {
+      final String docName = TextUtils.isEmpty(info.document) ? info.name : info.document;
+      title = docName + " – " + chat.getName();
+    }
+    getSupportActionBar().setTitle(title);
+
     String currSourceCodeUrl = info.sourceCodeUrl != null ? info.sourceCodeUrl : "";
     if (!sourceCodeUrl.equals(currSourceCodeUrl)) {
       sourceCodeUrl = currSourceCodeUrl;


### PR DESCRIPTION
show draft state already in title.
we got reports of ppl not aware they have to send an app for collaboration. to mitigate that, we set the subtitle to "tap 'send' to share". showing 'draft' when enlarged makes additionally clear that this is not sent out yet.
moreover, it removes clutter - the title and the chat is not really needed as the context is very much clear (more than eg. opening an app by icon from the media view)

counterpart of https://github.com/deltachat/deltachat-ios/pull/3178 cmp https://github.com/deltachat/deltachat-android/pull/4506

## before / after
<img width="320" src="https://github.com/user-attachments/assets/64249cc3-d54f-451e-8b00-d00970c522ed" /> <img width="320" src="https://github.com/user-attachments/assets/3005d6e2-8c46-4224-87d0-30f5ed9e826f" />
