### PR TITLE
remove getOauth2Url from CFFI

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -924,19 +924,6 @@ JNIEXPORT jstring Java_com_b44t_messenger_DcContext_getConnectivityHtml(JNIEnv *
 }
 
 
-JNIEXPORT jstring Java_com_b44t_messenger_DcContext_getOauth2Url(JNIEnv *env, jobject obj, jstring addr, jstring redirectUrl)
-{
-    CHAR_REF(addr);
-    CHAR_REF(redirectUrl);
-    char* temp = dc_get_oauth2_url(get_dc_context(env, obj), addrPtr, redirectUrlPtr);
-        jstring ret = JSTRING_NEW(temp);
-    dc_str_unref(temp);
-    CHAR_UNREF(redirectUrl);
-    CHAR_UNREF(addr);
-    return ret;
-}
-
-
 JNIEXPORT jstring Java_com_b44t_messenger_DcContext_getContactEncrInfo(JNIEnv *env, jobject obj, jint contact_id)
 {
     char* temp = dc_get_contact_encrinfo(get_dc_context(env, obj), contact_id);


### PR DESCRIPTION
the api is not used in java since 2+ years,
and will be finally removed in core at https://github.com/chatmail/core/pull/8431

#skip-changelog