### PR TITLE
Ignore leave hints during call prompts

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
@@ -1034,6 +1034,10 @@ public class CallActivity extends AppCompatActivity {
 
           case INITIALIZING:
           case PROMPTING_USER_ACCEPT:
+            // Let's just ignore the hint in these cases, as it's most likely
+            // unwanted, and caused issues on some setups.
+            break;
+
           case ENDED:
           case ANSWERED_ELSEWHERE:
           case ERROR:


### PR DESCRIPTION
Fixes #4571.
See https://github.com/deltachat/deltachat-android/issues/4571#issuecomment-5124047287 for more info.

Apparently in certain cases `Activity.onUserLeaveHint` can be called whenever there's some switching of activities, and this can cause the incoming call screen to "self-dismiss" with a locked screen. For whatever reason my phone (Motorola Moto G32, Android 16, CalyxOS 7.2.2.0) does this.

It looks like acknowledging the hint is unwanted anyways so let's just do that.

---

As I said in the comment above, I have no idea if this is the right fix. Also needs some testing, especially with other Android 16 phones (I don't have an emulator at hand sorry).