### PR TITLE
Block WebRTC per renderer instead of per webxdc app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add speed button for voice message playback
 * Fix: support scanning a channel-invite while creating a new profile
+* Fix: random long delay when reopening a WebXDC app
 
 ## v2.59.1
 2026-08

--- a/src/main/java/org/thoughtcrime/securesms/WebRtcHolder.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebRtcHolder.java
@@ -1,0 +1,206 @@
+package org.thoughtcrime.securesms;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+import android.webkit.JavascriptInterface;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import androidx.annotation.RequiresApi;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.thoughtcrime.securesms.util.Util;
+
+/**
+ * Holds the whole per-renderer RTCPeerConnection budget in a hidden WebView, so that no webxdc can
+ * use WebRTC.
+ *
+ * <p>WebView gives an app process a single renderer process, and Chromium's limit of 500
+ * RTCPeerConnections is enforced per renderer. Allocating all of them here blocks WebRTC in every
+ * WebView of this app.
+ */
+public final class WebRtcHolder {
+
+  private static final String TAG = "WebRtcHolder";
+
+  // RTCPeerConnection is only available in secure contexts
+  private static final String HOLDER_URL = "https://webrtc-holder.localhost/holder.html";
+
+  private static final long WAITER_TIMEOUT_MS = 15000;
+
+  public enum State {
+    IDLE,
+    FILLING,
+    CONFIRMED,
+    EMPTY,
+    PARTIAL,
+  }
+
+  // This is the mechanism itself. Also, there is no actual leak:
+  // the non-static classes only capture the singleton.
+  @SuppressLint("StaticFieldLeak")
+  private static WebRtcHolder instance;
+
+  private final Context appContext;
+  private final List<Runnable> waiters = new ArrayList<>();
+  private volatile WebView webView;
+  private volatile State state = State.IDLE;
+
+  private WebRtcHolder(Context context) {
+    this.appContext = context.getApplicationContext();
+  }
+
+  public static synchronized WebRtcHolder getInstance(Context context) {
+    if (instance == null) {
+      instance = new WebRtcHolder(context);
+    }
+    return instance;
+  }
+
+  public void start() {
+    Util.assertMainThread();
+    if (state != State.IDLE) {
+      return;
+    }
+    Log.i(TAG, "Starting fill");
+    state = State.FILLING;
+    createWebView();
+    webView.loadUrl(HOLDER_URL);
+  }
+
+  public State getState() {
+    if (!Util.isMainThread()) {
+      Log.w(TAG, "getState() off main thread, result may be stale");
+    }
+    return state;
+  }
+
+  private boolean isSettled() {
+    return state == State.CONFIRMED || state == State.EMPTY || state == State.PARTIAL;
+  }
+
+  public void awaitSettled(final Runnable callback) {
+    if (!Util.isMainThread()) {
+      Util.runOnMain(this::start);
+      return;
+    }
+    if (isSettled()) {
+      callback.run();
+      return;
+    }
+    final boolean[] fired = new boolean[1];
+    final Runnable once =
+        () -> {
+          if (!fired[0]) {
+            fired[0] = true;
+            callback.run();
+          }
+        };
+    waiters.add(once);
+    Util.runOnMainDelayed(
+        () -> {
+          if (!fired[0]) {
+            Log.w(TAG, "timed out waiting for holder");
+          }
+          once.run();
+        },
+        WAITER_TIMEOUT_MS);
+  }
+
+  public void onRendererGone() {
+    if (!Util.isMainThread()) {
+      Util.runOnMain(this::start);
+      return;
+    }
+    Log.w(TAG, "Renderer gone");
+    destroyWebView();
+    state = State.IDLE;
+    start();
+  }
+
+  private void createWebView() {
+    destroyWebView();
+
+    WebView wv = new WebView(appContext);
+    WebSettings settings = wv.getSettings();
+    settings.setJavaScriptEnabled(true);
+    settings.setBlockNetworkLoads(true);
+    settings.setAllowFileAccess(false);
+    settings.setAllowContentAccess(false);
+    settings.setGeolocationEnabled(false);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      settings.setSafeBrowsingEnabled(false);
+    }
+    wv.setWebViewClient(new HolderWebViewClient());
+    wv.addJavascriptInterface(new HolderJSApi(), "HolderJSApi");
+    webView = wv;
+  }
+
+  private void destroyWebView() {
+    if (webView != null) {
+      webView.destroy();
+      webView = null;
+    }
+  }
+
+  private void handleFillFinished(int count, String error, boolean stillHolding) {
+    Util.assertMainThread();
+    if (state != State.FILLING) {
+      return;
+    }
+    if (error == null) {
+      state = State.CONFIRMED;
+      Log.i(TAG, "Confirmed, holding " + count + " connections");
+    } else if (stillHolding) {
+      state = State.PARTIAL;
+      Log.w(TAG, "Holding " + count + " connections but not the whole budget: " + error);
+    } else {
+      state = State.EMPTY;
+      Log.w(TAG, "Fill failed after " + count + " connections, released: " + error);
+      destroyWebView();
+    }
+    List<Runnable> pending = new ArrayList<>(waiters);
+    waiters.clear();
+    for (Runnable waiter : pending) {
+      waiter.run();
+    }
+  }
+
+  private WebResourceResponse serve(String url) {
+    if (url != null && url.startsWith(HOLDER_URL)) {
+      InputStream stream = appContext.getResources().openRawResource(R.raw.webrtc_holder);
+      return new WebResourceResponse("text/html", "UTF-8", stream);
+    }
+    Log.w(TAG, "Blocked unexpected request from holder: " + url);
+    return new WebResourceResponse("text/plain", "UTF-8", new ByteArrayInputStream(new byte[0]));
+  }
+
+  private class HolderWebViewClient extends WebViewClient {
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+      return serve(request.getUrl().toString());
+    }
+
+    @Override
+    @RequiresApi(Build.VERSION_CODES.O)
+    public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+      Log.w(TAG, "Holder renderer gone, didCrash=" + detail.didCrash());
+      Util.runOnMainDelayed(WebRtcHolder.this::onRendererGone, 0);
+      return true;
+    }
+  }
+
+  private class HolderJSApi {
+    @JavascriptInterface
+    public void onFillFinished(final int count, final String error, final boolean stillHolding) {
+      Util.runOnMain(() -> handleFillFinished(count, error, stillHolding));
+    }
+  }
+}

--- a/src/main/java/org/thoughtcrime/securesms/WebRtcHolder.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebRtcHolder.java
@@ -40,7 +40,6 @@ public final class WebRtcHolder {
     FILLING,
     CONFIRMED,
     EMPTY,
-    PARTIAL,
   }
 
   // This is the mechanism itself. Also, there is no actual leak:
@@ -83,7 +82,7 @@ public final class WebRtcHolder {
   }
 
   private boolean isSettled() {
-    return state == State.CONFIRMED || state == State.EMPTY || state == State.PARTIAL;
+    return state == State.CONFIRMED || state == State.EMPTY;
   }
 
   public void awaitSettled(final Runnable callback) {
@@ -150,20 +149,16 @@ public final class WebRtcHolder {
     }
   }
 
-  private void handleFillFinished(int count, String error, boolean stillHolding) {
-    Util.assertMainThread();
+  private void handleFillFinished(String result, String reason) {
     if (state != State.FILLING) {
       return;
     }
-    if (error == null) {
+    if ("confirmed".equals(result)) {
       state = State.CONFIRMED;
-      Log.i(TAG, "Confirmed, holding " + count + " connections");
-    } else if (stillHolding) {
-      state = State.PARTIAL;
-      Log.w(TAG, "Holding " + count + " connections but not the whole budget: " + error);
+      Log.i(TAG, "Confirmed, holding the whole budget");
     } else {
       state = State.EMPTY;
-      Log.w(TAG, "Fill failed after " + count + " connections, released: " + error);
+      Log.w(TAG, "Released: " + reason);
       destroyWebView();
     }
     List<Runnable> pending = new ArrayList<>(waiters);
@@ -199,8 +194,8 @@ public final class WebRtcHolder {
 
   private class HolderJSApi {
     @JavascriptInterface
-    public void onFillFinished(final int count, final String error, final boolean stillHolding) {
-      Util.runOnMain(() -> handleFillFinished(count, error, stillHolding));
+    public void onFillFinished(final String result, final String reason) {
+      Util.runOnMain(() -> handleFillFinished(result, reason));
     }
   }
 }

--- a/src/main/java/org/thoughtcrime/securesms/WebRtcHolder.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebRtcHolder.java
@@ -81,13 +81,19 @@ public final class WebRtcHolder {
     return state;
   }
 
-  private boolean isSettled() {
+  /**
+   * Whether the fill has finished. Callers rely on this meaning exactly CONFIRMED or EMPTY.
+   *
+   * <p>Callers treat "settled but not CONFIRMED" as EMPTY, i.e. as permission to fill the budget
+   * themselves. A state where the holder has partial budget must not be settled.
+   */
+  public boolean isSettled() {
     return state == State.CONFIRMED || state == State.EMPTY;
   }
 
   public void awaitSettled(final Runnable callback) {
     if (!Util.isMainThread()) {
-      Util.runOnMain(this::start);
+      Util.runOnMain(() -> awaitSettled(callback));
       return;
     }
     if (isSettled()) {
@@ -115,7 +121,7 @@ public final class WebRtcHolder {
 
   public void onRendererGone() {
     if (!Util.isMainThread()) {
-      Util.runOnMain(this::start);
+      Util.runOnMain(this::onRendererGone);
       return;
     }
     Log.w(TAG, "Renderer gone");

--- a/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java
@@ -6,6 +6,9 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
@@ -77,6 +80,7 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
     }
 
     webView = findViewById(R.id.webview);
+    WebRtcHolder.getInstance(this).start();
 
     if (immersiveMode()) {
       // set a shadow in the status bar to make it more readable
@@ -132,7 +136,6 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
           }
 
           @Override
-          @RequiresApi(21)
           public WebResourceResponse shouldInterceptRequest(
               WebView view, WebResourceRequest request) {
             WebResourceResponse res = interceptRequest(request.getUrl().toString());
@@ -140,6 +143,16 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
               return res;
             }
             return super.shouldInterceptRequest(view, request);
+          }
+
+          @Override
+          @RequiresApi(Build.VERSION_CODES.O)
+          public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+            Log.w(TAG, "Renderer gone, didCrash=" + detail.didCrash());
+            WebRtcHolder.getInstance(WebViewActivity.this).onRendererGone();
+            Toast.makeText(WebViewActivity.this, R.string.error, Toast.LENGTH_LONG).show();
+            finish();
+            return true;
           }
         });
     webView.setFindListener(this);
@@ -180,8 +193,15 @@ public class WebViewActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   protected void onDestroy() {
+    if (webView != null) {
+      ViewParent parent = webView.getParent();
+      if (parent instanceof ViewGroup) {
+        ((ViewGroup) parent).removeView(webView);
+      }
+      webView.destroy();
+      webView = null;
+    }
     super.onDestroy();
-    webView.destroy();
   }
 
   @Override

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -293,14 +293,14 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
             if (isFinishing() || isDestroyed() || webView == null) {
               return;
             }
-            WebRtcHolder.State holderState = holder.getState();
             if (!holder.isSettled()) {
-              Log.e(TAG, "Cannot block WebRTC (" + holderState + "), refusing to load");
+              Log.e(TAG, "Cannot block WebRTC (" + holder.getState() + "), refusing to load");
               finish();
               return;
             }
             webView.loadUrl(
-                buildBootstrapUrl(holderState == WebRtcHolder.State.CONFIRMED, finalEncodedHref));
+                buildBootstrapUrl(
+                    holder.getState() == WebRtcHolder.State.CONFIRMED, finalEncodedHref));
           });
     }
 

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -294,8 +294,7 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
               return;
             }
             WebRtcHolder.State holderState = holder.getState();
-            if (holderState != WebRtcHolder.State.CONFIRMED
-                && holderState != WebRtcHolder.State.EMPTY) {
+            if (!holder.isSettled()) {
               Log.e(TAG, "Cannot block WebRTC (" + holderState + "), refusing to load");
               finish();
               return;

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -66,7 +66,6 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   private static final String EXTRA_HIDE_ACTION_BAR = "hideActionBar";
   private static final String EXTRA_HREF = "href";
   private static final int REQUEST_CODE_FILE_PICKER = 51426;
-  private static long lastOpenTime = 0;
 
   private ValueCallback<Uri[]> filePathCallback;
   private DcContext dcContext;
@@ -150,6 +149,16 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         .addNextIntentWithParentStack(chatIntent)
         .addNextIntent(webxdcIntent)
         .getIntents();
+  }
+
+  private String buildBootstrapUrl(boolean blockedByHolder, String encodedHref) {
+    return this.baseURL
+        + "/webxdc_bootstrap324567869.html?i="
+        + (internetAccess ? "1" : "0")
+        + "&h="
+        + (blockedByHolder ? "1" : "0")
+        + "&href="
+        + encodedHref;
   }
 
   @Override
@@ -272,23 +281,29 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
     } catch (UnsupportedEncodingException e) {
       e.printStackTrace();
     }
+    final String finalEncodedHref = encodedHref;
 
-    long timeDelta = System.currentTimeMillis() - lastOpenTime;
-    final String url =
-        this.baseURL
-            + "/webxdc_bootstrap324567869.html?i="
-            + (internetAccess ? "1" : "0")
-            + "&href="
-            + encodedHref;
-    Util.runOnAnyBackgroundThread(
-        () -> {
-          if (timeDelta < 2000) {
-            // this is to avoid getting stuck in the FILL500 in some devices if the
-            // previous webview was not destroyed yet and a new app is opened too soon
-            Util.sleep(1000);
-          }
-          Util.runOnMain(() -> webView.loadUrl(url));
-        });
+    if (internetAccess) {
+      webView.loadUrl(buildBootstrapUrl(false, finalEncodedHref));
+    } else {
+      // Wait until the state of the RTCPeerConnection budget is settled.
+      final WebRtcHolder holder = WebRtcHolder.getInstance(this);
+      holder.awaitSettled(
+          () -> {
+            if (isFinishing() || isDestroyed() || webView == null) {
+              return;
+            }
+            WebRtcHolder.State holderState = holder.getState();
+            if (holderState != WebRtcHolder.State.CONFIRMED
+                && holderState != WebRtcHolder.State.EMPTY) {
+              Log.e(TAG, "Cannot block WebRTC (" + holderState + "), refusing to load");
+              finish();
+              return;
+            }
+            webView.loadUrl(
+                buildBootstrapUrl(holderState == WebRtcHolder.State.CONFIRMED, finalEncodedHref));
+          });
+    }
 
     Util.runOnAnyBackgroundThread(
         () -> {
@@ -315,7 +330,6 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
 
   @Override
   protected void onDestroy() {
-    lastOpenTime = System.currentTimeMillis();
     DcHelper.getEventCenter(this.getApplicationContext()).removeObservers(this);
     leaveRealtimeChannel();
     tts.shutdown();
@@ -629,13 +643,17 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
   }
 
   private void leaveRealtimeChannel() {
-    int accountId = dcContext.getAccountId();
-    int msgId = dcAppMsg.getId();
-    try {
-      rpc.leaveWebxdcRealtime(accountId, msgId);
-    } catch (RpcException e) {
-      e.printStackTrace();
-    }
+    final Rpc rpc = this.rpc;
+    final int accountId = dcContext.getAccountId();
+    final int msgId = dcAppMsg.getId();
+    Util.runOnAnyBackgroundThread(
+        () -> {
+          try {
+            rpc.leaveWebxdcRealtime(accountId, msgId);
+          } catch (RpcException e) {
+            e.printStackTrace();
+          }
+        });
   }
 
   class InternalJSApi {

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcStoreActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcStoreActivity.java
@@ -1,18 +1,20 @@
 package org.thoughtcrime.securesms;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBar;
 import chat.delta.rpc.Rpc;
 import chat.delta.rpc.RpcException;
@@ -41,6 +43,7 @@ public class WebxdcStoreActivity extends PassphraseRequiredActionBarActivity {
     rpc = DcHelper.getRpc(this);
     dcContext = DcHelper.getContext(this);
     WebView webView = findViewById(R.id.webview);
+    WebRtcHolder.getInstance(this).start();
 
     // add padding to avoid content hidden behind system bars
     ViewUtil.applyWindowInsets(findViewById(R.id.content_container));
@@ -91,8 +94,8 @@ public class WebxdcStoreActivity extends PassphraseRequiredActionBarActivity {
             return true;
           }
 
-          @TargetApi(Build.VERSION_CODES.N)
           @Override
+          @RequiresApi(Build.VERSION_CODES.N)
           public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
             return shouldOverrideUrlLoading(view, request.getUrl().toString());
           }
@@ -102,6 +105,16 @@ public class WebxdcStoreActivity extends PassphraseRequiredActionBarActivity {
               WebView view, WebResourceRequest request) {
             return interceptRequest(request.getUrl().toString());
           }
+
+          @Override
+          @RequiresApi(Build.VERSION_CODES.O)
+          public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+            Log.w(TAG, "renderer gone, didCrash=" + detail.didCrash());
+            WebRtcHolder.getInstance(WebxdcStoreActivity.this).onRendererGone();
+            Toast.makeText(WebxdcStoreActivity.this, R.string.error, Toast.LENGTH_LONG).show();
+            finish();
+            return true;
+          }
         });
 
     WebSettings webSettings = webView.getSettings();
@@ -109,8 +122,6 @@ public class WebxdcStoreActivity extends PassphraseRequiredActionBarActivity {
     webSettings.setAllowFileAccess(false);
     webSettings.setAllowContentAccess(false);
     webSettings.setGeolocationEnabled(false);
-    webSettings.setAllowFileAccessFromFileURLs(false);
-    webSettings.setAllowUniversalAccessFromFileURLs(false);
     webSettings.setDatabaseEnabled(true);
     webSettings.setDomStorageEnabled(true);
     webView.setNetworkAvailable(

--- a/src/main/res/raw/webrtc_holder.html
+++ b/src/main/res/raw/webrtc_holder.html
@@ -27,11 +27,6 @@
       };
 
       try {
-        if (typeof RTCPeerConnection === "undefined") {
-          HolderJSApi.onFillFinished(0, "RTCPeerConnection unavailable", false);
-          return;
-        }
-
         const cert = {
           certificates: [
             await RTCPeerConnection.generateCertificate({

--- a/src/main/res/raw/webrtc_holder.html
+++ b/src/main/res/raw/webrtc_holder.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+<script>
+    // Allocates the whole per-renderer RTCPeerConnection budget so no other document in
+    // this app process can create one. See WebRtcHolder.java for additional info.
+    //
+    // `connections` is a top-level `const` and it must stay reachable for the lifetime
+    // of this document.
+    const connections = [];
+
+    (async () => {
+      const EXPECTED_CAPACITY = 500;
+      const HARD_LIMIT = 2000;
+      // 20 * 500ms = 10s, which must stay below WAITER_TIMEOUT_MS in WebRtcHolder.java.
+      const TOP_UP_ATTEMPTS = 20;
+      const TOP_UP_DELAY_MS = 500;
+
+      const release = () => {
+        for (const pc of connections) {
+          try { pc.close(); } catch (e) {}
+        }
+        connections.length = 0;
+      };
+
+      try {
+        if (typeof RTCPeerConnection === "undefined") {
+          HolderJSApi.onFillFinished(0, "RTCPeerConnection unavailable", false);
+          return;
+        }
+
+        const cert = {
+          certificates: [
+            await RTCPeerConnection.generateCertificate({
+              name: "ECDSA",
+              namedCurve: "P-256",
+            }),
+          ],
+        };
+
+        const fillUntilRejected = async () => {
+          while (connections.length < HARD_LIMIT) {
+            try {
+              connections.push(new RTCPeerConnection(cert));
+            } catch (error) {
+              return true;
+            }
+            if (connections.length % 50 === 0) {
+              // Yield so a page loading concurrently in the shared renderer is not blocked for
+              // the whole fill.
+              await new Promise((res) => setTimeout(res));
+            }
+          }
+          return false;
+        };
+
+        if (!(await fillUntilRejected())) {
+          const cl = connections.length;
+          release();
+          HolderJSApi.onFillFinished(cl, "no connection limit enforced", false);
+          return;
+        }
+
+        // We now hold every slot that was available. If that is fewer than the known capacity,
+        // something else still holds the rest.
+        let attempts = 0;
+        while (connections.length < EXPECTED_CAPACITY && attempts < TOP_UP_ATTEMPTS) {
+          attempts++;
+          await new Promise((res) => setTimeout(res, TOP_UP_DELAY_MS));
+          await fillUntilRejected();
+        }
+
+        if (connections.length < EXPECTED_CAPACITY) {
+          HolderJSApi.onFillFinished(
+            connections.length, "could not claim the whole budget", true);
+          return;
+        }
+
+        // Closing frees most of the memory (~46 KB instead of ~84 KB per connection) but does
+        // not free the slot. The process-wide counter is decremented in the destructor, not in
+        // close(). Note that an unclosed connection is kept alive by the engine, but a closed one
+        // is kept alive only by our reference to it. The `connections` array must not be cleared
+        // or go out of scope.
+        for (const pc of connections) {
+          pc.close();
+        }
+
+        let stillExhausted = false;
+        try {
+          new RTCPeerConnection();
+        } catch (error) {
+          stillExhausted = true;
+        }
+        if (!stillExhausted) {
+          const cl = connections.length;
+          release();
+          HolderJSApi.onFillFinished(
+            cl, "closed connections released their slots", false);
+          return;
+        }
+
+        HolderJSApi.onFillFinished(connections.length, null, true);
+      } catch (error) {
+        const cl = connections.length;
+        release();
+        HolderJSApi.onFillFinished(cl, "" + error, false);
+      }
+    })();
+</script>
+</body>
+</html>

--- a/src/main/res/raw/webrtc_holder.html
+++ b/src/main/res/raw/webrtc_holder.html
@@ -51,13 +51,7 @@
           }
           return false;
         };
-
-        if (!(await fillUntilRejected())) {
-          const cl = connections.length;
-          release();
-          HolderJSApi.onFillFinished(cl, "no connection limit enforced", false);
-          return;
-        }
+        await fillUntilRejected();
 
         // We now hold every slot that was available. If that is fewer than the known capacity,
         // something else still holds the rest.

--- a/src/main/res/raw/webrtc_holder.html
+++ b/src/main/res/raw/webrtc_holder.html
@@ -7,95 +7,65 @@
 <script>
     // Allocates the whole per-renderer RTCPeerConnection budget so no other document in
     // this app process can create one. See WebRtcHolder.java for additional info.
-    //
-    // `connections` is a top-level `const` and it must stay reachable for the lifetime
-    // of this document.
-    const connections = [];
+    window.__connections = [];
 
-    (async () => {
-      const EXPECTED_CAPACITY = 500;
-      const HARD_LIMIT = 2000;
-      // 20 * 500ms = 10s, which must stay below WAITER_TIMEOUT_MS in WebRtcHolder.java.
-      const TOP_UP_ATTEMPTS = 20;
-      const TOP_UP_DELAY_MS = 500;
+    const release = () => {
+      for (const pc of window.__connections) {
+        pc.close();
+      }
+      window.__connections = [];
+    };
 
-      const release = () => {
-        for (const pc of connections) {
-          try { pc.close(); } catch (e) {}
-        }
-        connections.length = 0;
+    const fill500 = async () => {
+      const cert = {
+        certificates: [
+          await RTCPeerConnection.generateCertificate({
+            name: "ECDSA",
+            namedCurve: "P-256",
+          }),
+        ],
       };
 
-      try {
-        const cert = {
-          certificates: [
-            await RTCPeerConnection.generateCertificate({
-              name: "ECDSA",
-              namedCurve: "P-256",
-            }),
-          ],
-        };
-
-        const fillUntilRejected = async () => {
-          while (connections.length < HARD_LIMIT) {
-            try {
-              connections.push(new RTCPeerConnection(cert));
-            } catch (error) {
-              return true;
-            }
-            if (connections.length % 50 === 0) {
-              // Yield so a page loading concurrently in the shared renderer is not blocked for
-              // the whole fill.
-              await new Promise((res) => setTimeout(res));
-            }
+      console.log("WEBRTC-WG: allocating");
+      while (window.__connections.length < 500) {
+        try {
+          window.__connections.push(new RTCPeerConnection(cert));
+          if (window.__connections.length%50 == 0) {
+            await new Promise((res) => setTimeout(res));
           }
-          return false;
-        };
-        await fillUntilRejected();
-
-        // We now hold every slot that was available. If that is fewer than the known capacity,
-        // something else still holds the rest.
-        let attempts = 0;
-        while (connections.length < EXPECTED_CAPACITY && attempts < TOP_UP_ATTEMPTS) {
-          attempts++;
-          await new Promise((res) => setTimeout(res, TOP_UP_DELAY_MS));
-          await fillUntilRejected();
+        } catch (error) {
+          new Array(1024*1024).fill(0);
+          await new Promise((res) => setTimeout(res, 500));
+          console.log("WEBRTC-WG: waiting for gc");
         }
+      }
+      console.log("WEBRTC-WG: done");
+    };
 
-        if (connections.length < EXPECTED_CAPACITY) {
-          HolderJSApi.onFillFinished(
-            connections.length, "could not claim the whole budget", true);
-          return;
-        }
+    (async () => {
+      try {
+        await fill500();
 
         // Closing frees most of the memory (~46 KB instead of ~84 KB per connection) but does
         // not free the slot. The process-wide counter is decremented in the destructor, not in
         // close(). Note that an unclosed connection is kept alive by the engine, but a closed one
         // is kept alive only by our reference to it. The `connections` array must not be cleared
         // or go out of scope.
-        for (const pc of connections) {
+        for (const pc of window.__connections) {
           pc.close();
         }
 
-        let stillExhausted = false;
         try {
-          new RTCPeerConnection();
-        } catch (error) {
-          stillExhausted = true;
-        }
-        if (!stillExhausted) {
-          const cl = connections.length;
+          window.__connections.push(new RTCPeerConnection());
+          console.log("Error: was able to create more than 500 connections");
           release();
-          HolderJSApi.onFillFinished(
-            cl, "closed connections released their slots", false);
-          return;
+          HolderJSApi.onFillFinished("empty", "was able to create more than 500 connections");
+        } catch (error) {
+          HolderJSApi.onFillFinished("confirmed", null);
         }
-
-        HolderJSApi.onFillFinished(connections.length, null, true);
       } catch (error) {
-        const cl = connections.length;
         release();
-        HolderJSApi.onFillFinished(cl, "" + error, false);
+        HolderJSApi.onFillFinished("empty", "" + error);
       }
     })();
 </script>

--- a/src/main/res/raw/webrtc_holder.html
+++ b/src/main/res/raw/webrtc_holder.html
@@ -29,7 +29,14 @@
       console.log("WEBRTC-WG: allocating");
       while (window.__connections.length < 500) {
         try {
-          window.__connections.push(new RTCPeerConnection(cert));
+          const pc = new RTCPeerConnection(cert);
+            // Closing frees most of the memory (~46 KB instead of ~84 KB per connection) but does
+            // not free the slot. The process-wide counter is decremented in the destructor, not in
+            // close(). Note that an unclosed connection is kept alive by the engine, but a closed one
+            // is kept alive only by our reference to it. The `connections` array must not be cleared
+            // or go out of scope.
+          pc.close();
+          window.__connections.push(pc);
           if (window.__connections.length%50 == 0) {
             await new Promise((res) => setTimeout(res));
           }
@@ -45,15 +52,6 @@
     (async () => {
       try {
         await fill500();
-
-        // Closing frees most of the memory (~46 KB instead of ~84 KB per connection) but does
-        // not free the slot. The process-wide counter is decremented in the destructor, not in
-        // close(). Note that an unclosed connection is kept alive by the engine, but a closed one
-        // is kept alive only by our reference to it. The `connections` array must not be cleared
-        // or go out of scope.
-        for (const pc of window.__connections) {
-          pc.close();
-        }
 
         try {
           window.__connections.push(new RTCPeerConnection());

--- a/src/main/res/raw/webxdc_wrapper.html
+++ b/src/main/res/raw/webxdc_wrapper.html
@@ -82,11 +82,6 @@
 
         if (blockedByHolder) {
           loadingProgress.style.display = "none";
-        } else {
-          await allocate();
-        }
-
-        if (blockedByHolder) {
           // The holder reported success, but verify it actually applies to this document in case
           // WebView's process model ever changed.
           let applied = false;
@@ -100,6 +95,8 @@
             loadingProgress.style.display = "";
             await allocate();
           }
+        } else {
+          await allocate();
         }
 
         try {

--- a/src/main/res/raw/webxdc_wrapper.html
+++ b/src/main/res/raw/webxdc_wrapper.html
@@ -61,23 +61,46 @@
           ],
         };
 
-        console.log("WEBRTC-WG: allocating");
-        loadingProgress.value = 0;
-        while (connections.length < 500) {
-          try {
-            connections.push(new RTCPeerConnection(cert));
-            if (connections.length%50 == 0) {
-              loadingProgress.value = connections.length;
-              await new Promise((res) => setTimeout(res));
+        const allocate = async () => {
+          console.log("WEBRTC-WG: allocating");
+          loadingProgress.value = 0;
+          while (connections.length < 500) {
+            try {
+              connections.push(new RTCPeerConnection(cert));
+              if (connections.length%50 == 0) {
+                loadingProgress.value = connections.length;
+                await new Promise((res) => setTimeout(res));
+              }
+            } catch (error) {
+              new Array(1024*1024).fill(0);
+              await new Promise((res) => setTimeout(res, 500));
+              console.log("WEBRTC-WG: waiting for gc");
             }
+          }
+          console.log("WEBRTC-WG: done");
+        };
+
+        if (blockedByHolder) {
+          loadingProgress.style.display = "none";
+        } else {
+          await allocate();
+        }
+
+        if (blockedByHolder) {
+          // The holder reported success, but verify it actually applies to this document in case
+          // WebView's process model ever changed.
+          let applied = false;
+          try {
+            connections.push(new RTCPeerConnection());
           } catch (error) {
-            loadingProgress.value++;
-            new Array(1024*1024).fill(0);
-            await new Promise((res) => setTimeout(res, 500));
-            console.log("WEBRTC-WG: waiting for gc");
+            applied = true;
+          }
+          if (!applied) {
+            console.log("WEBRTC-WG: holder budget did not apply, filling locally");
+            loadingProgress.style.display = "";
+            await allocate();
           }
         }
-        console.log("WEBRTC-WG: done");
 
         try {
           connections.push(new RTCPeerConnection());
@@ -93,8 +116,14 @@
               // Why `"*"`? See the comment below.
               sandboxedIframe.contentWindow.postMessage("performCheck", "*");
             };
-            /** @type {(e: MessageEvent) => void} */
-            const messageListener = (e) => {
+            let retry = null;
+            const finish = (result) => {
+              clearInterval(retry);
+              window.removeEventListener("message", messageListener);
+              resolve(result);
+            };
+            /** @type {(event: MessageEvent) => void} */
+            const messageListener = (event) => {
               // Checking `event.origin !== location.origin` just in case would be safer,
               // but `sandbox`ed iframes seem to send messages with `origin` set to `null`,
               // so we skip the check, relying on the fact that we don't actually load any
@@ -111,15 +140,15 @@
                   break;
                 }
                 case "result": {
-                  resolve(event.data.rtcpcCreationFailed);
-
                   sandboxedIframe.remove();
-                  window.removeEventListener("message", messageListener);
+                  finish(event.data.rtcpcCreationFailed);
                   break;
                 }
               }
             }
             window.addEventListener("message", messageListener);
+            retry = setInterval(askIframeToPerformCheck, 250);
+            setTimeout(() => finish(false), 10000);
             askIframeToPerformCheck();
           });
 
@@ -145,6 +174,7 @@
 
      const params = new URLSearchParams(document.location.search);
      const internetAccess = (params.get("i") || "0") === "1";
+     const blockedByHolder = (params.get("h") || "0") === "1";
      const href = params.get("href");
 
      if (internetAccess) {  // fill500 not needed, just load the frame


### PR DESCRIPTION
Chromium's RTCPeerConnection limit is enforced per renderer process, so we allocate the whole budget in a hidden WebView, blockinng WebRTC in every WebView of the app.

WebRTC is now also blocked in the HTML mail viewer, help, connectivity and app store views, but this is not an issue since none of them needs WebRTC.

Closes #4436