### PR TITLE
ConversationItemFooter: improve screen reader accessibility

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -29,6 +29,7 @@ public class ConversationItemFooter extends LinearLayout {
   private Integer textColor = null;
   private Context context;
   private Rpc rpc;
+  private int channelReadCount;
 
   public ConversationItemFooter(Context context) {
     super(context);
@@ -90,14 +91,15 @@ public class ConversationItemFooter extends LinearLayout {
 
     locationIndicatorView.setVisibility(messageRecord.hasLocation() ? View.VISIBLE : View.GONE);
 
+    channelReadCount = 0;
     boolean isOutChannel =
         DcHelper.getContext(context).getChat(messageRecord.getChatId()).isOutBroadcast();
 
     if (isOutChannel && messageRecord.isOutgoing()) {
       try {
         int accId = rpc.getSelectedAccountId();
-        int count = rpc.getMessageReadReceiptCount(accId, messageRecord.getId());
-        viewsLabel.setText(String.format("%d", count));
+        channelReadCount = rpc.getMessageReadReceiptCount(accId, messageRecord.getId());
+        viewsLabel.setText(String.format("%d", channelReadCount));
         viewsLabel.setVisibility(View.VISIBLE);
         viewsIcon.setVisibility(View.VISIBLE);
       } catch (RpcException e) {
@@ -144,10 +146,31 @@ public class ConversationItemFooter extends LinearLayout {
   }
 
   public String getDescription() {
-    String desc = dateView.getText().toString();
-    String deliveryDesc = deliveryStatusView.getDescription();
-    if (!"".equals(deliveryDesc)) {
-      desc += "\n" + deliveryDesc;
+    String desc = "";
+    if (locationIndicatorView.getVisibility() == View.VISIBLE) {
+      desc += context.getString(R.string.location) + "\n";
+    }
+
+    if (bookmarkIndicatorView.getVisibility() == View.VISIBLE) {
+      desc += context.getString(R.string.saved) + "\n";
+    }
+
+    if (editedView.getVisibility() == View.VISIBLE) {
+      desc += editedView.getText() + "\n";
+    }
+
+    desc += dateView.getText().toString();
+    if (channelReadCount >= 1) {
+      desc +=
+          "\n"
+              + context
+                  .getResources()
+                  .getQuantityString(R.plurals.x_members_read, channelReadCount, channelReadCount);
+    } else {
+      String deliveryDesc = deliveryStatusView.getDescription();
+      if (!"".equals(deliveryDesc)) {
+        desc += "\n" + deliveryDesc;
+      }
     }
     return desc;
   }

--- a/src/main/res/layout/conversation_item_footer.xml
+++ b/src/main/res/layout/conversation_item_footer.xml
@@ -6,6 +6,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
+    android:importantForAccessibility="noHideDescendants"
     tools:parentTag="org.thoughtcrime.securesms.components.ConversationItemFooter">
 
     <ImageView
@@ -35,6 +36,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:linksClickable="false"
+        android:importantForAccessibility="no"
         style="@style/Signal.Text.Caption.MessageSent"
         android:textColor="?conversation_item_outgoing_text_secondary_color"
         android:text="@string/edited"
@@ -48,6 +50,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:linksClickable="false"
+        android:importantForAccessibility="no"
         style="@style/Signal.Text.Caption.MessageSent"
         android:textColor="?conversation_item_outgoing_text_secondary_color"
         tools:text="30 mins" />
@@ -57,9 +60,9 @@
         android:layout_width="12sp"
         android:layout_height="11sp"
         android:src="@drawable/ic_location_msg"
+        android:importantForAccessibility="no"
         android:visibility="gone"
         android:layout_gravity="center_vertical|end"
-        android:contentDescription="@string/location"
         tools:visibility="gone" />
 
     <ImageView
@@ -81,6 +84,7 @@
         android:linksClickable="false"
         style="@style/Signal.Text.Caption.MessageSent"
         android:textColor="?conversation_item_outgoing_text_secondary_color"
+        android:importantForAccessibility="no"
         android:visibility="gone"
         tools:visibility="visible"
         tools:text="150" />
@@ -91,7 +95,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical|end"
         android:layout_marginStart="6dp"
-        android:contentDescription="@null"
+        android:importantForAccessibility="no"
         android:visibility="gone"
         app:tint="?attr/conversation_item_outgoing_text_secondary_color" />
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1198,17 +1198,22 @@
     <string name="insert_newline">Insert Newline</string>
 
     <!-- accessibility, the general idea is to use the normal strings for accessibility hints wherever possible -->
-    <string name="a11y_delivery_status_error">Delivery status: Error</string>
-    <string name="a11y_delivery_status_sending">Delivery status: Sending</string>
-    <string name="a11y_delivery_status_draft">Delivery status: Draft</string>
-    <string name="a11y_delivery_status_delivered">Delivery status: Delivered</string>
-    <string name="a11y_delivery_status_read">Delivery status: Read</string>
+    <string name="a11y_delivery_status_error">Error</string>
+    <string name="a11y_delivery_status_sending">Sending</string>
+    <string name="a11y_delivery_status_draft">Draft</string>
+    <string name="a11y_delivery_status_delivered">Delivered</string>
+    <string name="a11y_delivery_status_read">Read</string>
     <string name="a11y_delivery_status_invalid">Invalid delivery status</string>
     <string name="a11y_message_context_menu_btn_label">Message actions</string>
     <string name="a11y_background_preview_label">Wallpaper preview</string>
     <string name="a11y_disappearing_messages_activated">Disappearing messages activated</string>
     <!-- The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility. -->
     <string name="open_link">Open %1$s</string>
+    <!-- The placeholder will be replaced by a number representing count of members who have seen a channel post eg. "150 members read". Used for accessibility -->
+    <plurals name="x_members_read">
+        <item quantity="one">%d member read</item>
+        <item quantity="other">%d members read</item>
+    </plurals>
 
     <!-- iOS specific strings, developers: please take care to remove strings that are no longer used! -->
     <string name="stop_sharing_location">Stop sharing location</string>


### PR DESCRIPTION
(Fixes #4592)

* Since there are no actionable controls inside ConversationItemFooter, make all of it not important for accessibility
* Expand its getDescription() method so it describes all the missing indicators that were inaccessible up to this point making it similar as other children inside ConversationItem.
* Shorten all the accessibility specific strings describing delivery status of a chat messages (This contributes to https://github.com/deltachat/deltachat-desktop/issues/6605 ).