### PR TITLE
make big badge counters more human readable and avoid badge overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix: Mic will stay active during a call when screen is off on Android 14+
 * Fix: allow to pick image without requiring storage permission
+* Fix: avoid overflow with big numbers in badge counters
 
 ## v2.57.0
 2026-07

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -421,6 +421,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     if (unreadCount == 0) {
       unreadIndicator.setVisibility(View.GONE);
     } else {
+      String badgeText = Util.humanReadableCount(unreadCount);
       unreadIndicator.setImageDrawable(
           TextDrawable.builder()
               .beginConfig()
@@ -429,8 +430,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
               .textColor(Color.WHITE)
               .bold()
               .endConfig()
-              .buildRound(
-                  String.valueOf(unreadCount), getResources().getColor(R.color.unread_count)));
+              .buildRound(badgeText, getResources().getColor(R.color.unread_count)));
       unreadIndicator.setVisibility(View.VISIBLE);
     }
   }

--- a/src/main/java/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationListItem.java
@@ -310,6 +310,7 @@ public class ConversationListItem extends RelativeLayout
                           ? R.color.unread_count_muted_dark
                           : R.color.unread_count_muted)
                       : R.color.unread_count);
+      String badgeText = Util.humanReadableCount(unreadCount);
       unreadIndicator.setImageDrawable(
           TextDrawable.builder()
               .beginConfig()
@@ -318,7 +319,7 @@ public class ConversationListItem extends RelativeLayout
               .textColor(Color.WHITE)
               .bold()
               .endConfig()
-              .buildRound(String.valueOf(unreadCount), color));
+              .buildRound(badgeText, color));
       unreadIndicator.setVisibility(View.VISIBLE);
     }
   }

--- a/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/accounts/AccountSelectionListItem.java
@@ -21,6 +21,7 @@ import org.thoughtcrime.securesms.components.AvatarView;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.ThemeUtil;
+import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class AccountSelectionListItem extends LinearLayout {
@@ -125,6 +126,7 @@ public class AccountSelectionListItem extends LinearLayout {
                           ? R.color.unread_count_muted_dark
                           : R.color.unread_count_muted)
                       : R.color.unread_count);
+      String badgeText = Util.humanReadableCount(unreadCount);
       unreadIndicator.setImageDrawable(
           TextDrawable.builder()
               .beginConfig()
@@ -133,7 +135,7 @@ public class AccountSelectionListItem extends LinearLayout {
               .textColor(Color.WHITE)
               .bold()
               .endConfig()
-              .buildRound(String.valueOf(unreadCount), color));
+              .buildRound(badgeText, color));
       unreadIndicator.setVisibility(View.VISIBLE);
     }
   }

--- a/src/main/java/org/thoughtcrime/securesms/util/Util.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Util.java
@@ -110,6 +110,13 @@ public class Util {
     }
   }
 
+  public static String humanReadableCount(int count) {
+    if (count >= 1000) {
+      return (count / 1000) + "k";
+    }
+    return String.valueOf(count);
+  }
+
   public static List<Integer> toList(int[] array) {
     ArrayList<Integer> list = new ArrayList<>(array.length);
     for (int i : array) {


### PR DESCRIPTION
if number is bigger than 999 there is no much space left in the badge-counter bubbles, it also doesn't make much sense to be so precise at that point so changing shape of badge counter to accommodate hard to read big numbers is not helpful, instead this PR does similar to Telegram and start counting in k, ex `1k, 2k, 3k, etc.` this gives a bit of more information than just 99+ which would only provide accurate counting on `< 99`

## Chat list
<img width="1024" height="899" alt="image" src="https://github.com/user-attachments/assets/6f3e2693-fe8e-431e-b1b8-a586711a5bd1" />

## Title bar badge

<img width="1024" height="548" alt="image" src="https://github.com/user-attachments/assets/254b7d7b-5ca5-4948-a020-3b729347fd77" />

## Account switcher

<img width="1024" height="365" alt="image" src="https://github.com/user-attachments/assets/07a5273c-4437-4d9d-a4f5-96159ade86ed" />


----

close #4564