### PR TITLE
chore: scripts/upload*.sh: update upload user

### DIFF
--- a/scripts/upload-beta.sh
+++ b/scripts/upload-beta.sh
@@ -21,9 +21,9 @@ ls -l $APKGPLAY
 ls -l $APKDEV
 read -p "upload these apks to download.delta.chat/android/beta? ENTER to continue, CTRL-C to abort."
 
-# see docs/upload-release for some hints wrt keys
-rsync --progress $APKGPLAY jekyll@download.delta.chat:/var/www/html/download/android/beta/
-rsync --progress $APKDEV jekyll@download.delta.chat:/var/www/html/download/android/beta/
+# If you want to be able to upload, send your public SSH key to sysadmin@testrun.org 
+rsync --progress $APKGPLAY www-android@download.delta.chat:/var/www/html/download/android/beta/
+rsync --progress $APKDEV www-android@download.delta.chat:/var/www/html/download/android/beta/
 
 echo "upload done."
 echo ""

--- a/scripts/upload-release.sh
+++ b/scripts/upload-release.sh
@@ -21,14 +21,8 @@ APK="deltachat-gplay-release-$VERSION.apk"
 ls -l $APK
 read -p "upload this apk and belonging symbols to download.delta.chat/android? ENTER to continue, CTRL-C to abort."
 
-# you need the private SSH key of the jekyll user; you can find it in this file:
-# https://github.com/hpk42/otf-deltachat/blob/master/secrets/delta.chat
-# It is protected with [git-crypt](https://www.agwa.name/projects/git-crypt/) -
-# after installing it, you can decrypt it with `git crypt unlock`.
-# If your key isn't added to the secrets, and you know some of the team in person,
-# you can ask on irc #deltachat for access.
-# Add the key to your `~/.ssh/config` for the host, or to your ssh-agent, so rsync is able to use it)
-rsync --progress $APK jekyll@download.delta.chat:/var/www/html/download/android/
+# If you want to be able to upload, send your public SSH key to sysadmin@testrun.org 
+rsync --progress $APK www-android@download.delta.chat:/var/www/html/download/android/
 
 cd ../..
 SYMBOLS_ZIP="$APK-symbols.zip"
@@ -36,7 +30,7 @@ rm $SYMBOLS_ZIP
 zip -r $SYMBOLS_ZIP obj
 zip $SYMBOLS_ZIP build/outputs/mapping/gplayRelease/mapping.txt
 ls -l $SYMBOLS_ZIP
-rsync --progress $SYMBOLS_ZIP jekyll@download.delta.chat:/var/www/html/download/android/symbols/
+rsync --progress $SYMBOLS_ZIP www-android@download.delta.chat:/var/www/html/download/android/symbols/
 
 echo "upload done."
 echo ""


### PR DESCRIPTION
The renewed delta.chat webserver now has per-service upload users; update script accordingly.