### PR TITLE
Add local network permission check/request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ android {
         multiDexEnabled true
 
         minSdkVersion 21
-        targetSdkVersion 36
+        targetSdkVersion 37
 
         vectorDrawables.useSupportLibrary = true
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
         android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/src/main/java/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -17,6 +17,7 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.Manifest;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -25,6 +26,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.fragment.app.Fragment;
@@ -107,6 +109,31 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
   }
 
   public void showBackupProvider() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+      requestLocalNetworkForBackupProvider();
+    } else {
+      startBackupProvider();
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.CINNAMON_BUN)
+  public void requestLocalNetworkForBackupProvider() {
+    Permissions.with(this)
+        .request(Manifest.permission.ACCESS_LOCAL_NETWORK)
+        .ifNecessary()
+        .onAllGranted(this::startBackupProvider)
+        .onAnyDenied(
+            () ->
+                new AlertDialog.Builder(this)
+                    .setTitle(R.string.perm_required_title)
+                    .setMessage(R.string.perm_explain_local_network_denied)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show())
+        .withPermanentDenialDialog(getString(R.string.perm_explain_local_network_denied))
+        .execute();
+  }
+
+  private void startBackupProvider() {
     Intent intent = new Intent(this, BackupTransferActivity.class);
     intent.putExtra(
         BackupTransferActivity.TRANSFER_MODE,

--- a/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/WebxdcActivity.java
@@ -1,6 +1,8 @@
 package org.thoughtcrime.securesms;
 
+import android.Manifest;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -53,9 +55,12 @@ import org.json.JSONObject;
 import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.permissions.LocalNetworkPermission;
+import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.JsonUtils;
 import org.thoughtcrime.securesms.util.MediaUtil;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.thoughtcrime.securesms.util.Util;
 
 public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcEventDelegate {
@@ -655,6 +660,28 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
         });
   }
 
+  @NonNull
+  private Runnable getAdvertise() {
+    final int accountId = WebxdcActivity.this.dcContext.getAccountId();
+    final int msgId = WebxdcActivity.this.dcAppMsg.getId();
+    return () ->
+        Util.runOnAnyBackgroundThread(
+            () -> {
+              try {
+                this.rpc.sendWebxdcRealtimeAdvertisement(accountId, msgId);
+              } catch (RpcException e) {
+                e.printStackTrace();
+              }
+            });
+  }
+
+  @Override
+  public void onRequestPermissionsResult(
+      int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    Permissions.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
+  }
+
   class InternalJSApi {
     @JavascriptInterface
     public int sendUpdateMaxSize() {
@@ -753,18 +780,37 @@ public class WebxdcActivity extends WebViewActivity implements DcEventCenter.DcE
       }
     }
 
-    /**
-     * @noinspection unused
-     */
     @JavascriptInterface
     public void sendRealtimeAdvertisement() {
-      int accountId = WebxdcActivity.this.dcContext.getAccountId();
-      int msgId = WebxdcActivity.this.dcAppMsg.getId();
-      try {
-        WebxdcActivity.this.rpc.sendWebxdcRealtimeAdvertisement(accountId, msgId);
-      } catch (RpcException e) {
-        e.printStackTrace();
-      }
+      final Runnable doAdvertise = getAdvertise();
+
+      Util.runOnMain(
+          () -> {
+            if (isFinishing() || isDestroyed()) {
+              return;
+            }
+            if (!LocalNetworkPermission.isNeeded()
+                || LocalNetworkPermission.hasPermission(WebxdcActivity.this)
+                || Prefs.getBooleanPreference(
+                    WebxdcActivity.this, Prefs.ASKED_FOR_LOCAL_NETWORK_PERMISSION, false)) {
+              doAdvertise.run();
+              return;
+            }
+            Prefs.setBooleanPreference(
+                WebxdcActivity.this, Prefs.ASKED_FOR_LOCAL_NETWORK_PERMISSION, true);
+            new AlertDialog.Builder(WebxdcActivity.this)
+                .setMessage(R.string.perm_explain_local_network_denied)
+                .setPositiveButton(R.string.perm_continue, null)
+                .setOnDismissListener(
+                    d ->
+                        Permissions.with(WebxdcActivity.this)
+                            .request(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                            .ifNecessary()
+                            .onAllGranted(doAdvertise)
+                            .onAnyDenied(doAdvertise)
+                            .execute())
+                .show();
+          });
     }
 
     /**

--- a/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/calls/CallActivity.java
@@ -48,6 +48,8 @@ import java.util.List;
 import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.EglUtils;
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.permissions.LocalNetworkPermission;
+import org.thoughtcrime.securesms.util.Prefs;
 import org.webrtc.RendererCommon;
 import org.webrtc.SurfaceViewRenderer;
 import org.webrtc.VideoTrack;
@@ -60,6 +62,7 @@ public class CallActivity extends AppCompatActivity {
   private static final int MIC_PERMISSION_REQUEST_CODE = 1001;
   private static final int CAMERA_PERMISSION_REQUEST_CODE = 1002;
   private static final int CAMERA_MID_CALL_PERMISSION_REQUEST_CODE = 1003;
+  private static final int LOCAL_NETWORK_PERMISSION_REQUEST_CODE = 1004;
 
   public static final String ACTION_ANSWER_CALL = BuildConfig.APPLICATION_ID + ".ANSWER_CALL";
   public static final String ACTION_DECLINE_CALL = BuildConfig.APPLICATION_ID + ".DECLINE_CALL";
@@ -108,6 +111,7 @@ public class CallActivity extends AppCompatActivity {
   private boolean pausedWhileAwaitingPermission = false;
   private boolean intentHandled = false;
   private boolean doNotAutoFinish = false;
+  private boolean localNetworkAsked = false;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -172,6 +176,11 @@ public class CallActivity extends AppCompatActivity {
       awaitingPermissionResult = true;
       ActivityCompat.requestPermissions(
           this, new String[] {Manifest.permission.CAMERA}, CAMERA_PERMISSION_REQUEST_CODE);
+      return;
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN
+        && maybeAskLocalNetworkPermission()) {
       return;
     }
 
@@ -913,8 +922,38 @@ public class CallActivity extends AppCompatActivity {
       return;
     }
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN
+        && maybeAskLocalNetworkPermission()) {
+      return;
+    }
+
     handleIntents(getIntent());
     intentHandled = true;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.CINNAMON_BUN)
+  private boolean maybeAskLocalNetworkPermission() {
+    if (localNetworkAsked
+        || LocalNetworkPermission.hasPermission(this)
+        || Prefs.getBooleanPreference(this, Prefs.ASKED_FOR_LOCAL_NETWORK_PERMISSION, false)) {
+      return false;
+    }
+    localNetworkAsked = true;
+    Prefs.setBooleanPreference(this, Prefs.ASKED_FOR_LOCAL_NETWORK_PERMISSION, true);
+    new AlertDialog.Builder(this)
+        .setMessage(R.string.perm_explain_local_network_denied)
+        .setPositiveButton(R.string.perm_continue, null)
+        .setOnDismissListener(
+            dialog -> {
+              if (isFinishing() || isDestroyed()) return;
+              awaitingPermissionResult = true;
+              ActivityCompat.requestPermissions(
+                  this,
+                  new String[] {Manifest.permission.ACCESS_LOCAL_NETWORK},
+                  LOCAL_NETWORK_PERMISSION_REQUEST_CODE);
+            })
+        .show();
+    return true;
   }
 
   @Override
@@ -940,6 +979,11 @@ public class CallActivity extends AppCompatActivity {
           Toast.makeText(this, R.string.call_requires_camera_permission, Toast.LENGTH_SHORT).show();
         }
       }
+      return;
+    }
+
+    if (requestCode == LOCAL_NETWORK_PERMISSION_REQUEST_CODE) {
+      proceedAfterPermissions();
       return;
     }
 

--- a/src/main/java/org/thoughtcrime/securesms/permissions/LocalNetworkPermission.java
+++ b/src/main/java/org/thoughtcrime/securesms/permissions/LocalNetworkPermission.java
@@ -1,0 +1,64 @@
+package org.thoughtcrime.securesms.permissions;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.util.Log;
+import androidx.core.content.ContextCompat;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Locale;
+
+public class LocalNetworkPermission {
+
+  private static final String TAG = "LocalNetworkPermission";
+
+  private LocalNetworkPermission() {}
+
+  public static boolean isNeeded() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN;
+  }
+
+  public static boolean hasPermission(Context context) {
+    if (!isNeeded()) return true;
+    return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK)
+        == PackageManager.PERMISSION_GRANTED;
+  }
+
+  public static boolean isLocalAddress(String host) {
+    if (host == null) return false;
+    String hostBase = host.trim().toLowerCase(Locale.ROOT);
+    if (hostBase.isEmpty()) return false;
+
+    // remove ipv6 brackets
+    if (hostBase.length() > 2 && hostBase.startsWith("[") && hostBase.endsWith("]")) {
+      hostBase = hostBase.substring(1, hostBase.length() - 1);
+    }
+
+    if (hostBase.equals("localhost")) return false;
+    if (hostBase.endsWith(".local")) return true;
+
+    try {
+      for (InetAddress address : InetAddress.getAllByName(hostBase)) {
+        if (isLocalAddress(address)) return true;
+      }
+    } catch (UnknownHostException e) {
+      Log.w(TAG, "cannot resolve " + host, e);
+    }
+    return false;
+  }
+
+  private static boolean isLocalAddress(InetAddress address) {
+    if (address == null) return false;
+    if (address.isLoopbackAddress()) return false;
+    if (address.isLinkLocalAddress()) return true;
+    if (address.isSiteLocalAddress()) return true;
+    if (address instanceof Inet6Address) {
+      byte[] bytes = address.getAddress();
+      return (bytes[0] & 0xfe) == 0xfc;
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/src/main/java/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -412,4 +412,8 @@ public class Permissions {
       }
     }
   }
+
+  public static void showSettingsDialog(Context context, String message) {
+    new SettingsDialogListener(context, message).run();
+  }
 }

--- a/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
+++ b/src/main/java/org/thoughtcrime/securesms/qr/QrCodeHandler.java
@@ -1,12 +1,16 @@
 package org.thoughtcrime.securesms.qr;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.os.Build;
 import android.util.Log;
+import android.widget.TextView;
 import android.widget.Toast;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import chat.delta.rpc.Rpc;
@@ -19,6 +23,7 @@ import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.connect.AccountManager;
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.relay.RelayListActivity;
 import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.ScreenLockUtil;
@@ -41,6 +46,7 @@ public class QrCodeHandler {
   private final DcContext dcContext;
   private final Rpc rpc;
   private final int accId;
+  private boolean localNetworkHintShown = false;
 
   public QrCodeHandler(Activity activity) {
     this.activity = activity;
@@ -215,17 +221,24 @@ public class QrCodeHandler {
             activity.getString(R.string.multidevice_receiver_scanning_ask)
                 + "\n\n"
                 + activity.getString(R.string.multidevice_same_network_hint));
-        builder.setPositiveButton(
-            R.string.perm_continue,
-            (dialog, which) -> {
-              AccountManager.getInstance().addAccountFromSecondDevice(activity, rawString);
-            });
+        // `null` is intentionally to disable auto-dismiss
+        builder.setPositiveButton(R.string.perm_continue, null);
         builder.setNegativeButton(R.string.cancel, null);
         builder.setCancelable(false);
 
         AlertDialog alertDialog = builder.create();
         alertDialog.show();
         BackupTransferActivity.appendSSID(activity, alertDialog.findViewById(android.R.id.message));
+        alertDialog
+            .getButton(AlertDialog.BUTTON_POSITIVE)
+            .setOnClickListener(
+                v -> {
+                  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+                    receiveBackupWithPermission(alertDialog, rawString);
+                  } else {
+                    proceedWithBackupTransfer(alertDialog, rawString);
+                  }
+                });
         return true;
 
       case DcContext.DC_QR_BACKUP_TOO_NEW:
@@ -239,6 +252,43 @@ public class QrCodeHandler {
 
       default:
         return false;
+    }
+  }
+
+  private void proceedWithBackupTransfer(AlertDialog alertDialog, String rawString) {
+    alertDialog.dismiss();
+    AccountManager.getInstance().addAccountFromSecondDevice(activity, rawString);
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.CINNAMON_BUN)
+  private void receiveBackupWithPermission(AlertDialog alertDialog, String rawString) {
+    Permissions.with(activity)
+        .request(Manifest.permission.ACCESS_LOCAL_NETWORK)
+        .ifNecessary()
+        .onAllGranted(
+            () -> {
+              alertDialog.dismiss();
+              AccountManager.getInstance().addAccountFromSecondDevice(activity, rawString);
+            })
+        .onAnyDenied(() -> appendLocalNetworkDeniedHint(alertDialog))
+        .onAnyPermanentlyDenied(
+            () -> {
+              alertDialog.dismiss();
+              Permissions.showSettingsDialog(
+                  activity, activity.getString(R.string.perm_explain_local_network_denied));
+            })
+        .execute();
+  }
+
+  private void appendLocalNetworkDeniedHint(AlertDialog alertDialog) {
+    if (localNetworkHintShown) return;
+    localNetworkHintShown = true;
+    TextView textView = alertDialog.findViewById(android.R.id.message);
+    if (textView != null) {
+      textView.setText(
+          textView.getText()
+              + "\n\n"
+              + activity.getString(R.string.perm_explain_local_network_denied));
     }
   }
 

--- a/src/main/java/org/thoughtcrime/securesms/relay/EditRelayActivity.java
+++ b/src/main/java/org/thoughtcrime/securesms/relay/EditRelayActivity.java
@@ -2,8 +2,10 @@ package org.thoughtcrime.securesms.relay;
 
 import static org.thoughtcrime.securesms.connect.DcHelper.getContext;
 
+import android.Manifest;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -18,6 +20,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.constraintlayout.widget.Group;
@@ -37,6 +40,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.WelcomeActivity;
 import org.thoughtcrime.securesms.connect.DcEventCenter;
 import org.thoughtcrime.securesms.connect.DcHelper;
+import org.thoughtcrime.securesms.permissions.LocalNetworkPermission;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -333,6 +337,50 @@ public class EditRelayActivity extends BaseActionBarActivity
       return;
     }
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN
+        && !LocalNetworkPermission.hasPermission(this)) {
+      maybeAskLocalNetworkThenLogin();
+      return;
+    }
+
+    startLogin();
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.CINNAMON_BUN)
+  private void maybeAskLocalNetworkThenLogin() {
+    final String imapServer = getParam(R.id.imap_server_text, true);
+    final String smtpServer = getParam(R.id.smtp_server_text, true);
+    Util.runOnAnyBackgroundThread(
+        () -> {
+          final boolean imapIsLocal = LocalNetworkPermission.isLocalAddress(imapServer);
+          final boolean smtpIsLocal = LocalNetworkPermission.isLocalAddress(smtpServer);
+          Util.runOnMain(
+              () -> {
+                if (isFinishing() || isDestroyed()) return;
+                if (!imapIsLocal && !smtpIsLocal) {
+                  startLogin();
+                  return;
+                }
+                final int errorViewId = imapIsLocal ? R.id.imap_server_text : R.id.smtp_server_text;
+                Permissions.with(this)
+                    .request(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                    .ifNecessary()
+                    .onAllGranted(this::startLogin)
+                    .onAnyDenied(
+                        () -> {
+                          TextInputEditText view = findViewById(errorViewId);
+                          if (view != null) {
+                            view.setError(getString(R.string.perm_explain_local_network_denied));
+                          }
+                        })
+                    .withPermanentDenialDialog(
+                        getString(R.string.perm_explain_local_network_denied))
+                    .execute();
+              });
+        });
+  }
+
+  private void startLogin() {
     cancelled = false;
     setupConfig();
 

--- a/src/main/java/org/thoughtcrime/securesms/util/Prefs.java
+++ b/src/main/java/org/thoughtcrime/securesms/util/Prefs.java
@@ -48,6 +48,8 @@ public class Prefs {
   public static final String DOZE_ASKED_DIRECTLY = "pref_doze_asked_directly";
   public static final String ASKED_FOR_NOTIFICATION_PERMISSION =
       "pref_asked_for_notification_permission";
+  public static final String ASKED_FOR_LOCAL_NETWORK_PERMISSION =
+      "asked_for_local_network_permission";
   private static final String IN_THREAD_NOTIFICATION_PREF = "pref_key_inthread_notifications";
 
   public static final String NOTIFICATION_PRIVACY_PREF = "pref_notification_privacy";

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1138,6 +1138,7 @@
     <string name="perm_explain_access_to_storage_denied">To receive or send files, go to the app settings, select \"Permissions\", and enable \"Storage\".</string>
     <string name="perm_explain_access_to_location_denied">To attach a location, go to the app settings, select \"Permissions\", and enable \"Location\".</string>
     <string name="perm_explain_access_to_notifications_denied">To receive notifications, go to \"System Settings / Apps / Delta Chat\" and enable \"Notifications\".</string>
+    <string name="perm_explain_local_network_denied">Delta Chat needs the "Nearby devices" permission to connect to devices on the local network. You can set it under Apps / Delta Chat / Permissions.</string>
 
     <!-- ImageEditorHud -->
     <string name="ImageEditorHud_draw_anywhere_to_blur">Draw anywhere to blur</string>


### PR DESCRIPTION
- Request permission for: Profile transfer, Call, WebXDC Realtime Channel, Relay with local addresses
- Raise Target SDK to 37

I only tested the permission request itself. For Call and WebXDC the request is shown only once, since they have backup channels from relay.

Closes #4624