### PR TITLE
allow to pick image even without storage permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix: Mic will stay active during a call when screen is off on Android 14+
+* Fix: allow to pick image without requiring storage permission
 
 ## v2.57.0
 2026-07

--- a/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -454,18 +454,15 @@ public class AttachmentManager {
   }
 
   public static void selectGallery(Activity activity, int requestCode) {
-    // to enable camera roll,
-    // we're asking for "gallery permissions" also on newer systems that do not strictly require
-    // that.
+    // to enable camera roll, we're asking for "gallery permissions".
+    // Regardless of permissions granted or not,
+    // we continue launching the file picker since it doesn't require permissions.
     // (asking directly after tapping "attachment" would be not-so-good as the user may want to
-    // attach sth. else
-    // and asking for permissions is better done on-point)
+    // attach sth. else and asking for permissions is better done on-point)
     Permissions.with(activity)
         .request(Permissions.galleryPermissions())
         .ifNecessary()
-        .withPermanentDenialDialog(
-            activity.getString(R.string.perm_explain_access_to_storage_denied))
-        .onAllGranted(
+        .onAnyResult(
             () ->
                 selectMediaType(
                     activity,
@@ -478,12 +475,13 @@ public class AttachmentManager {
   }
 
   public static void selectImage(Activity activity, int requestCode) {
+    // similar to selectGallery, we ask for permission just for camera roll
+    // but it is not really necessary to pick image,
+    // so we proceed regardless of the result
     Permissions.with(activity)
         .request(Permissions.galleryPermissions())
         .ifNecessary()
-        .withPermanentDenialDialog(
-            activity.getString(R.string.perm_explain_access_to_storage_denied))
-        .onAllGranted(() -> selectMediaType(activity, "image/*", null, requestCode, null, false))
+        .onAnyResult(() -> selectMediaType(activity, "image/*", null, requestCode, null, false))
         .execute();
   }
 


### PR DESCRIPTION
the minimum android version we support is android 5 and there already is possible to pick files via the system file picker without storage permission

we ask for storage permission for the camera roll, but if the permission is denied we should still proceed to the picker

in more recent android versions we can also use a new image&video-focused picker it seems, but that can be done at later point, this already solves the problem at hand

close #4563