### PR TITLE
Update flake.nix to match bulid.gradle (Android SDK 37)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1775939535,
-        "narHash": "sha256-Zq1U7Vhw5ctvhJQy+3ShqIv7Mplf3XkgJY+QJnhfUGQ=",
+        "lastModified": 1789082799,
+        "narHash": "sha256-Xhvy0m8aqCLrSXEVgxAUVr3DYgTSx1EYQ4UYh/LYdUQ=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d2e16192309bf3101e4998ffa62e914819dee077",
+        "rev": "64e0e22fbbdd6b234b1a93dc184076c6c4747bee",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768818222,
-        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "lastModified": 1788342953,
+        "narHash": "sha256-EWkNM4JzBhZ/Yn1PG6lP4/QJuFAFeHYlY5gVxXu940Y=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "rev": "a67c0f87b63bcbdbdcb56785bec0205a2e3d6026",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,10 @@
         pkgs = import nixpkgs { inherit system overlays; };
         android-sdk = android.sdk.${system} (sdkPkgs:
           with sdkPkgs; [
-            build-tools-35-0-0
+            build-tools-36-0-0
             cmdline-tools-latest
             platform-tools
-            platforms-android-36
+            platforms-android-37-0
             ndk-27-2-12479018
           ]);
         rust-version = pkgs.lib.removeSuffix "\n"
@@ -31,7 +31,7 @@
           ANDROID_SDK_ROOT = "${android-sdk}/share/android-sdk";
           ANDROID_NDK_ROOT =
             "${android-sdk}/share/android-sdk/ndk/27.2.12479018";
-          GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/35.0.0/aapt2";
+          GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/36.0.0/aapt2";
           buildInputs = [
             android-sdk
             pkgs.openjdk17


### PR DESCRIPTION
Otherwise build in `nix develop` shell fails
when it tries to download a different SDK into read-only /nix/... directory