### PR TITLE
feat: show pinned messages in chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Pin messages in chats
 * Add support for reactions in channels
 * Improve reactions details overview
 * Allow channel owners to mute their channel

--- a/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java
@@ -99,8 +99,14 @@ public class ConversationFragment extends MessageSelectorFragment {
   private View scrollToBottomButton;
   private View floatingLocationButton;
   private View bottomDivider;
+  private View pinnedMessageBanner;
   private AddReactionView addReactionView;
   private TextView noMessageTextView;
+  private TextView pinnedMessageText;
+  private TextView pinnedMessageCount;
+  private int listBasePaddingTop;
+  private final List<Integer> pinnedMessageIds = new ArrayList<>();
+  private int pinnedMessageIndex = -1;
   private Timer reloadTimer;
   private ConversationScrollListener scrollListener;
 
@@ -145,8 +151,13 @@ public class ConversationFragment extends MessageSelectorFragment {
     addReactionView = ViewUtil.findById(view, R.id.add_reaction_view);
     noMessageTextView = ViewUtil.findById(view, R.id.no_messages_text_view);
     bottomDivider = ViewUtil.findById(view, R.id.bottom_divider);
+    pinnedMessageBanner = ViewUtil.findById(view, R.id.pinned_message_banner);
+    pinnedMessageText = ViewUtil.findById(view, R.id.pinned_message_text);
+    pinnedMessageCount = ViewUtil.findById(view, R.id.pinned_message_count);
+    listBasePaddingTop = list.getPaddingTop();
 
     scrollToBottomButton.setOnClickListener(v -> scrollToBottom());
+    pinnedMessageBanner.setOnClickListener(v -> showCurrentPinnedMessage());
 
     final SetStartingPositionLinearLayoutManager layoutManager =
         new SetStartingPositionLinearLayoutManager(
@@ -317,8 +328,14 @@ public class ConversationFragment extends MessageSelectorFragment {
   }
 
   private void initializeResources() {
-    this.chatId =
+    long requestedChatId =
         this.getActivity().getIntent().getIntExtra(ConversationActivity.CHAT_ID_EXTRA, -1);
+    if (this.chatId != requestedChatId) {
+      pinnedMessageIds.clear();
+      pinnedMessageIndex = -1;
+      hidePinnedMessageBanner();
+    }
+    this.chatId = requestedChatId;
     this.recipient = Recipient.from(getActivity(), Address.fromChat((int) this.chatId));
 
     if (chatId > 0) {
@@ -683,6 +700,100 @@ public class ConversationFragment extends MessageSelectorFragment {
     }
   }
 
+  private void reloadPinnedMessages() {
+    Integer displayedMessageId =
+        pinnedMessageIndex >= 0 && pinnedMessageIndex < pinnedMessageIds.size()
+            ? pinnedMessageIds.get(pinnedMessageIndex)
+            : null;
+
+    try {
+      List<Integer> newPinnedMessageIds =
+          rpc.getPinnedMessages(rpc.getSelectedAccountId(), (int) chatId);
+      boolean messageWasAdded = false;
+      for (Integer messageId : newPinnedMessageIds) {
+        if (!pinnedMessageIds.contains(messageId)) {
+          messageWasAdded = true;
+          break;
+        }
+      }
+
+      pinnedMessageIds.clear();
+      pinnedMessageIds.addAll(newPinnedMessageIds);
+
+      if (pinnedMessageIds.isEmpty()) {
+        pinnedMessageIndex = -1;
+        hidePinnedMessageBanner();
+        return;
+      }
+
+      int preservedIndex =
+          displayedMessageId == null ? -1 : pinnedMessageIds.indexOf(displayedMessageId);
+      pinnedMessageIndex =
+          messageWasAdded || preservedIndex < 0 ? pinnedMessageIds.size() - 1 : preservedIndex;
+      bindPinnedMessageBanner();
+    } catch (RpcException e) {
+      Log.e(TAG, "Could not load pinned messages", e);
+    }
+  }
+
+  private void bindPinnedMessageBanner() {
+    if (pinnedMessageIndex < 0 || pinnedMessageIndex >= pinnedMessageIds.size()) {
+      hidePinnedMessageBanner();
+      return;
+    }
+
+    int messageId = pinnedMessageIds.get(pinnedMessageIndex);
+    DcMsg message = DcHelper.getContext(getContext()).getMsg(messageId);
+    if (message == null || !message.isOk()) {
+      hidePinnedMessageBanner();
+      return;
+    }
+
+    String summary = message.getSummarytext(200);
+    String position =
+        getString(
+            R.string.pinned_message_position, pinnedMessageIndex + 1, pinnedMessageIds.size());
+    pinnedMessageText.setText(summary);
+    pinnedMessageCount.setText(position);
+    pinnedMessageBanner.setContentDescription(
+        getString(R.string.pinned_message) + ": " + summary + ", " + position);
+    pinnedMessageBanner.setVisibility(View.VISIBLE);
+    pinnedMessageBanner.post(this::updatePinnedMessageBannerInsets);
+  }
+
+  private void hidePinnedMessageBanner() {
+    if (pinnedMessageBanner == null || list == null) {
+      return;
+    }
+    pinnedMessageBanner.setVisibility(View.GONE);
+    list.setPadding(
+        list.getPaddingLeft(), listBasePaddingTop, list.getPaddingRight(), list.getPaddingBottom());
+    floatingLocationButton.setTranslationY(0);
+  }
+
+  private void updatePinnedMessageBannerInsets() {
+    if (pinnedMessageBanner.getVisibility() != View.VISIBLE) {
+      return;
+    }
+    int bannerHeight = pinnedMessageBanner.getHeight();
+    list.setPadding(
+        list.getPaddingLeft(),
+        listBasePaddingTop + bannerHeight,
+        list.getPaddingRight(),
+        list.getPaddingBottom());
+    floatingLocationButton.setTranslationY(bannerHeight);
+  }
+
+  private void showCurrentPinnedMessage() {
+    if (pinnedMessageIndex < 0 || pinnedMessageIndex >= pinnedMessageIds.size()) {
+      return;
+    }
+    scrollMaybeSmoothToMsgId(pinnedMessageIds.get(pinnedMessageIndex));
+    pinnedMessageIndex =
+        pinnedMessageIndex == 0 ? pinnedMessageIds.size() - 1 : pinnedMessageIndex - 1;
+    bindPinnedMessageBanner();
+  }
+
   private void reloadList() {
     reloadList(false);
   }
@@ -724,6 +835,7 @@ public class ConversationFragment extends MessageSelectorFragment {
     int[] msgs = dcContext.getChatMsgs((int) chatId, 0, 0);
     Log.i(TAG, "⏰ getChatMsgs(" + chatId + "): " + (System.currentTimeMillis() - startMs) + "ms");
 
+    reloadPinnedMessages();
     adapter.changeData(msgs);
 
     if (firstLoad) {

--- a/src/main/java/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/main/java/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatImageView;
 import com.b44t.messenger.DcChat;
+import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcMsg;
 import java.io.ByteArrayInputStream;
 import java.util.Set;
@@ -110,7 +111,16 @@ public class ConversationUpdateItem extends BaseConversationItem {
       appIcon.setVisibility(GONE);
     }
 
-    bodyText.setText(messageRecord.getDisplayBody());
+    if (infoType == DcMsg.DC_INFO_MESSAGE_PINNED) {
+      if (messageRecord.getFromId() == DcContact.DC_CONTACT_ID_SELF) {
+        bodyText.setText(R.string.message_pinned_by_you);
+      } else {
+        String senderName = dcContext.getContact(messageRecord.getFromId()).getDisplayName();
+        bodyText.setText(context.getString(R.string.message_pinned_by_other, senderName));
+      }
+    } else {
+      bodyText.setText(messageRecord.getDisplayBody());
+    }
     bodyText.setVisibility(VISIBLE);
 
     if (messageRecord.isFailed()) deliveryStatusView.setFailed();

--- a/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
+++ b/src/main/java/org/thoughtcrime/securesms/connect/DcHelper.java
@@ -236,6 +236,8 @@ public class DcHelper {
     dcContext.setStockTranslation(
         241, context.getString(R.string.chat_description_changed_by_other));
     dcContext.setStockTranslation(242, context.getString(R.string.messages_are_e2ee));
+    dcContext.setStockTranslation(243, context.getString(R.string.message_pinned_by_you));
+    dcContext.setStockTranslation(244, context.getString(R.string.message_pinned_by_other));
   }
 
   public static File getImexDir() {

--- a/src/main/res/layout/conversation_fragment.xml
+++ b/src/main/res/layout/conversation_fragment.xml
@@ -7,6 +7,66 @@
     android:layout_width="fill_parent"
     android:layout_height="match_parent">
 
+    <LinearLayout
+        android:id="@+id/pinned_message_banner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:background="?android:attr/windowBackground"
+        android:clickable="true"
+        android:elevation="3dp"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="12dp"
+        android:paddingTop="6dp"
+        android:paddingEnd="12dp"
+        android:paddingBottom="6dp"
+        android:visibility="gone">
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:contentDescription="@string/pinned_message"
+            android:src="@drawable/ic_pin_24"
+            android:tint="?attr/colorAccent" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/pinned_message"
+                android:textColor="?attr/colorAccent"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/pinned_message_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textSize="14sp"
+                tools:text="Pinned message preview" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/pinned_message_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp"
+            tools:text="2/3" />
+    </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@android:id/list"
         android:layout_width="match_parent"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -376,6 +376,12 @@
     <string name="pin">Pin</string>
     <!-- Opposite of "Pin chat", removing the sticky-state from a chat. -->
     <string name="unpin">Unpin</string>
+    <!-- A message that stays accessible from a banner at the top of a chat. -->
+    <string name="pinned_message">Pinned message</string>
+    <!-- Position of the shown pinned message within all pinned messages. -->
+    <string name="pinned_message_position">%1$d/%2$d</string>
+    <string name="message_pinned_by_you">You pinned a message.</string>
+    <string name="message_pinned_by_other">Message pinned by %1$s.</string>
     <string name="ConversationFragment_quoted_message_not_found">Original message not found</string>
     <string name="reply_privately">Reply Privately</string>
     <string name="source_code">Source Code</string>


### PR DESCRIPTION
## Summary

- add a banner at the top of chats that shows the newest pinned message and cycles through pinned messages on click
- localize pin info messages at render time and register the new core stock strings
- add the feature to the Android changelog

This targets `adb/pin-messages` and complements #4586. English source strings are included here; locale updates continue through the regular translation workflow.

## Testing

- `./gradlew.bat spotlessJavaCheck`
- `./gradlew.bat assembleFossDebug`