### PR TITLE
i try to resolve audio conflict issue #4578

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -99,6 +99,7 @@ import org.thoughtcrime.securesms.components.InputPanel;
 import org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout.OnKeyboardShownListener;
 import org.thoughtcrime.securesms.components.ScaleStableImageView;
 import org.thoughtcrime.securesms.components.SendButton;
+import org.thoughtcrime.securesms.components.audioplay.AudioPlaybackState;
 import org.thoughtcrime.securesms.components.audioplay.AudioPlaybackViewModel;
 import org.thoughtcrime.securesms.components.audioplay.AudioView;
 import org.thoughtcrime.securesms.components.audioplay.ChatAudioQueueProvider;
@@ -1463,6 +1464,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     fragment.hideAddReactionView();
     Vibrator vibrator = ServiceUtil.getVibrator(this);
     vibrator.vibrate(20);
+
+    AudioPlaybackState currentPlaybackState = playbackViewModel.getPlaybackState().getValue();
+    if (currentPlaybackState != null
+        && currentPlaybackState.getStatus() == AudioPlaybackState.PlaybackStatus.PLAYING) {
+      playbackViewModel.pause(currentPlaybackState.getMsgId());
+    }
 
     getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 


### PR DESCRIPTION
Closes #4578
Hi! I submitted a small fix for issue #4578 created by me. 
The problem is audio overlapping, that is, when I listen to an audio I can also record, but it's not good, when I listen to an audio and press to record, it has to stop the audio I'm listening to, so I tried to look for where the audio was managed (both listening to audio and the start of a recording) and where the startRecording method was called, then I checked that if the PlaybackStatus of PlaybackState is = PLAYING, and before starting startRecording() of AudioRecorder, you have to set the PlaybackStatus = PAUSED, and then I called the pause method to stop the current audio;

I'm very sorry but this is one of my first times trying to modify a large project and I'm having trouble managing the whole environment and i wasn't able to set up the local environment to test it, so I would appreciate it if someone could double-check/test it. In the meantime I'm trying to set up the whole environment. Thanks!