### PR TITLE
Upgrade gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,6 +278,10 @@ dependencies {
     androidTestImplementation ('org.assertj:assertj-core:3.27.3') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
+
+    constraints {
+        implementation 'androidx.activity:activity:1.11.0'  // 1.13.0 requires minSdk=23
+    }
 }
 
 String buildConfigProperty(String name) {


### PR DESCRIPTION
This one is pretty tricky to figure out, because the obfuscated symbols are from libraries that shipped obfuscated, not our code.
The cause is two packages, `com.google.android.material:material` and `androidx.activity`. The first one is already upgraded in #4623, so this PR only upgrade the second one. If the cause is as expected, the deprecation warning shall disappear next version.

Closes #4607 