### PR TITLE
Fix videos not being recoded when sending multiple/from file picker

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/BaseConversationListFragment.java
@@ -121,9 +121,6 @@ public abstract class BaseConversationListFragment extends Fragment implements A
 
               Context context = getContext();
               if (context != null) {
-                if (SendRelayedMessageUtil.containsVideoType(context, uris)) {
-                  message += "\n\n" + getString(R.string.videos_sent_without_recoding);
-                }
                 new AlertDialog.Builder(context)
                     .setMessage(message)
                     .setCancelable(false)

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -884,9 +884,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private void askSendingFiles(ArrayList<Uri> uriList, Runnable onConfirm) {
     String message =
         String.format(getString(R.string.ask_send_files_to_chat), uriList.size(), dcChat.getName());
-    if (SendRelayedMessageUtil.containsVideoType(context, uriList)) {
-      message += "\n\n" + getString(R.string.videos_sent_without_recoding);
-    }
     new AlertDialog.Builder(this)
         .setMessage(message)
         .setCancelable(false)

--- a/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/SendRelayedMessageUtil.java
@@ -27,6 +27,7 @@ import org.thoughtcrime.securesms.ConversationListRelayingActivity;
 import org.thoughtcrime.securesms.connect.DcHelper;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
+import org.thoughtcrime.securesms.video.recode.VideoRecoder;
 
 public class SendRelayedMessageUtil {
 
@@ -95,30 +96,26 @@ public class SendRelayedMessageUtil {
 
   public static void sendMultipleMsgs(
       Context context, int chatId, ArrayList<Uri> sharedUris, String sharedText) {
-    DcContext dcContext = DcHelper.getContext(context);
     ArrayList<Uri> uris = sharedUris;
     String text = sharedText;
 
     if (uris.size() == 1) {
-      dcContext.sendMsg(chatId, createMessage(context, uris.get(0), text));
+      sendMsgRecodingVideo(context, chatId, createMessage(context, uris.get(0), text));
     } else {
       if (text != null) {
-        dcContext.sendMsg(chatId, createMessage(context, null, text));
+        sendMsgRecodingVideo(context, chatId, createMessage(context, null, text));
       }
       for (Uri uri : uris) {
-        dcContext.sendMsg(chatId, createMessage(context, uri, null));
+        sendMsgRecodingVideo(context, chatId, createMessage(context, uri, null));
       }
     }
   }
 
-  public static boolean containsVideoType(Context context, ArrayList<Uri> uris) {
-    for (final Uri uri : uris) {
-      final String mimeType = MediaUtil.getMimeType(context, uri);
-      if (MediaUtil.isVideoType(mimeType)) {
-        return true;
-      }
+  private static void sendMsgRecodingVideo(Context context, int chatId, DcMsg msg) {
+    if (msg.getType() == DcMsg.DC_MSG_VIDEO && !VideoRecoder.prepareVideo(context, chatId, msg)) {
+      return;
     }
-    return false;
+    DcHelper.getContext(context).sendMsg(chatId, msg);
   }
 
   public static DcMsg createMessage(Context context, Uri uri, String text)

--- a/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
+++ b/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
@@ -467,7 +467,7 @@ public class VideoRecoder {
       return false;
     }
     // didWriteData(messageObject, cacheFile, true, error);
-    return true;
+    return !error;
   }
 
   private static class VideoEditedInfo {
@@ -684,9 +684,8 @@ public class VideoRecoder {
       if (!videoRecoder.convertVideo(vei, tempPath)) {
         alert(
             context,
-            String.format(
-                "Recoding failed for %s: cannot convert to temporary file %s", inPath, tempPath));
-        return false;
+            String.format("Could not recode %s; sending it at its original size.", inPath));
+        return true;
       }
 
       msg.setFileAndDeduplicate(tempPath, msg.getFilename(), msg.getFilemime());

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -769,6 +769,7 @@
     <!-- first placeholder is replaced by the number of files (always 2 or more); second placeholder is replaced by a chat name -->
     <string name="ask_send_files_to_chat">Send %1$d files to \"%2$s\"?</string>
     <string name="ask_send_files_to_selected_chats">Send %1$d file(s) to %2$d chats?</string>
+    <!-- deprecated -->
     <string name="videos_sent_without_recoding">(Sending multiple videos will send them as-is, which may be large. To make them smaller and save data, you can send each video in its own message)</string>
     <string name="share_text_multiple_chats">Send this text to %1$d chats?\n\n\"%2$s\"</string>
     <string name="share_abort">Sharing aborted due to missing permissions.</string>


### PR DESCRIPTION
Fixes #3928
Fixes #4541

There is one minor inconvenience that if there are multiple videos to be encoded, each one will get a dialog. But it is not very common and increase complexity of the patch so I left it as-is.

#skip-changelog