### PR TITLE
Add audio focus handling to recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix: avoid overflow with big numbers in badge counters
 * Fix: make video players truly fullscreen
 * Fix: avoid ending search mode when a new message arrive to the chat
+* Fix: Recording now request and respect audio focus
 
 ## v2.57.0
 2026-07

--- a/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java
@@ -388,7 +388,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   protected void onPause() {
     super.onPause();
 
-    if (inputPanel.isRecording() && inputPanel.getRecordingDuration() > 1000) {
+    if (shouldSaveRecording()) {
       saveRecording();
     } else {
       processComposeControls(ACTION_SAVE_DRAFT);
@@ -1054,7 +1054,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     attachmentTypeSelector = null;
     attachmentManager = new AttachmentManager(this, this);
-    audioRecorder = new AudioRecorder(this);
+    audioRecorder = new AudioRecorder(this, this::handleRecordingInterrupted);
 
     SendButtonListener sendButtonListener = new SendButtonListener();
     ComposeKeyPressedListener composeKeyPressedListener = new ComposeKeyPressedListener();
@@ -1467,6 +1467,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
+    playbackViewModel.setRecording(true);
     audioRecorder.startRecording();
   }
 
@@ -1484,7 +1485,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
-    ListenableFuture<Pair<Uri, Long>> future = audioRecorder.stopRecording();
+    ListenableFuture<Pair<Uri, Long>> future = stopAudioRecorder();
     future.addListener(
         new ListenableFuture.Listener<Pair<Uri, Long>>() {
           @Override
@@ -1535,7 +1536,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
-    ListenableFuture<Pair<Uri, Long>> future = audioRecorder.stopRecording();
+    ListenableFuture<Pair<Uri, Long>> future = stopAudioRecorder();
     future.addListener(
         new ListenableFuture.Listener<Pair<Uri, Long>>() {
           @Override
@@ -1699,6 +1700,39 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
+  private ListenableFuture<Pair<Uri, Long>> stopAudioRecorder() {
+    ListenableFuture<Pair<Uri, Long>> future = audioRecorder.stopRecording();
+    future.addListener(
+        new ListenableFuture.Listener<Pair<Uri, Long>>() {
+          @Override
+          public void onSuccess(Pair<Uri, Long> result) {
+            playbackViewModel.setRecording(false);
+          }
+
+          @Override
+          public void onFailure(ExecutionException e) {
+            playbackViewModel.setRecording(false);
+          }
+        });
+    return future;
+  }
+
+  private boolean shouldSaveRecording() {
+    return inputPanel.isRecording() && inputPanel.getRecordingDuration() > 1000;
+  }
+
+  private void handleRecordingInterrupted() {
+    if (!inputPanel.isRecording()) {
+      return;
+    }
+
+    if (shouldSaveRecording()) {
+      saveRecording();
+    } else {
+      inputPanel.cancelRecording();
+    }
+  }
+
   private void saveRecording() {
     inputPanel.resetRecordingUI();
     getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
@@ -1706,7 +1740,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     final int thisChatId = chatId;
     final Optional<QuoteModel> quote = inputPanel.getQuote();
 
-    ListenableFuture<Pair<Uri, Long>> future = audioRecorder.stopRecording();
+    ListenableFuture<Pair<Uri, Long>> future = stopAudioRecorder();
     future.addListener(
         new ListenableFuture.Listener<Pair<Uri, Long>>() {
           @Override

--- a/src/main/java/org/thoughtcrime/securesms/audio/AudioFocusHolder.java
+++ b/src/main/java/org/thoughtcrime/securesms/audio/AudioFocusHolder.java
@@ -1,0 +1,103 @@
+package org.thoughtcrime.securesms.audio;
+
+import android.content.Context;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
+import android.os.Build;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class AudioFocusHolder {
+
+  private static final String TAG = "AudioFocusHolder";
+
+  private final @Nullable AudioManager audioManager;
+  private final Runnable onFocusLost;
+
+  private @Nullable AudioManager.OnAudioFocusChangeListener focusChangeListener;
+  private @Nullable Object focusRequest; // API 26+ only
+  private boolean held;
+
+  public AudioFocusHolder(@NonNull Context context, @NonNull Runnable onFocusLost) {
+    this.audioManager =
+        (AudioManager) context.getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
+    this.onFocusLost = onFocusLost;
+  }
+
+  @SuppressWarnings("deprecation")
+  public synchronized boolean acquire() {
+    if (held) {
+      return true;
+    }
+    if (audioManager == null) {
+      return false;
+    }
+
+    focusChangeListener = this::onAudioFocusChange;
+
+    int result;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      AudioAttributes attributes =
+          new AudioAttributes.Builder()
+              .setUsage(AudioAttributes.USAGE_MEDIA)
+              .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+              .build();
+      AudioFocusRequest request =
+          new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+              .setAudioAttributes(attributes)
+              .setOnAudioFocusChangeListener(focusChangeListener)
+              .build();
+      focusRequest = request;
+      result = audioManager.requestAudioFocus(request);
+    } else {
+      result =
+          audioManager.requestAudioFocus(
+              focusChangeListener,
+              AudioManager.STREAM_MUSIC,
+              AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE);
+    }
+
+    held = result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+    if (!held) {
+      Log.w(TAG, "Audio focus request was not granted: " + result);
+      focusRequest = null;
+      focusChangeListener = null;
+    }
+    return held;
+  }
+
+  @SuppressWarnings("deprecation")
+  public synchronized void release() {
+    if (!held || audioManager == null) {
+      return;
+    }
+    held = false;
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      if (focusRequest != null) {
+        audioManager.abandonAudioFocusRequest((AudioFocusRequest) focusRequest);
+      }
+    } else if (focusChangeListener != null) {
+      audioManager.abandonAudioFocus(focusChangeListener);
+    }
+
+    focusRequest = null;
+    focusChangeListener = null;
+  }
+
+  private void onAudioFocusChange(int focusChange) {
+    if (focusChange != AudioManager.AUDIOFOCUS_LOSS
+        && focusChange != AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
+      return;
+    }
+
+    synchronized (this) {
+      if (!held) return;
+    }
+
+    Log.w(TAG, "Audio focus lost during recording");
+    onFocusLost.run();
+  }
+}

--- a/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
+++ b/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
@@ -24,6 +24,7 @@ public class AudioRecorder {
 
   private final Context context;
   private final PersistentBlobProvider blobProvider;
+  private final AudioFocusHolder audioFocusHolder;
 
   private final AtomicReference<RecordingState> recordingState = new AtomicReference<>(null);
 
@@ -37,13 +38,18 @@ public class AudioRecorder {
     }
   }
 
-  public AudioRecorder(@NonNull Context context) {
+  public AudioRecorder(@NonNull Context context, @NonNull Runnable onInterrupted) {
     this.context = context;
     this.blobProvider = PersistentBlobProvider.getInstance();
+    this.audioFocusHolder = new AudioFocusHolder(context, onInterrupted);
   }
 
   public void startRecording() {
     Log.w(TAG, "startRecording()");
+
+    if (!audioFocusHolder.acquire()) {
+      Log.w(TAG, "Recording without acquiring audio focus");
+    }
 
     executor.execute(
         () -> {
@@ -65,6 +71,7 @@ public class AudioRecorder {
           } catch (IOException e) {
             Log.w(TAG, e);
             recordingState.set(null);
+            audioFocusHolder.release();
           }
         });
   }
@@ -76,48 +83,52 @@ public class AudioRecorder {
 
     executor.execute(
         () -> {
-          RecordingState state = recordingState.getAndSet(null);
-
-          if (state == null || state.audioCodec == null) {
-            sendToFuture(
-                future, new IOException("MediaRecorder was never initialized successfully!"));
-            return;
-          }
-
-          state.audioCodec.stop();
-
-          Exception encodingError = state.audioCodec.getEncodingError();
-          if (encodingError != null) {
-            File outputFile = new File(state.outputFilePath);
-            if (outputFile.exists() && !outputFile.delete()) {
-              Log.w(TAG, "Could not delete corrupt recording");
-            }
-            sendToFuture(future, new IOException("Recording failed", encodingError));
-            return;
-          }
-
           try {
-            File outputFile = new File(state.outputFilePath);
+            RecordingState state = recordingState.getAndSet(null);
 
-            if (!outputFile.exists()) {
-              sendToFuture(future, new IOException("Output file does not exist"));
+            if (state == null || state.audioCodec == null) {
+              sendToFuture(
+                  future, new IOException("MediaRecorder was never initialized successfully!"));
               return;
             }
 
-            long size = outputFile.length();
+            state.audioCodec.stop();
 
-            // Create blob using synchronous file-based method
-            Uri captureUri =
-                blobProvider.create(context, outputFile, MediaUtil.AUDIO_M4A, "voice.m4a", size);
-
-            if (!outputFile.delete()) {
-              Log.d(TAG, "Temp file already moved or couldn't be deleted");
+            Exception encodingError = state.audioCodec.getEncodingError();
+            if (encodingError != null) {
+              File outputFile = new File(state.outputFilePath);
+              if (outputFile.exists() && !outputFile.delete()) {
+                Log.w(TAG, "Could not delete corrupt recording");
+              }
+              sendToFuture(future, new IOException("Recording failed", encodingError));
+              return;
             }
 
-            sendToFuture(future, new Pair<>(captureUri, size));
-          } catch (IOException ioe) {
-            Log.w(TAG, "Failed to create blob from recording", ioe);
-            sendToFuture(future, ioe);
+            try {
+              File outputFile = new File(state.outputFilePath);
+
+              if (!outputFile.exists()) {
+                sendToFuture(future, new IOException("Output file does not exist"));
+                return;
+              }
+
+              long size = outputFile.length();
+
+              // Create blob using synchronous file-based method
+              Uri captureUri =
+                  blobProvider.create(context, outputFile, MediaUtil.AUDIO_M4A, "voice.m4a", size);
+
+              if (!outputFile.delete()) {
+                Log.d(TAG, "Temp file already moved or couldn't be deleted");
+              }
+
+              sendToFuture(future, new Pair<>(captureUri, size));
+            } catch (IOException ioe) {
+              Log.w(TAG, "Failed to create blob from recording", ioe);
+              sendToFuture(future, ioe);
+            }
+          } finally {
+            audioFocusHolder.release();
           }
         });
 

--- a/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
@@ -260,8 +260,12 @@ public class InputPanel extends ConstraintLayout
     if (listener != null) listener.onRecorderLocked();
   }
 
-  public void onPause() {
+  public void cancelRecording() {
     this.microphoneRecorderView.cancelAction();
+  }
+
+  public void onPause() {
+    cancelRecording();
   }
 
   public void setEnabled(boolean enabled) {

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioPlaybackViewModel.java
@@ -31,6 +31,7 @@ public class AudioPlaybackViewModel extends ViewModel {
 
   private final MutableLiveData<Map<Integer, Long>> durations =
       new MutableLiveData<>(new HashMap<>());
+  private final MutableLiveData<Boolean> recording = new MutableLiveData<>(false);
   private final Map<Integer, Uri> durationUris = new HashMap<>();
   private final Set<Integer> extractionInProgress = new HashSet<>();
   private final ExecutorService extractionExecutor = Executors.newFixedThreadPool(2);
@@ -67,6 +68,7 @@ public class AudioPlaybackViewModel extends ViewModel {
   // Public methods
   public void loadAudioAndPlay(int msgId, Uri audioUri) {
     if (mediaController == null) return;
+    if (Boolean.TRUE.equals(recording.getValue())) return;
 
     String mediaId = String.valueOf(msgId);
 
@@ -176,6 +178,7 @@ public class AudioPlaybackViewModel extends ViewModel {
   }
 
   public void play(int msgId) {
+    if (Boolean.TRUE.equals(recording.getValue())) return;
     if (isCurrentItem(msgId)) {
       mediaController.play();
     }
@@ -238,6 +241,21 @@ public class AudioPlaybackViewModel extends ViewModel {
 
   public void setUserSeeking(boolean isUserSeeking) {
     this.isUserSeeking = isUserSeeking;
+  }
+
+  public LiveData<Boolean> isRecording() {
+    return recording;
+  }
+
+  public void setRecording(boolean isRecording) {
+    if (Boolean.valueOf(isRecording).equals(recording.getValue())) return;
+    recording.setValue(isRecording);
+
+    if (isRecording) {
+      stopUpdateProgress();
+    } else if (mediaController != null && mediaController.isPlaying()) {
+      startUpdateProgress();
+    }
   }
 
   // Private methods

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -35,6 +35,7 @@ public class AudioView extends FrameLayout {
   private final @NonNull TextView timestamp;
   private final @NonNull TextView title;
   private final @NonNull View mask;
+  private final Observer<Boolean> recordingObserver = this::onRecordingChanged;
   private OnActionListener listener;
 
   private int msgId = -1;
@@ -99,6 +100,9 @@ public class AudioView extends FrameLayout {
 
       viewModel.getDurations().removeObserver(durationObserver);
       viewModel.getDurations().observeForever(durationObserver);
+
+      viewModel.isRecording().removeObserver(recordingObserver);
+      viewModel.isRecording().observeForever(recordingObserver);
     }
 
     playPauseButton.setOnClickListener(
@@ -106,6 +110,7 @@ public class AudioView extends FrameLayout {
           Log.w(TAG, "playPauseButton onClick");
 
           if (viewModel == null || audioUri == null) return;
+          if (Boolean.TRUE.equals(viewModel.isRecording().getValue())) return;
 
           AudioPlaybackState state = viewModel.getPlaybackState().getValue();
 
@@ -165,6 +170,7 @@ public class AudioView extends FrameLayout {
     if (viewModel != null) {
       viewModel.getPlaybackState().removeObserver(stateObserver);
       viewModel.getDurations().removeObserver(durationObserver);
+      viewModel.isRecording().removeObserver(recordingObserver);
     }
     if (playToPauseDrawable != null) {
       playToPauseDrawable.clearAnimationCallbacks();
@@ -179,6 +185,7 @@ public class AudioView extends FrameLayout {
     if (this.viewModel != null) {
       this.viewModel.getPlaybackState().removeObserver(stateObserver);
       this.viewModel.getDurations().removeObserver(durationObserver);
+      this.viewModel.isRecording().removeObserver(recordingObserver);
     }
 
     // ViewModel is used directly for simplicity, since there is no reuse yet
@@ -187,6 +194,7 @@ public class AudioView extends FrameLayout {
     if (viewModel != null) {
       viewModel.getPlaybackState().observeForever(stateObserver);
       viewModel.getDurations().observeForever(durationObserver);
+      viewModel.isRecording().observeForever(recordingObserver);
     }
   }
 
@@ -195,7 +203,7 @@ public class AudioView extends FrameLayout {
     audioUri = audio.getUri();
     playPauseButton.setImageDrawable(playDrawable);
 
-    seekBar.setEnabled(true);
+    applyRecordingState(Boolean.TRUE.equals(viewModel.isRecording().getValue()));
 
     this.progress = 0;
     this.duration = 0;
@@ -277,6 +285,22 @@ public class AudioView extends FrameLayout {
 
   public void disablePlayer(boolean disable) {
     this.mask.setVisibility(disable ? View.VISIBLE : View.GONE);
+  }
+
+  private void applyRecordingState(boolean recording) {
+    playPauseButton.setEnabled(!recording);
+    playPauseButton.setAlpha(recording ? 0.5f : 1f);
+    seekBar.setEnabled(!recording);
+  }
+
+  private void onRecordingChanged(Boolean isRecording) {
+    applyRecordingState(isRecording);
+
+    if (isRecording) {
+      togglePlayPause(false);
+    } else {
+      onPlaybackStateChanged(viewModel.getPlaybackState().getValue());
+    }
   }
 
   public void getSeekBarGlobalVisibleRect(@NonNull Rect rect) {


### PR DESCRIPTION
Fixes #4578

This changes a few things:
1. When recording starts, it will stop audio playback (requests audio focus)
2. When recording stops, playback will resume, as long as the playing app respects audio focus
3. During recording, play/pause/seek on audios are disabled in a chat
4. If some other app requests audio focus during recording, the recording will stop and save to draft

Supersede #4581