### PR TITLE
fix: apply maximum file size limit to videos as is, without 5/4 factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improve a11y on Conversation List
 * Fix: support scanning a channel-invite while creating a new profile
 * Fix: random long delay when reopening a WebXDC app
+* Fix: apply maximum file size limit to videos as is, without 5/4 factor.
 
 ## v2.59.1
 2026-08

--- a/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
+++ b/src/main/java/org/thoughtcrime/securesms/video/recode/VideoRecoder.java
@@ -590,7 +590,7 @@ public class VideoRecoder {
       VideoEditedInfo vei = getVideoEditInfoFromFile(inPath);
       if (vei == null) {
         Log.w(TAG, String.format("Recoding failed for %s: cannot get info", inPath));
-        if (msg.getFilebytes() > MAX_BYTES + MAX_BYTES / 4) {
+        if (msg.getFilebytes() > MAX_BYTES) {
           alert(context, TOO_BIG_FILE);
           return false;
         }
@@ -673,6 +673,7 @@ public class VideoRecoder {
               vei.originalDurationMs,
               vei.originalAudioBytes);
 
+      // If estimated size is higher than the limit by 25%, don't even try to reencode.
       if (vei.estimatedBytes > MAX_BYTES + MAX_BYTES / 4) {
         alert(context, TOO_BIG_FILE);
         return false;
@@ -682,15 +683,27 @@ public class VideoRecoder {
       String tempPath = DcHelper.getBlobdirFile(DcHelper.getContext(context), inPath);
       VideoRecoder videoRecoder = new VideoRecoder();
       if (!videoRecoder.convertVideo(vei, tempPath)) {
-        alert(
-            context,
-            String.format("Could not recode %s; sending it at its original size.", inPath));
-        return true;
+        if (msg.getFilebytes() <= MAX_BYTES) {
+          alert(
+              context,
+              String.format("Could not recode %s; sending it at its original size.", inPath));
+          return true;
+        } else {
+          // The file is too large and we failed to reencode the video.
+          alert(context, TOO_BIG_FILE);
+          return false;
+        }
       }
+      Log.i(TAG, String.format("recoding for %s done", inPath));
 
       msg.setFileAndDeduplicate(tempPath, msg.getFilename(), msg.getFilemime());
 
-      Log.i(TAG, String.format("recoding for %s done", inPath));
+      // Do not send the message if it turned out to be too large even after reencoding.
+      if (msg.getFilebytes() > MAX_BYTES) {
+        alert(context, TOO_BIG_FILE);
+        return false;
+      }
+
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
UI should not need to do any calculations before comparing the file size to sys.msgsize_max_recommended. Any overhead, e.g. base64 overhead, is taken into account in the core already.

Factor 5/4 seems to come from https://github.com/deltachat/deltachat-android/pull/883, commit https://github.com/deltachat/deltachat-android/commit/a59f6fd69b6f27f5d5d044a881e4767a3c48ff1f

Looking at this code because of https://github.com/chatmail/core/issues/8678