### PR TITLE
drop usage of `dc_chatlist_get_context()`

### DIFF
--- a/jni/dc_wrapper.c
+++ b/jni/dc_wrapper.c
@@ -1137,23 +1137,9 @@ JNIEXPORT jint Java_com_b44t_messenger_DcChatlist_getChatId(JNIEnv *env, jobject
 }
 
 
-JNIEXPORT jlong Java_com_b44t_messenger_DcChatlist_getChatCPtr(JNIEnv *env, jobject obj, jint index)
-{
-    dc_chatlist_t* chatlist = get_dc_chatlist(env, obj);
-    return (jlong)dc_get_chat(dc_chatlist_get_context(chatlist), dc_chatlist_get_chat_id(chatlist, index));
-}
-
-
 JNIEXPORT jint Java_com_b44t_messenger_DcChatlist_getMsgId(JNIEnv *env, jobject obj, jint index)
 {
     return dc_chatlist_get_msg_id(get_dc_chatlist(env, obj), index);
-}
-
-
-JNIEXPORT jlong Java_com_b44t_messenger_DcChatlist_getMsgCPtr(JNIEnv *env, jobject obj, jint index)
-{
-    dc_chatlist_t* chatlist = get_dc_chatlist(env, obj);
-    return (jlong)dc_get_msg(dc_chatlist_get_context(chatlist), dc_chatlist_get_msg_id(chatlist, index));
 }
 
 

--- a/src/main/java/com/b44t/messenger/DcChatlist.java
+++ b/src/main/java/com/b44t/messenger/DcChatlist.java
@@ -24,15 +24,7 @@ public class DcChatlist {
 
   public native int getChatId(int index);
 
-  public DcChat getChat(int index) {
-    return new DcChat(accountId, getChatCPtr(index));
-  }
-
   public native int getMsgId(int index);
-
-  public DcMsg getMsg(int index) {
-    return new DcMsg(getMsgCPtr(index));
-  }
 
   public DcLot getSummary(int index, DcChat chat) {
     return new DcLot(getSummaryCPtr(index, chat == null ? 0 : chat.getChatCPtr()));
@@ -56,10 +48,6 @@ public class DcChatlist {
   private long chatlistCPtr; // CAVE: the name is referenced in the JNI
 
   private native void unrefChatlistCPtr();
-
-  private native long getChatCPtr(int index);
-
-  private native long getMsgCPtr(int index);
 
   private native long getSummaryCPtr(int index, long chatCPtr);
 }

--- a/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DirectShareUtil.java
@@ -116,7 +116,7 @@ public class DirectShareUtil {
       max = chatlist.getCnt();
     }
     for (int i = 0; i < max; i++) {
-      DcChat chat = chatlist.getChat(i);
+      DcChat chat = dcContext.getChat(chatlist.getChatId(i));
       if (!chat.canSend()) {
         continue;
       }


### PR DESCRIPTION
it was not widely used anyways, and the one occurance was easy to replace, without any additional database call or other negative performance impact.

i also checked other UI: no one else seems to use `dc_chatlist_get_context()`, so it can be removed directly from core, instead of maintaining it, cmp https://github.com/chatmail/core/pull/8506

#skip-changelog