### PR TITLE
a11y: Renovate chat/messages screen

### DIFF
--- a/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationItem.java
@@ -36,6 +36,7 @@ import android.widget.Toast;
 import androidx.annotation.DimenRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.view.ViewCompat;
 import chat.delta.rpc.RpcException;
@@ -57,6 +58,7 @@ import org.thoughtcrime.securesms.components.CallItemView;
 import org.thoughtcrime.securesms.components.ConversationItemFooter;
 import org.thoughtcrime.securesms.components.ConversationItemThumbnail;
 import org.thoughtcrime.securesms.components.DocumentView;
+import org.thoughtcrime.securesms.components.MessageState;
 import org.thoughtcrime.securesms.components.QuoteView;
 import org.thoughtcrime.securesms.components.VcardView;
 import org.thoughtcrime.securesms.components.WebxdcView;
@@ -125,6 +127,8 @@ public class ConversationItem extends BaseConversationItem {
 
   // IDs of accessibility actions registered via ViewCompat.addAccessibilityAction
   private final List<Integer> linkActionIds = new ArrayList<>();
+  // IDs of message-action accessibility actions
+  private final List<Integer> msgActionIds = new ArrayList<>();
 
   private int measureCalls;
 
@@ -216,12 +220,14 @@ public class ConversationItem extends BaseConversationItem {
     setGroupMessageStatus();
     setAuthor(messageRecord, showSender);
     setMessageSpacing(context);
+
+    final boolean isOutBroadcast = dcChat.isOutBroadcast();
+    final MessageState state = MessageState.of(messageRecord, isOutBroadcast);
+
     setReactions(messageRecord);
-    setFooter(messageRecord);
+    setFooter(messageRecord, isOutBroadcast, state);
     setQuote(messageRecord);
-    if (Util.isTouchExplorationEnabled(context)) {
-      setContentDescription();
-    }
+    setAccessibility(messageRecord, state);
   }
 
   @Override
@@ -353,39 +359,87 @@ public class ConversationItem extends BaseConversationItem {
     }
   }
 
-  private void setContentDescription() {
-    String desc = "";
-    if (groupSenderHolder.getVisibility() == View.VISIBLE) {
-      desc = groupSender.getText() + "\n";
+  private void setAccessibility(@NonNull DcMsg messageRecord, @NonNull MessageState state) {
+    ViewCompat.setScreenReaderFocusable(this, true);
+    ViewCompat.setStateDescription(this, state.getA11yLabel(context));
+
+    if (contactPhoto != null) {
+      contactPhoto.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
     }
 
-    if (audioViewStub.resolved() && audioViewStub.get().getVisibility() == View.VISIBLE) {
-      desc += audioViewStub.get().getDescription() + "\n";
-    } else if (documentViewStub.resolved()
-        && documentViewStub.get().getVisibility() == View.VISIBLE) {
-      desc += documentViewStub.get().getDescription() + "\n";
-    } else if (webxdcViewStub.resolved() && webxdcViewStub.get().getVisibility() == View.VISIBLE) {
-      desc += webxdcViewStub.get().getDescription() + "\n";
-    } else if (vcardViewStub.resolved() && vcardViewStub.get().getVisibility() == View.VISIBLE) {
-      desc += vcardViewStub.get().getDescription() + "\n";
-    } else if (callViewStub.resolved() && callViewStub.get().getVisibility() == View.VISIBLE) {
-      desc += callViewStub.get().getDescription() + "\n";
-    } else if (mediaThumbnailStub.resolved()
-        && mediaThumbnailStub.get().getVisibility() == View.VISIBLE) {
-      desc += mediaThumbnailStub.get().getDescription() + "\n";
-    } else if (stickerStub.resolved() && stickerStub.get().getVisibility() == View.VISIBLE) {
-      desc += stickerStub.get().getDescription() + "\n";
+    registerMessageActions(messageRecord);
+  }
+
+  private void registerMessageActions(@NonNull DcMsg messageRecord) {
+    for (int id : msgActionIds) {
+      ViewCompat.removeAccessibilityAction(this, id);
+    }
+    msgActionIds.clear();
+
+    if (!batchSelected.isEmpty()) return;
+
+    int downloadState = messageRecord.getDownloadState();
+    if (downloadState == DcMsg.DC_DOWNLOAD_AVAILABLE
+        || downloadState == DcMsg.DC_DOWNLOAD_FAILURE) {
+      addMsgAction(
+          R.string.download,
+          () -> {
+            if (eventListener != null) eventListener.onDownloadClicked(messageRecord);
+          });
+      return;
+    }
+    if (downloadState == DcMsg.DC_DOWNLOAD_IN_PROGRESS) return;
+
+    if (messageRecord.isFailed()) {
+      addMsgAction(R.string.a11y_action_show_error, this::performClick);
+      return;
     }
 
-    if (bodyText.getVisibility() == View.VISIBLE) {
-      desc += bodyText.getText() + "\n";
+    if (messageRecord.hasHtml()) {
+      addMsgAction(
+          R.string.show_full_message,
+          () -> {
+            if (eventListener != null) eventListener.onShowFullClicked(messageRecord);
+          });
     }
 
-    if (footer.getVisibility() == View.VISIBLE) {
-      desc += footer.getDescription();
+    int type = messageRecord.getType();
+    if (hasAudio(messageRecord)) {
+      addMsgAction(R.string.menu_play, () -> audioViewStub.get().togglePlay());
+    } else if (hasDocument(messageRecord)) {
+      addMsgAction(R.string.a11y_action_open_file, () -> documentViewStub.get().performClick());
+    } else if (hasWebxdc(messageRecord)) {
+      addMsgAction(R.string.start_app, () -> webxdcViewStub.get().performClick());
+    } else if (hasVcard(messageRecord)) {
+      addMsgAction(R.string.a11y_action_open_contact, () -> vcardViewStub.get().performClick());
+    } else if (type == DcMsg.DC_MSG_CALL) {
+      addMsgAction(R.string.call_back, () -> callViewStub.get().performClick());
+    } else if (hasThumbnail(messageRecord)) {
+      addMsgAction(
+          type == DcMsg.DC_MSG_VIDEO
+              ? R.string.a11y_action_open_video
+              : R.string.a11y_action_open_image,
+          () -> mediaThumbnailStub.get().performClick());
     }
 
-    this.setContentDescription(desc);
+    if (messageRecord.getOriginalMsgId() != 0 && dcChat.isSelfTalk()) {
+      addMsgAction(
+          R.string.show_in_chat,
+          () -> {
+            if (eventListener != null) eventListener.onJumpToOriginalClicked(messageRecord);
+          });
+    }
+  }
+
+  private void addMsgAction(@StringRes int label, @NonNull Runnable action) {
+    msgActionIds.add(
+        ViewCompat.addAccessibilityAction(
+            this,
+            context.getString(label),
+            (v, args) -> {
+              action.run();
+              return true;
+            }));
   }
 
   private boolean hasAudio(DcMsg messageRecord) {
@@ -525,6 +579,15 @@ public class ConversationItem extends BaseConversationItem {
     }
   }
 
+  private void describeAsSingleNode(@NonNull ViewGroup view, @Nullable String desc) {
+    view.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+    view.setContentDescription(desc);
+    for (int i = 0; i < view.getChildCount(); i++) {
+      view.getChildAt(i)
+          .setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+    }
+  }
+
   private void setMediaAttributes(
       @NonNull DcMsg messageRecord,
       boolean showSender,
@@ -544,9 +607,7 @@ public class ConversationItem extends BaseConversationItem {
       audioViewStub.get().setAudio(new AudioSlide(context, messageRecord));
       audioViewStub.get().setOnClickListener(passthroughClickListener);
       audioViewStub.get().setOnLongClickListener(passthroughClickListener);
-      audioViewStub
-          .get()
-          .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      describeAsSingleNode(audioViewStub.get(), audioViewStub.get().getDescription());
 
       ViewUtil.updateLayoutParams(
           bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -568,9 +629,7 @@ public class ConversationItem extends BaseConversationItem {
       documentViewStub.get().setDocument(new DocumentSlide(context, messageRecord));
       documentViewStub.get().setDocumentClickListener(new ThumbnailClickListener());
       documentViewStub.get().setOnLongClickListener(passthroughClickListener);
-      documentViewStub
-          .get()
-          .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      describeAsSingleNode(documentViewStub.get(), documentViewStub.get().getDescription());
 
       ViewUtil.updateLayoutParams(
           bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -591,9 +650,7 @@ public class ConversationItem extends BaseConversationItem {
       webxdcViewStub.get().setWebxdc(messageRecord, context.getString(R.string.webxdc_app));
       webxdcViewStub.get().setWebxdcClickListener(new ThumbnailClickListener());
       webxdcViewStub.get().setOnLongClickListener(passthroughClickListener);
-      webxdcViewStub
-          .get()
-          .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      describeAsSingleNode(webxdcViewStub.get(), webxdcViewStub.get().getDescription());
 
       ViewUtil.updateLayoutParams(
           bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -614,10 +671,7 @@ public class ConversationItem extends BaseConversationItem {
       vcardViewStub.get().setVcard(glideRequests, new VcardSlide(context, messageRecord), rpc);
       vcardViewStub.get().setVcardClickListener(new ThumbnailClickListener());
       vcardViewStub.get().setOnLongClickListener(passthroughClickListener);
-
-      vcardViewStub
-          .get()
-          .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      describeAsSingleNode(vcardViewStub.get(), vcardViewStub.get().getDescription());
 
       ViewUtil.updateLayoutParams(
           bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -646,10 +700,7 @@ public class ConversationItem extends BaseConversationItem {
       }
       callViewStub.get().setCallClickListener(new CallClickListener());
       callViewStub.get().setOnLongClickListener(passthroughClickListener);
-
-      callViewStub
-          .get()
-          .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      describeAsSingleNode(callViewStub.get(), callViewStub.get().getDescription());
 
       ViewUtil.updateLayoutParams(
           groupSenderHolder,
@@ -687,9 +738,6 @@ public class ConversationItem extends BaseConversationItem {
       mediaThumbnailStub.get().setOnLongClickListener(passthroughClickListener);
       mediaThumbnailStub.get().setOnClickListener(passthroughClickListener);
       mediaThumbnailStub.get().showShade(TextUtils.isEmpty(messageRecord.getText()));
-      mediaThumbnailStub
-          .get()
-          .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
 
       setThumbnailOutlineCorners(messageRecord, showSender);
 
@@ -717,9 +765,6 @@ public class ConversationItem extends BaseConversationItem {
       stickerStub.get().setThumbnailClickListener(new StickerClickListener());
       stickerStub.get().setOnLongClickListener(passthroughClickListener);
       stickerStub.get().setOnClickListener(passthroughClickListener);
-      stickerStub
-          .get()
-          .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
 
       ViewUtil.updateLayoutParams(
           bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -800,6 +845,7 @@ public class ConversationItem extends BaseConversationItem {
       } else if (stickerStub.resolved()) {
         ViewUtil.setTopMargin(stickerStub.get(), 0);
       }
+      quoteView.setContentDescription(null);
       return;
     }
     DcMsg msg = current.getQuotedMsg();
@@ -826,6 +872,15 @@ public class ConversationItem extends BaseConversationItem {
         slideDeck,
         current.getType() == DcMsg.DC_MSG_STICKER,
         false);
+
+    if (msg != null) {
+      DcContact quoteContact = dcContext.getContact(msg.getFromId());
+      quoteView.setContentDescription(
+          context.getString(R.string.a11y_msg_reply_to, msg.getSenderName(quoteContact), quoteTxt));
+    } else {
+      quoteView.setContentDescription(
+          context.getString(R.string.a11y_msg_reply_to_no_author, quoteTxt));
+    }
 
     quoteView.setVisibility(View.VISIBLE);
     quoteView.getLayoutParams().width = ViewGroup.LayoutParams.WRAP_CONTENT;
@@ -857,7 +912,8 @@ public class ConversationItem extends BaseConversationItem {
     }
   }
 
-  private void setFooter(@NonNull DcMsg current) {
+  private void setFooter(
+      @NonNull DcMsg current, boolean isOutBroadcast, @NonNull MessageState state) {
     ViewUtil.updateLayoutParams(footer, LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 
     footer.setVisibility(GONE);
@@ -865,7 +921,7 @@ public class ConversationItem extends BaseConversationItem {
 
     ConversationItemFooter activeFooter = getActiveFooter(current);
     activeFooter.setVisibility(VISIBLE);
-    activeFooter.setMessageRecord(current);
+    activeFooter.setMessageRecord(current, isOutBroadcast, state);
   }
 
   private void setReactions(@NonNull DcMsg current) {
@@ -1001,12 +1057,13 @@ public class ConversationItem extends BaseConversationItem {
 
   @Override
   public void onAccessibilityClick() {
-    if (mediaThumbnailStub.resolved()) mediaThumbnailStub.get().performClick();
-    else if (audioViewStub.resolved()) audioViewStub.get().togglePlay();
-    else if (documentViewStub.resolved()) documentViewStub.get().performClick();
-    else if (webxdcViewStub.resolved()) webxdcViewStub.get().performClick();
-    else if (vcardViewStub.resolved()) vcardViewStub.get().performClick();
-    else if (callViewStub.resolved()) callViewStub.get().performClick();
+    if (hasAudio(messageRecord)) audioViewStub.get().togglePlay();
+    else if (hasDocument(messageRecord)) documentViewStub.get().performClick();
+    else if (hasWebxdc(messageRecord)) webxdcViewStub.get().performClick();
+    else if (hasVcard(messageRecord)) vcardViewStub.get().performClick();
+    else if (messageRecord.getType() == DcMsg.DC_MSG_CALL) callViewStub.get().performClick();
+    else if (hasThumbnail(messageRecord)) mediaThumbnailStub.get().performClick();
+    else if (hasSticker(messageRecord)) stickerStub.get().performClick();
   }
 
   /// Event handlers

--- a/src/main/java/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -8,22 +8,29 @@ import android.util.AttributeSet;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatImageView;
+import androidx.core.view.ViewCompat;
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcMsg;
 import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import org.json.JSONObject;
 import org.thoughtcrime.securesms.components.DeliveryStatusView;
+import org.thoughtcrime.securesms.components.MessageState;
 import org.thoughtcrime.securesms.components.audioplay.AudioPlaybackViewModel;
 import org.thoughtcrime.securesms.components.audioplay.AudioView;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.AccessibilityUtil;
+import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.JsonUtils;
 
 public class ConversationUpdateItem extends BaseConversationItem {
   private DeliveryStatusView deliveryStatusView;
   private AppCompatImageView appIcon;
   private int textColor;
+  private final List<Integer> msgActionIds = new ArrayList<>();
 
   public ConversationUpdateItem(Context context) {
     this(context, null);
@@ -63,6 +70,7 @@ public class ConversationUpdateItem extends BaseConversationItem {
       AudioView.OnActionListener audioPlayPauseListener) {
     bindPartial(messageRecord, dcChat, batchSelected, pulseUpdate, conversationRecipient);
     setGenericInfoRecord(messageRecord);
+    setAccessibility(messageRecord);
   }
 
   private void initializeAttributes() {
@@ -91,27 +99,25 @@ public class ConversationUpdateItem extends BaseConversationItem {
 
     if (infoType == DcMsg.DC_INFO_WEBXDC_INFO_MESSAGE) {
       DcMsg parentMsg = messageRecord.getParent();
-
-      // It is possible that we only received an update without the webxdc itself.
-      // In this case parentMsg is null and we display update message without the icon.
+      Drawable drawable = null;
       if (parentMsg != null) {
         JSONObject info = parentMsg.getWebxdcInfo();
         byte[] blob = parentMsg.getWebxdcBlob(JsonUtils.optString(info, "icon"));
         if (blob != null) {
-          ByteArrayInputStream is = new ByteArrayInputStream(blob);
-          Drawable drawable = Drawable.createFromStream(is, "icon");
-          appIcon.setImageDrawable(drawable);
-          appIcon.setVisibility(VISIBLE);
-        } else {
-          appIcon.setVisibility(GONE);
+          drawable = Drawable.createFromStream(new ByteArrayInputStream(blob), "icon");
         }
       }
+      appIcon.setImageDrawable(drawable);
+      appIcon.setVisibility(drawable != null ? VISIBLE : GONE);
     } else {
+      appIcon.setImageDrawable(null);
       appIcon.setVisibility(GONE);
     }
 
     bodyText.setText(messageRecord.getDisplayBody());
     bodyText.setVisibility(VISIBLE);
+
+    deliveryStatusView.setState(MessageState.ofInfo(messageRecord));
 
     if (messageRecord.isFailed()) deliveryStatusView.setFailed();
     else if (!messageRecord.isOutgoing()) deliveryStatusView.setNone();
@@ -122,4 +128,41 @@ public class ConversationUpdateItem extends BaseConversationItem {
 
   @Override
   public void unbind() {}
+
+  private void setAccessibility(@NonNull DcMsg messageRecord) {
+    ViewCompat.setScreenReaderFocusable(this, true);
+    ViewCompat.setStateDescription(this, MessageState.ofInfo(messageRecord).getA11yLabel(context));
+
+    StringBuilder desc = new StringBuilder();
+    AccessibilityUtil.append(desc, messageRecord.getDisplayBody());
+    AccessibilityUtil.append(
+        desc, DateUtils.getExtendedRelativeTimeSpanString(context, messageRecord.getTimestamp()));
+    setContentDescription(AccessibilityUtil.toDescription(desc));
+
+    for (int id : msgActionIds) {
+      ViewCompat.removeAccessibilityAction(this, id);
+    }
+    msgActionIds.clear();
+    if (!batchSelected.isEmpty()) return;
+
+    int infoType = messageRecord.getInfoType();
+    Integer label = null;
+    if (messageRecord.isFailed()) {
+      label = R.string.a11y_action_show_error;
+    } else if (infoType == DcMsg.DC_INFO_CHAT_E2EE
+        || infoType == DcMsg.DC_INFO_PROTECTION_ENABLED
+        || infoType == DcMsg.DC_INFO_INVALID_UNENCRYPTED_MAIL) {
+      label = R.string.learn_more;
+    }
+    if (label != null) {
+      msgActionIds.add(
+          ViewCompat.addAccessibilityAction(
+              this,
+              context.getString(label),
+              (v, args) -> {
+                performClick();
+                return true;
+              }));
+    }
+  }
 }

--- a/src/main/java/org/thoughtcrime/securesms/components/BorderlessImageView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/BorderlessImageView.java
@@ -34,6 +34,8 @@ public class BorderlessImageView extends FrameLayout {
     this.image = findViewById(R.id.sticker_thumbnail);
     this.missingShade = findViewById(R.id.sticker_missing_shade);
     this.footer = findViewById(R.id.sticker_footer);
+
+    missingShade.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
   }
 
   @Override
@@ -64,10 +66,7 @@ public class BorderlessImageView extends FrameLayout {
     }
 
     missingShade.setVisibility(showControls ? View.VISIBLE : View.GONE);
-  }
-
-  public String getDescription() {
-    return getContext().getString(R.string.sticker) + "\n" + footer.getDescription();
+    image.setContentDescription(getContext().getString(R.string.sticker));
   }
 
   public ConversationItemFooter getFooter() {

--- a/src/main/java/org/thoughtcrime/securesms/components/CallItemView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/CallItemView.java
@@ -98,7 +98,7 @@ public class CallItemView extends FrameLayout {
 
   public String getDescription() {
     return title.getText()
-        + (duration.getVisibility() == VISIBLE ? ("\n" + duration.getText()) : "");
+        + (duration.getVisibility() == VISIBLE ? (", " + duration.getText()) : "");
   }
 
   public interface CallClickListener {

--- a/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.components;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -12,11 +13,15 @@ import androidx.annotation.Nullable;
 import chat.delta.rpc.Rpc;
 import chat.delta.rpc.RpcException;
 import com.b44t.messenger.DcMsg;
+import java.util.Locale;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.util.AccessibilityUtil;
 import org.thoughtcrime.securesms.util.DateUtils;
 
 public class ConversationItemFooter extends LinearLayout {
+
+  private static final String TAG = "ConversationItemFooter";
 
   private TextView dateView;
   private TextView editedView;
@@ -59,6 +64,11 @@ public class ConversationItemFooter extends LinearLayout {
     locationIndicatorView = findViewById(R.id.footer_location_indicator);
     deliveryStatusView = new DeliveryStatusView(findViewById(R.id.delivery_indicator));
 
+    setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+    for (int i = 0; i < getChildCount(); i++) {
+      getChildAt(i).setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
+    }
+
     if (attrs != null) {
       try (TypedArray typedArray =
           getContext()
@@ -72,43 +82,61 @@ public class ConversationItemFooter extends LinearLayout {
     }
   }
 
-  public void setMessageRecord(@NonNull DcMsg messageRecord) {
+  public void setMessageRecord(
+      @NonNull DcMsg messageRecord, boolean isOutChannel, @NonNull MessageState state) {
     presentDate(messageRecord);
+
     boolean bookmark = messageRecord.getOriginalMsgId() != 0 || messageRecord.getSavedMsgId() != 0;
     bookmarkIndicatorView.setVisibility(bookmark ? View.VISIBLE : View.GONE);
-    editedView.setVisibility(messageRecord.isEdited() ? View.VISIBLE : View.GONE);
+
+    boolean edited = messageRecord.isEdited();
+    editedView.setVisibility(edited ? View.VISIBLE : View.GONE);
 
     int downloadState = messageRecord.getDownloadState();
-    if (messageRecord.isSecure()
-        || downloadState == DcMsg.DC_DOWNLOAD_AVAILABLE
-        || downloadState == DcMsg.DC_DOWNLOAD_FAILURE
-        || downloadState == DcMsg.DC_DOWNLOAD_IN_PROGRESS) {
-      emailIndicatorView.setVisibility(View.GONE);
-    } else {
-      emailIndicatorView.setVisibility(View.VISIBLE);
-    }
+    boolean notEncrypted =
+        !(messageRecord.isSecure()
+            || downloadState == DcMsg.DC_DOWNLOAD_AVAILABLE
+            || downloadState == DcMsg.DC_DOWNLOAD_FAILURE
+            || downloadState == DcMsg.DC_DOWNLOAD_IN_PROGRESS);
+    emailIndicatorView.setVisibility(notEncrypted ? View.VISIBLE : View.GONE);
 
-    locationIndicatorView.setVisibility(messageRecord.hasLocation() ? View.VISIBLE : View.GONE);
+    boolean hasLocation = messageRecord.hasLocation();
+    locationIndicatorView.setVisibility(hasLocation ? View.VISIBLE : View.GONE);
 
-    boolean isOutChannel =
-        DcHelper.getContext(context).getChat(messageRecord.getChatId()).isOutBroadcast();
-
+    int readCount = -1;
     if (isOutChannel && messageRecord.isOutgoing()) {
       try {
-        int accId = rpc.getSelectedAccountId();
-        int count = rpc.getMessageReadReceiptCount(accId, messageRecord.getId());
-        viewsLabel.setText(String.format("%d", count));
+        readCount =
+            rpc.getMessageReadReceiptCount(rpc.getSelectedAccountId(), messageRecord.getId());
+        viewsLabel.setText(String.format(Locale.getDefault(), "%d", readCount));
         viewsLabel.setVisibility(View.VISIBLE);
         viewsIcon.setVisibility(View.VISIBLE);
       } catch (RpcException e) {
-        e.printStackTrace();
+        Log.w(TAG, "failed to get read receipt count", e);
+        viewsLabel.setText("");
+        viewsLabel.setVisibility(View.GONE);
+        viewsIcon.setVisibility(View.GONE);
       }
     } else {
+      viewsLabel.setText("");
       viewsLabel.setVisibility(View.GONE);
       viewsIcon.setVisibility(View.GONE);
     }
 
-    presentDeliveryStatus(messageRecord, isOutChannel);
+    deliveryStatusView.setState(state);
+
+    StringBuilder desc = new StringBuilder();
+    if (edited) AccessibilityUtil.append(desc, getContext().getString(R.string.edited));
+    if (bookmark) AccessibilityUtil.append(desc, getContext().getString(R.string.saved));
+    if (notEncrypted)
+      AccessibilityUtil.append(desc, getContext().getString(R.string.a11y_msg_not_encrypted));
+    if (hasLocation) AccessibilityUtil.append(desc, getContext().getString(R.string.location));
+    if (readCount >= 0) {
+      AccessibilityUtil.append(
+          desc, getResources().getQuantityString(R.plurals.a11y_msg_read_by, readCount, readCount));
+    }
+    AccessibilityUtil.append(desc, dateView.getText());
+    setContentDescription(AccessibilityUtil.toDescription(desc));
   }
 
   private void setTextColor(int color) {
@@ -141,14 +169,5 @@ public class ConversationItemFooter extends LinearLayout {
     else if (messageRecord.isDelivered()) deliveryStatusView.setSent();
     else if (messageRecord.isPreparing()) deliveryStatusView.setPreparing();
     else deliveryStatusView.setPending();
-  }
-
-  public String getDescription() {
-    String desc = dateView.getText().toString();
-    String deliveryDesc = deliveryStatusView.getDescription();
-    if (!"".equals(deliveryDesc)) {
-      desc += "\n" + deliveryDesc;
-    }
-    return desc;
   }
 }

--- a/src/main/java/org/thoughtcrime/securesms/components/ConversationItemThumbnail.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/ConversationItemThumbnail.java
@@ -7,7 +7,6 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
 import android.util.AttributeSet;
-import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import androidx.annotation.DimenRes;
@@ -79,15 +78,9 @@ public class ConversationItemThumbnail extends FrameLayout {
         ThemeUtil.isDarkTheme(getContext()) ? DARK_THEME_OUTLINE_PAINT : LIGHT_THEME_OUTLINE_PAINT;
     this.cornerMask = new CornerMask(this);
 
-    setTouchDelegate(thumbnail.getTouchDelegate());
-  }
+    shade.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
 
-  public String getDescription() {
-    String desc = thumbnail.getDescription();
-    if (footer.getVisibility() == View.VISIBLE) {
-      desc += "\n" + footer.getDescription();
-    }
-    return desc;
+    setTouchDelegate(thumbnail.getTouchDelegate());
   }
 
   @Override
@@ -199,6 +192,7 @@ public class ConversationItemThumbnail extends FrameLayout {
     this.naturalWidth = naturalWidth;
     this.naturalHeight = naturalHeight;
     refreshSlideAttachmentState(thumbnail.setImageResource(glideRequests, slide), slide);
+    thumbnail.setContentDescription(thumbnail.getDescription());
   }
 
   public void clear(GlideRequests glideRequests) {

--- a/src/main/java/org/thoughtcrime/securesms/components/DeliveryStatusView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/DeliveryStatusView.java
@@ -6,6 +6,7 @@ import android.view.animation.Animation;
 import android.view.animation.LinearInterpolator;
 import android.view.animation.RotateAnimation;
 import android.widget.ImageView;
+import androidx.annotation.NonNull;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.AccessibilityUtil;
 
@@ -20,6 +21,35 @@ public class DeliveryStatusView {
   public DeliveryStatusView(ImageView deliveryIndicator) {
     this.deliveryIndicator = deliveryIndicator;
     this.context = deliveryIndicator.getContext();
+    deliveryIndicator.setContentDescription(null);
+    deliveryIndicator.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+  }
+
+  public void setState(@NonNull MessageState state) {
+    switch (state) {
+      case DOWNLOADING:
+        setDownloading();
+        break;
+      case PREPARING:
+        setPreparing();
+        break;
+      case PENDING:
+        setPending();
+        break;
+      case SENT:
+        setSent();
+        break;
+      case READ:
+        setRead();
+        break;
+      case FAILED:
+        setFailed();
+        break;
+      case NONE:
+      default:
+        setNone();
+        break;
+    }
   }
 
   private void animatePrepare() {
@@ -69,46 +99,36 @@ public class DeliveryStatusView {
   public void setDownloading() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sending);
-    deliveryIndicator.setContentDescription(context.getString(R.string.one_moment));
     animatePrepare();
   }
 
   public void setPreparing() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sending);
-    deliveryIndicator.setContentDescription(
-        context.getString(R.string.a11y_delivery_status_sending));
     animatePrepare();
   }
 
   public void setPending() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sending);
-    deliveryIndicator.setContentDescription(
-        context.getString(R.string.a11y_delivery_status_sending));
     animateSending();
   }
 
   public void setSent() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_sent);
-    deliveryIndicator.setContentDescription(
-        context.getString(R.string.a11y_delivery_status_delivered));
     clearAnimation();
   }
 
   public void setRead() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_read);
-    deliveryIndicator.setContentDescription(context.getString(R.string.a11y_delivery_status_read));
     clearAnimation();
   }
 
   public void setFailed() {
     deliveryIndicator.setVisibility(View.VISIBLE);
     deliveryIndicator.setImageResource(R.drawable.ic_delivery_status_failed);
-    deliveryIndicator.setContentDescription(
-        context.getString(R.string.a11y_delivery_status_invalid));
     clearAnimation();
   }
 
@@ -122,12 +142,5 @@ public class DeliveryStatusView {
 
   public void resetTint() {
     deliveryIndicator.setColorFilter(null);
-  }
-
-  public String getDescription() {
-    if (deliveryIndicator.getVisibility() == View.VISIBLE) {
-      return deliveryIndicator.getContentDescription().toString();
-    }
-    return "";
   }
 }

--- a/src/main/java/org/thoughtcrime/securesms/components/DocumentView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/DocumentView.java
@@ -56,8 +56,8 @@ public class DocumentView extends FrameLayout {
 
   public String getDescription() {
     String desc = getContext().getString(R.string.file);
-    desc += "\n" + fileName.getText();
-    desc += "\n" + fileSize.getText();
+    desc += ", " + fileName.getText();
+    desc += ", " + fileSize.getText();
     return desc;
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/components/MessageState.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/MessageState.java
@@ -1,0 +1,55 @@
+package org.thoughtcrime.securesms.components;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.b44t.messenger.DcMsg;
+import org.thoughtcrime.securesms.R;
+
+public enum MessageState {
+  NONE,
+  DOWNLOADING,
+  PREPARING,
+  PENDING,
+  SENT,
+  READ,
+  FAILED;
+
+  public static @NonNull MessageState of(@NonNull DcMsg msg, boolean isOutBroadcast) {
+    if (msg.getDownloadState() == DcMsg.DC_DOWNLOAD_IN_PROGRESS) return DOWNLOADING;
+    if (msg.isPending()) return PENDING;
+    if (msg.isFailed()) return FAILED;
+    if (!msg.isOutgoing() || isOutBroadcast) return NONE;
+    if (msg.isRemoteRead()) return READ;
+    if (msg.isDelivered()) return SENT;
+    if (msg.isPreparing()) return PREPARING;
+    return PENDING;
+  }
+
+  public static @NonNull MessageState ofInfo(@NonNull DcMsg msg) {
+    if (msg.isFailed()) return FAILED;
+    if (!msg.isOutgoing()) return NONE;
+    if (msg.isPreparing()) return PREPARING;
+    if (msg.isPending()) return PENDING;
+    return NONE;
+  }
+
+  public @Nullable String getA11yLabel(@NonNull Context context) {
+    switch (this) {
+      case DOWNLOADING:
+        return context.getString(R.string.downloading);
+      case PREPARING:
+      case PENDING:
+        return context.getString(R.string.a11y_delivery_status_sending);
+      case SENT:
+        return context.getString(R.string.a11y_delivery_status_delivered);
+      case READ:
+        return context.getString(R.string.a11y_delivery_status_read);
+      case FAILED:
+        return context.getString(R.string.a11y_delivery_status_error);
+      case NONE:
+      default:
+        return null;
+    }
+  }
+}

--- a/src/main/java/org/thoughtcrime/securesms/components/WebxdcView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/WebxdcView.java
@@ -91,11 +91,11 @@ public class WebxdcView extends FrameLayout {
 
   public String getDescription() {
     String desc = getContext().getString(R.string.webxdc_app);
-    desc += "\n" + appName.getText();
+    desc += ", " + appName.getText();
     if (appSubtitle.getText() != null
         && !appSubtitle.getText().toString().isEmpty()
         && !appSubtitle.getText().toString().equals(getContext().getString(R.string.webxdc_app))) {
-      desc += "\n" + appSubtitle.getText();
+      desc += ", " + appSubtitle.getText();
     }
     return desc;
   }

--- a/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
+++ b/src/main/java/org/thoughtcrime/securesms/components/audioplay/AudioView.java
@@ -265,9 +265,9 @@ public class AudioView extends FrameLayout {
     } else {
       desc = getContext().getString(R.string.voice_message);
     }
-    desc += "\n" + this.timestamp.getText();
+    desc += ", " + this.timestamp.getText();
     if (title.getVisibility() == View.VISIBLE) {
-      desc += "\n" + this.title.getText();
+      desc += ", " + this.title.getText();
     }
     return desc;
   }

--- a/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsConversationView.java
+++ b/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsConversationView.java
@@ -16,6 +16,7 @@ import chat.delta.rpc.types.Reaction;
 import java.util.ArrayList;
 import java.util.List;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.AccessibilityUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class ReactionsConversationView extends LinearLayout {
@@ -49,6 +50,9 @@ public class ReactionsConversationView extends LinearLayout {
   public void clear() {
     this.reactions.clear();
     removeAllViews();
+    setOnClickListener(null);
+    setContentDescription(null);
+    setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
   }
 
   public void setReactions(List<Reaction> reactions) {
@@ -59,8 +63,11 @@ public class ReactionsConversationView extends LinearLayout {
     clear();
     this.reactions.addAll(reactions);
 
-    for (Reaction reaction : buildShortenedReactionsList(this.reactions)) {
+    List<Reaction> shortened = buildShortenedReactionsList(this.reactions);
+
+    for (Reaction reaction : shortened) {
       View pill = buildPill(getContext(), this, reaction);
+      pill.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
       addView(pill);
     }
 
@@ -68,6 +75,26 @@ public class ReactionsConversationView extends LinearLayout {
       ViewUtil.setLeftMargin(this, OUTER_MARGIN);
     } else {
       ViewUtil.setRightMargin(this, OUTER_MARGIN);
+    }
+
+    StringBuilder parts = new StringBuilder();
+    for (Reaction reaction : shortened) {
+      if (reaction.emoji == null) {
+        AccessibilityUtil.append(
+            parts, getContext().getString(R.string.a11y_reactions_more, reaction.count));
+      } else if (reaction.count > 1) {
+        AccessibilityUtil.append(parts, reaction.emoji + " " + reaction.count);
+      } else {
+        AccessibilityUtil.append(parts, reaction.emoji);
+      }
+    }
+
+    if (parts.length() > 0) {
+      setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+      setContentDescription(getContext().getString(R.string.a11y_reactions, parts.toString()));
+    } else {
+      setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
+      setContentDescription(null);
     }
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/util/AccessibilityUtil.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/AccessibilityUtil.java
@@ -3,6 +3,8 @@ package org.thoughtcrime.securesms.util;
 import android.content.Context;
 import android.provider.Settings;
 import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public final class AccessibilityUtil {
 
@@ -16,5 +18,15 @@ public final class AccessibilityUtil {
     return Settings.Global.getFloat(
             context.getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1)
         == 0f;
+  }
+
+  public static void append(@NonNull StringBuilder sb, @Nullable CharSequence text) {
+    if (text == null || text.length() == 0) return;
+    if (sb.length() > 0) sb.append(", ");
+    sb.append(text);
+  }
+
+  public static @Nullable String toDescription(@NonNull StringBuilder sb) {
+    return sb.length() == 0 ? null : sb.toString();
   }
 }

--- a/src/main/res/layout/conversation_item_footer.xml
+++ b/src/main/res/layout/conversation_item_footer.xml
@@ -14,7 +14,6 @@
         android:layout_height="11sp"
         android:src="@drawable/baseline_bookmark_24"
         android:layout_gravity="center_vertical|end"
-        android:importantForAccessibility="no"
         android:visibility="gone"
         tools:visibility="visible" />
 
@@ -26,7 +25,6 @@
         android:visibility="gone"
         android:layout_marginEnd="5dp"
         android:layout_gravity="center_vertical|end"
-        android:importantForAccessibility="no"
         tools:visibility="visible" />
 
     <TextView
@@ -59,7 +57,6 @@
         android:src="@drawable/ic_location_msg"
         android:visibility="gone"
         android:layout_gravity="center_vertical|end"
-        android:contentDescription="@string/location"
         tools:visibility="gone" />
 
     <ImageView
@@ -69,7 +66,6 @@
         android:layout_marginStart="6dp"
         android:layout_gravity="center_vertical|end"
         android:src="@drawable/ic_baseline_eye"
-        android:importantForAccessibility="no"
         android:visibility="gone"
         tools:visibility="visible" />
 
@@ -91,7 +87,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical|end"
         android:layout_marginStart="6dp"
-        android:contentDescription="@null"
         android:visibility="gone"
         app:tint="?attr/conversation_item_outgoing_text_secondary_color" />
 

--- a/src/main/res/layout/conversation_item_received.xml
+++ b/src/main/res/layout/conversation_item_received.xml
@@ -192,7 +192,6 @@
                     android:paddingTop="@dimen/message_bubble_top_padding"
                     android:textColor="?conversation_item_incoming_text_primary_color"
                     android:textColorLink="?attr/colorAccent"
-                    android:importantForAccessibility="no"
                     tools:text="Mango pickle lorem ipsum" />
 
                 <Button

--- a/src/main/res/layout/conversation_item_sent.xml
+++ b/src/main/res/layout/conversation_item_sent.xml
@@ -174,7 +174,6 @@
                 android:paddingTop="@dimen/message_bubble_top_padding"
                 android:textColor="?conversation_item_outgoing_text_primary_color"
                 android:textColorLink="?attr/colorAccent"
-                android:importantForAccessibility="no"
                 tools:text="Mango pickle lorem ipsum" />
 
             <Button

--- a/src/main/res/layout/conversation_item_update.xml
+++ b/src/main/res/layout/conversation_item_update.xml
@@ -33,6 +33,7 @@
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/app_icon"
+                android:importantForAccessibility="no"
                 android:layout_width="18sp"
                 android:layout_height="18sp"
                 android:layout_marginEnd="2dp"
@@ -57,6 +58,7 @@
 
         <ImageView
             android:id="@+id/delivery_indicator"
+            android:importantForAccessibility="no"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|end"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1198,15 +1198,39 @@
     <string name="insert_newline">Insert Newline</string>
 
     <!-- accessibility, the general idea is to use the normal strings for accessibility hints wherever possible -->
-    <string name="a11y_delivery_status_error">Delivery status: Error</string>
-    <string name="a11y_delivery_status_sending">Delivery status: Sending</string>
+    <!-- deprecated -->
+    <string name="a11y_delivery_status_error">Error</string>
+    <string name="a11y_delivery_status_sending">Sending</string>
+    <!-- deprecated -->
     <string name="a11y_delivery_status_draft">Delivery status: Draft</string>
-    <string name="a11y_delivery_status_delivered">Delivery status: Delivered</string>
-    <string name="a11y_delivery_status_read">Delivery status: Read</string>
+    <string name="a11y_delivery_status_delivered">Delivered</string>
+    <string name="a11y_delivery_status_read">Read</string>
+    <!-- deprecated -->
     <string name="a11y_delivery_status_invalid">Invalid delivery status</string>
+    <!-- deprecated -->
     <string name="a11y_message_context_menu_btn_label">Message actions</string>
+    <!-- deprecated -->
     <string name="a11y_background_preview_label">Wallpaper preview</string>
+    <!-- deprecated -->
     <string name="a11y_disappearing_messages_activated">Disappearing messages activated</string>
+    <string name="a11y_msg_not_encrypted">Not end-to-end encrypted</string>
+
+    <plurals name="a11y_msg_read_by">
+        <item quantity="one">Read by %d</item>
+        <item quantity="other">Read by %d</item>
+    </plurals>
+    <string name="a11y_msg_reply_to">Replying to %1$s: %2$s</string>
+    <string name="a11y_msg_reply_to_no_author">Replying to: %1$s</string>
+
+    <string name="a11y_action_open_image">Open image</string>
+    <string name="a11y_action_open_video">Open video</string>
+    <string name="a11y_action_open_file">Open file</string>
+    <string name="a11y_action_open_contact">Open contact</string>
+    <string name="a11y_action_show_error">Show error</string>
+
+    <string name="a11y_reactions">Reactions: %1$s</string>
+    <string name="a11y_reactions_more">%1$d more</string>
+
     <!-- The placeholder will be replaced by a link, eg. "Open https://delta.chat". Used e.g. in for accessibility. -->
     <string name="open_link">Open %1$s</string>
 


### PR DESCRIPTION
Main changes:
- Make each row a screen reader node, mark item roots screenReaderFocusable, suppress decorative descendants, and label media wrappers
- Build descriptions from DcMsg/DcChat instead of aggregation of child view text
- Announce the Edited, Saved, Location and not-encrypted indicators, channel read count, quoted messages, reactions, and info message timestamps
- Add labeled actions: Play, Open image, Open file, Start app, Download, Show full message, Show error, Learn more
- Fix minor recycling and formatting issues

Fixes #4592

Supersede #4593